### PR TITLE
Fix svg pan zoom on Safari

### DIFF
--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -165,11 +165,16 @@ export default Vue.extend({
 .grapher {
   flex: 1 1;
   background: $stone-pine;
+  position: relative;
 }
 
 .grapher-svg {
+  // https://stackoverflow.com/questions/7570917/svg-height-incorrectly-calculated-in-webkit-browsers
   width: 100%;
   height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .grapher--line-container {


### PR DESCRIPTION
See this stack overflow post. https://stackoverflow.com/questions/7570917/svg-height-incorrectly-calculated-in-webkit-browsers

The issue is that the height was not properly calculated on the svg object.