### PR TITLE
Show metadata V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,30 @@
 
 Calchart 4.0 for the web!
 
-See this [Figma link](https://www.figma.com/file/XIkyioLzRlGlpmNiEu47glkQ/Calchart) for the design.
+See this [Figma link](https://www.figma.com/file/XIkyioLzRlGlpmNiEu47glkQ/Calchart) for the design. Also see [calchart-redesign-old](https://github.com/calband/calchart-redesign-old) for the prototype.
 
-Project created from [Vue CLI](https://cli.vuejs.org/).
+Project bootstrapped from [Vue CLI](https://cli.vuejs.org/).
 
 ## Project setup
 ```
 npm install
 ```
 
-### Compiles and hot-reloads for development
+Please use the LTS version of [NodeJS/npm](https://nodejs.org/en/) for this project.
+
+We recommend using [Visual Studio Code](https://code.visualstudio.com/) as your IDE. This integrates well with Typescript. We recommend installing the following extensions: ESLint, and Vetur.
+
+## Compiles and hot-reloads for development
 ```
 npm run serve
 ```
 
-### Compiles and minifies for production
+## Compiles and minifies for production
 ```
 npm run build
 ```
 
-### Run your unit tests
+## Run your unit tests
 ```sh
 # Run all tests
 npm run test:unit
@@ -31,18 +35,22 @@ npm run test:unit Grapher
 npm run test:unit -- --watchAll
 ```
 
-See [this](https://cli.vuejs.org/core-plugins/unit-jest.html#injected-commands) for more information. To run with flags for jest, insert `--` before the flags.
+We are using [Jest](https://jestjs.io/) for the unit test framework.
 
-### Debug your unit tests
+[Vue CLI docs](https://cli.vuejs.org/core-plugins/unit-jest.html#injected-commands).
+
+## Debug your unit tests
 ```sh
 # macOS or linux
 node --inspect-brk ./node_modules/.bin/vue-cli-service test:unit
 # Windows
 node --inspect-brk ./node_modules/@vue/cli-service/bin/vue-cli-service.js test:unit
 ```
-See [this](https://cli.vuejs.org/core-plugins/unit-jest.html#debugging-tests) for more information on how to debug.
+See [this](https://jestjs.io/docs/en/troubleshooting.html#tests-are-failing-and-you-dont-know-why) for instructions on how to attach Google Chrome or VSCode to the tests.
 
-### Run your end-to-end tests
+[Vue CLI docs](https://cli.vuejs.org/core-plugins/unit-jest.html#debugging-tests)
+
+## Run your end-to-end tests
 ```sh
 # Run normally (opens Chrome)
 npm run test:e2e
@@ -50,11 +58,13 @@ npm run test:e2e
 npm run test:e2e -- --headless
 ```
 
-See [this](https://cli.vuejs.org/core-plugins/e2e-cypress.html) for more information.
+We are using [Cypress](https://www.cypress.io/) for the end to end test framework.
 
-### Lints and fixes files
+[Vue CLI docs](https://cli.vuejs.org/core-plugins/e2e-cypress.html)
+
+## Lints and fixes files
 ```
 npm run lint
 ```
 
-See [this](https://cli.vuejs.org/core-plugins/eslint.html#injected-commands) for more information.
+[Vue CLI docs](https://cli.vuejs.org/core-plugins/eslint.html#injected-commands)

--- a/src/models/Field.ts
+++ b/src/models/Field.ts
@@ -1,6 +1,10 @@
 /**
  * Defines landmarks needed to determine the size of the field.
  * Defaults to college field measurements.
+ * 
+ * @property frontHashOffsetY - How many steps from the West sideline the front hash is (used to calculate the field height)
+ * @property backHashOffsetY  - How many steps from the West sideline the back hash is (used to calculate the field height)
+ * @property middleOfField    - Defines the yard line in the middle (used to calculate the field width)
  */
 export default class Field {
   frontHashOffsetY: number;

--- a/src/models/Field.ts
+++ b/src/models/Field.ts
@@ -2,7 +2,6 @@
  * Defines landmarks needed to determine the size of the field.
  * Defaults to college field measurements.
  */
-
 export default class Field {
   frontHashOffsetY: number;
 

--- a/src/models/Show.ts
+++ b/src/models/Show.ts
@@ -1,6 +1,10 @@
 import Field from './Field';
+import StuntSheet from './StuntSheet';
+import StuntSheetDot from './StuntSheetDot';
+import BaseContinuity from './continuity/BaseContinuity';
+import { FlowBeat } from './util/types';
 
-// Upon changing show metadata, please increment.
+// Upon making show metadata changes that break previous versions, please increment.
 const METADATA_VERSION: number = 1;
 
 /**
@@ -11,14 +15,45 @@ export default class Show {
 
   title: string;
 
-  numDots: number;
+  dotLabels: string[];
 
   field: Field;
 
+  stuntSheets: StuntSheet[];
+
   constructor() {
     this.metadataVersion = METADATA_VERSION;
-    this.numDots = 1;
     this.title = 'Example Show';
+    this.dotLabels = [];
     this.field = new Field();
+    this.stuntSheets = [new StuntSheet()];
+  }
+
+  /**
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store the flow
+   * based on it's continuities in stuntSheetDot.cachedFlow.
+   */
+  generateFlows(stuntSheetIndex: number): void {
+    if (stuntSheetIndex >= this.stuntSheets.length) {
+      throw `stuntSheetIndex (${stuntSheetIndex}) is larger than the length of stuntSheets (${this.stuntSheets.length})`;
+    }
+
+    const startSS: StuntSheet = this.stuntSheets[stuntSheetIndex];
+    const endSS: StuntSheet = this.stuntSheets[stuntSheetIndex + 1];
+
+    startSS.stuntSheetDots.map((startDot: StuntSheetDot) => {
+      const endDot: StuntSheetDot|undefined = startDot.dotLabelIndex === null
+        ? undefined
+        : endSS.stuntSheetDots.find((dot: StuntSheetDot) => startDot.dotLabelIndex === dot.dotLabelIndex);
+
+      let flow: FlowBeat[] = [];
+      const continuities: BaseContinuity[] = startSS.dotTypes[startDot.dotTypeIndex];
+
+      continuities.forEach((continuity: BaseContinuity) => {
+        continuity.addToFlow(flow, startDot, endDot);
+      });
+
+      startDot.cachedFlow = flow;
+    });
   }
 }

--- a/src/models/Show.ts
+++ b/src/models/Show.ts
@@ -9,6 +9,12 @@ const METADATA_VERSION: number = 1;
 
 /**
  * Defines all metadata to edit, render, and animate a Calchart show.
+ * 
+ * @property metadataVersion - Upon loading the show, determines what migrations are needed to make the show compatible with future CalChart versions
+ * @property title           - Used to categorize saved shows
+ * @property dotLabels       - A list of names used for each dot. Ex. ['A0', 'A1', ...]
+ * @property field           - Defines the sizing of the field that is being marched on
+ * @property stuntSheets     - The set of all StuntSheet objects
  */
 export default class Show {
   metadataVersion: number;
@@ -30,12 +36,11 @@ export default class Show {
   }
 
   /**
-   * For each StuntSheetDot in the specified StuntSheet, calculate and store the flow
-   * based on it's continuities in stuntSheetDot.cachedFlow.
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store the flow based on it's continuities in stuntSheetDot.cachedFlow.
    */
   generateFlows(stuntSheetIndex: number): void {
-    if (stuntSheetIndex >= this.stuntSheets.length) {
-      throw `stuntSheetIndex (${stuntSheetIndex}) is larger than the length of stuntSheets (${this.stuntSheets.length})`;
+    if (stuntSheetIndex < 0 || stuntSheetIndex + 1 >= this.stuntSheets.length) {
+      throw `stuntSheetIndex (${stuntSheetIndex}) is invalid`;
     }
 
     const startSS: StuntSheet = this.stuntSheets[stuntSheetIndex];

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -1,11 +1,15 @@
 import StuntSheetDot from './StuntSheetDot';
 import BaseContinuity from './continuity/BaseContinuity';
 import ContinuityInPlace from './continuity/ContinuityInPlace';
-import { DIRECTIONS, MARCH_TYPES } from './util/constants';
+import { DIRECTION_TO_DEGREES, MARCH_TYPES } from './util/constants';
 
 /**
  * Defines the positions/directions in a formation and the continuities
  * used to reach the next position.
+ * 
+ * @property stuntSheetDots - The collection of positions that make up a formation
+ * @property dotTypes       - The set of continuities used to describe the movements to get to the next StuntSheet
+ * @property beats          - How many beats to execute the continuities to the next StuntSheet
  */
 export default class StuntSheet {
   stuntSheetDots: StuntSheetDot[];
@@ -16,7 +20,18 @@ export default class StuntSheet {
 
   constructor() {
     this.stuntSheetDots = [];
-    this.dotTypes = [[new ContinuityInPlace(0, DIRECTIONS.E, MARCH_TYPES.HS)]];
+    this.dotTypes = [[new ContinuityInPlace(0, DIRECTION_TO_DEGREES.E, MARCH_TYPES.HS)]];
     this.beats = 16;
+  }
+
+  /**
+   * Helper function to separate dots by their dot types
+   */
+  organizeDotsByDotType(): StuntSheetDot[][] {
+    return this.dotTypes.map((_, dotTypeIndex: number) => {
+      return this.stuntSheetDots.filter((dot: StuntSheetDot) => {
+        return dot.dotTypeIndex === dotTypeIndex;
+      });
+    });
   }
 }

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -23,15 +23,4 @@ export default class StuntSheet {
     this.dotTypes = [[new ContinuityInPlace(0, DIRECTION_TO_DEGREES.E, MARCH_TYPES.HS)]];
     this.beats = 16;
   }
-
-  /**
-   * Helper function to separate dots by their dot types
-   */
-  organizeDotsByDotType(): StuntSheetDot[][] {
-    return this.dotTypes.map((_, dotTypeIndex: number) => {
-      return this.stuntSheetDots.filter((dot: StuntSheetDot) => {
-        return dot.dotTypeIndex === dotTypeIndex;
-      });
-    });
-  }
 }

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -1,0 +1,22 @@
+import StuntSheetDot from './StuntSheetDot';
+import BaseContinuity from './continuity/BaseContinuity';
+import ContinuityInPlace from './continuity/ContinuityInPlace';
+import { DIRECTIONS, MARCH_TYPES } from './util/constants';
+
+/**
+ * Defines the positions/directions in a formation and the continuities
+ * used to reach the next position.
+ */
+export default class StuntSheet {
+  stuntSheetDots: StuntSheetDot[];
+
+  dotTypes: BaseContinuity[][];
+
+  beats: number;
+
+  constructor() {
+    this.stuntSheetDots = [];
+    this.dotTypes = [[new ContinuityInPlace(0, DIRECTIONS.E, MARCH_TYPES.HS)]];
+    this.beats = 16;
+  }
+}

--- a/src/models/StuntSheetDot.ts
+++ b/src/models/StuntSheetDot.ts
@@ -1,0 +1,27 @@
+import { FlowBeat } from './util/types';
+
+/**
+ * Defines the position and direction of a marcher for a specific StuntSheet.
+ */
+export default class StuntSheetDot {
+  x: number;
+
+  y: number;
+
+  dotLabelIndex: number|null;
+
+  direction: number;
+
+  dotTypeIndex: number;
+
+  cachedFlow: FlowBeat[]|null;
+
+  constructor(x: number, y: number, dotLabelIndex?: number) {
+    this.x = x;
+    this.y = y;
+    this.dotLabelIndex = dotLabelIndex !== undefined ? dotLabelIndex : null;
+    this.direction = 0;
+    this.dotTypeIndex = 0;
+    this.cachedFlow = null;
+  }
+}

--- a/src/models/StuntSheetDot.ts
+++ b/src/models/StuntSheetDot.ts
@@ -2,6 +2,13 @@ import { FlowBeat } from './util/types';
 
 /**
  * Defines the position and direction of a marcher for a specific StuntSheet.
+ * 
+ * @property x             - EW position
+ * @property y             - NS position
+ * @property dotLabelIndex - Which label to use in Show.dotLabels
+ * @property dotTypeIndex  - Which set of continuities to use in StuntSheet.dotTypes
+ * @property 
+ * @property cachedFlow    - Cached so that the flow does not need to be recalculated again
  */
 export default class StuntSheetDot {
   x: number;
@@ -9,8 +16,6 @@ export default class StuntSheetDot {
   y: number;
 
   dotLabelIndex: number|null;
-
-  direction: number;
 
   dotTypeIndex: number;
 
@@ -20,7 +25,6 @@ export default class StuntSheetDot {
     this.x = x;
     this.y = y;
     this.dotLabelIndex = dotLabelIndex !== undefined ? dotLabelIndex : null;
-    this.direction = 0;
     this.dotTypeIndex = 0;
     this.cachedFlow = null;
   }

--- a/src/models/StuntSheetDot.ts
+++ b/src/models/StuntSheetDot.ts
@@ -3,8 +3,8 @@ import { FlowBeat } from './util/types';
 /**
  * Defines the position and direction of a marcher for a specific StuntSheet.
  * 
- * @property x             - EW position
- * @property y             - NS position
+ * @property x             - EW position of the first beat
+ * @property y             - NS position of the first beat
  * @property dotLabelIndex - Which label to use in Show.dotLabels
  * @property dotTypeIndex  - Which set of continuities to use in StuntSheet.dotTypes
  * @property cachedFlow    - Cached so that the flow does not need to be recalculated again

--- a/src/models/StuntSheetDot.ts
+++ b/src/models/StuntSheetDot.ts
@@ -7,7 +7,6 @@ import { FlowBeat } from './util/types';
  * @property y             - NS position
  * @property dotLabelIndex - Which label to use in Show.dotLabels
  * @property dotTypeIndex  - Which set of continuities to use in StuntSheet.dotTypes
- * @property 
  * @property cachedFlow    - Cached so that the flow does not need to be recalculated again
  */
 export default class StuntSheetDot {

--- a/src/models/continuity/BaseContinuity.ts
+++ b/src/models/continuity/BaseContinuity.ts
@@ -1,0 +1,51 @@
+import StuntSheetDot from '../StuntSheetDot';
+import { MARCH_TYPES } from '../util/constants';
+import { FlowBeat } from '../util/types';
+
+/**
+ * Defines a unique identifier for each continuity class so that it is possible
+ * to deserialize from a JSON string.
+ */
+export enum CONTINUITY_IDS {
+  IN_PLACE,
+  EIGHT_TO_FIVE_STATIC,
+  EIGHT_TO_FIVE_DYNAMIC,
+  EVEN,
+  FOLLOW_THE_LEADER,
+  COUNTER_MARCH,
+  GATE_TURN,
+  STEP_TWO,
+}
+
+/**
+ * Defines a specific movement that is used by a group of marchers
+ * to get to their next positions.
+ * 
+ * @property continuityId      - Identifier for deserializer.
+ * @property duration          - How many beats to execute. If 0, it indicates to do the continuity until reached the end position or for the rest of the stunt sheet.
+ * @property marchType         - Marks each generated FlowBeat with this type.
+ * @property humanReadableText - User defined text to be used to describe the continuity to bandsmen. Leave blank to use the computer generated text.
+ */
+export default interface BaseContinuity {
+  continuityId: CONTINUITY_IDS;
+
+  duration: number;
+
+  marchType: MARCH_TYPES;
+
+  humanReadableText: string;
+
+  /**
+   * If the user has not defined text, generate the continuity's description
+   */
+  getHumanReadableText(): string;
+
+  /**
+   * Execute the continuity for the specified dot and flow. Directly concats to flow.
+   * 
+   * @param flow     - The flow to concat
+   * @param startDot - The dot in the start stuntsheet
+   * @param endDot   - The dot in the next stuntsheet
+   */
+  addToFlow(flow: FlowBeat[], startDot: StuntSheetDot, endDot?: StuntSheetDot): void;
+}

--- a/src/models/continuity/ContinuityCounterMarch.ts
+++ b/src/models/continuity/ContinuityCounterMarch.ts
@@ -1,29 +1,25 @@
 import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
 import { MARCH_TYPES } from '../util/constants';
 import { FlowBeat } from '../util/types';
-import StuntSheetDot from '../StuntSheetDot';
 
 /**
- * Moves in even steps for the entirety of the specified duration to the end position.
- * Accepts HS, MM, and Military.
- * 
- * - Even HS 16
- * - Even MM 8
+ * Similar to follow the leader, but the leader also follows the tail.
  */
-export default class ContinuityEven implements BaseContinuity {
+export default class ContinuityCounterMarch implements BaseContinuity {
   continuityId: CONTINUITY_IDS;
 
   duration: number;
 
-  marchType: MARCH_TYPES;
-
   humanReadableText: string;
 
+  marchType: MARCH_TYPES;
+
   constructor(duration: number, marchType: MARCH_TYPES) {
-    this.continuityId = CONTINUITY_IDS.EVEN;
+    this.continuityId = CONTINUITY_IDS.FOLLOW_THE_LEADER;
     this.duration = duration;
-    this.marchType = marchType;
     this.humanReadableText = '';
+    this.marchType = marchType;
   }
 
   getHumanReadableText(): string {

--- a/src/models/continuity/ContinuityEightToFiveDynamic.ts
+++ b/src/models/continuity/ContinuityEightToFiveDynamic.ts
@@ -18,6 +18,8 @@ export enum EIGHT_TO_FIVE_DYNAMIC_TYPES {
  * - NS/EW FMHS
  * - DHS/FMHS
  * - FMHS/DHS
+ * 
+ * @property eightToFiveType - Determines the order of directions to move in
  */
 export default class ContinuityEightToFiveDynamic implements BaseContinuity {
   continuityId: CONTINUITY_IDS;

--- a/src/models/continuity/ContinuityEightToFiveDynamic.ts
+++ b/src/models/continuity/ContinuityEightToFiveDynamic.ts
@@ -1,0 +1,99 @@
+import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
+import { MARCH_TYPES } from '../util/constants';
+import { FlowBeat } from '../util/types';
+import { startPositionHelper, ewHelper, nsHelper, diagonalHelper } from './continuity-util';
+
+export enum EIGHT_TO_FIVE_DYNAMIC_TYPES {
+  EWNS,
+  NSEW,
+  DFM,
+  FMD,
+}
+
+/**
+ * Move in a combination of directions until reach the end position. Can only move in an eight-to-five step.
+ * Accepts HS, MM, and Military.
+ * - EW/NS FMHS
+ * - NS/EW FMHS
+ * - DHS/FMHS
+ * - FMHS/DHS
+ */
+export default class ContinuityEightToFiveDynamic implements BaseContinuity {
+  continuityId: CONTINUITY_IDS;
+
+  duration: number;
+
+  humanReadableText: string;
+
+  eightToFiveType: EIGHT_TO_FIVE_DYNAMIC_TYPES;
+
+  marchType: MARCH_TYPES;
+
+  constructor(eightToFiveType: EIGHT_TO_FIVE_DYNAMIC_TYPES, marchType: MARCH_TYPES) {
+    this.continuityId = CONTINUITY_IDS.EIGHT_TO_FIVE_DYNAMIC;
+    this.duration = 0;
+    this.humanReadableText = '';
+    this.eightToFiveType = eightToFiveType;
+    this.marchType = marchType;
+  }
+
+  getHumanReadableText(): string {
+    if (this.humanReadableText !== '') return this.humanReadableText;
+
+    switch (this.eightToFiveType) {
+      case EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS:
+        return `EW/NS FM${this.marchType}`;
+
+      case EIGHT_TO_FIVE_DYNAMIC_TYPES.NSEW:
+        return `NS/EW FM${this.marchType}`;
+
+      case EIGHT_TO_FIVE_DYNAMIC_TYPES.DFM:
+        return `D${this.marchType}/FM${this.marchType}`;
+
+      case EIGHT_TO_FIVE_DYNAMIC_TYPES.FMD:
+        return `FM${this.marchType}/D${this.marchType}`
+
+      default:
+        return 'Unknown';
+    }
+  }
+
+  addToFlow(flow: FlowBeat[], startDot: StuntSheetDot, endDot?: StuntSheetDot): void {
+    if (endDot === undefined) return;
+
+    let [startX, startY]: [number, number] = startPositionHelper(flow, startDot);
+    const [endX, endY]: [number, number] = [endDot.x, endDot.y];
+    let offsetX: number = endX - startX;
+    let offsetY: number = endY - startY;
+    let diagOffsetX: number;
+    let diagOffsetY: number;
+    
+    if (this.eightToFiveType === EIGHT_TO_FIVE_DYNAMIC_TYPES.DFM || this.eightToFiveType === EIGHT_TO_FIVE_DYNAMIC_TYPES.FMD) {
+      const absOffsetX: number = Math.abs(offsetX);
+      const absOffsetY: number = Math.abs(offsetY);
+      const absDiagOffset: number = Math.min(absOffsetX, absOffsetY);
+
+      diagOffsetX = Math.sign(offsetX) * absDiagOffset;
+      diagOffsetY = Math.sign(offsetY) * absDiagOffset;
+
+      offsetX = Math.sign(offsetX) * (absOffsetX - absDiagOffset);
+      offsetY = Math.sign(offsetY) * (absOffsetY - absDiagOffset);
+
+      if (this.eightToFiveType === EIGHT_TO_FIVE_DYNAMIC_TYPES.DFM) {
+        [startX, startY] = diagonalHelper(flow, startX, startY, diagOffsetX, diagOffsetY, this.marchType);
+        [startX, startY] = offsetX > 0 ? nsHelper(flow, startX, startY, offsetX, this.marchType) : ewHelper(flow, startX, startY, offsetY, this.marchType);
+      } else if (this.eightToFiveType === EIGHT_TO_FIVE_DYNAMIC_TYPES.FMD) {
+        [startX, startY] = offsetX > 0 ? nsHelper(flow, startX, startY, offsetX, this.marchType) : ewHelper(flow, startX, startY, offsetY, this.marchType);
+        [startX, startY] = diagonalHelper(flow, startX, startY, diagOffsetX, diagOffsetY, this.marchType);
+      }
+
+    } else if (this.eightToFiveType === EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS) {
+      [startX, startY] = ewHelper(flow, startX, startY, offsetY, this.marchType);
+      [startX, startY] = nsHelper(flow, startX, startY, offsetX, this.marchType);
+    } else if (this.eightToFiveType === EIGHT_TO_FIVE_DYNAMIC_TYPES.NSEW) {
+      [startX, startY] = nsHelper(flow, startX, startY, offsetX, this.marchType);
+      [startX, startY] = ewHelper(flow, startX, startY, offsetY, this.marchType);
+    }
+  }
+}

--- a/src/models/continuity/ContinuityEightToFiveStatic.ts
+++ b/src/models/continuity/ContinuityEightToFiveStatic.ts
@@ -1,0 +1,47 @@
+import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
+import { MARCH_TYPES, DIRECTION_TO_DEGREES } from '../util/constants';
+import { FlowBeat } from '../util/types';
+
+/**
+ * Move in a specified direction for a duration. Can only move in an eight-to-five step.
+ * Accepts HS, MM, and Military.
+ * - FMHS 8 E
+ * - FMMM 4 SW
+ * 
+ * @property marchingDirection - Which direction the marcher is moving
+ * @property facingDirection   - Which direction the marcher is facing during the movement. If undefined, will be marchingDirection.
+ */
+export default class ContinuityEightToFiveStatic implements BaseContinuity {
+  continuityId: CONTINUITY_IDS;
+
+  duration: number;
+
+  marchingDirection: DIRECTION_TO_DEGREES;
+
+  facingDirection: DIRECTION_TO_DEGREES;
+
+  humanReadableText: string;
+
+  marchType: MARCH_TYPES;
+
+  constructor(duration: number, marchType: MARCH_TYPES, marchingDirection: DIRECTION_TO_DEGREES, facingDirection?: DIRECTION_TO_DEGREES) {
+    this.continuityId = CONTINUITY_IDS.EIGHT_TO_FIVE_STATIC;
+    this.duration = duration;
+    this.marchingDirection = marchingDirection;
+    this.facingDirection = facingDirection === undefined ? marchingDirection : facingDirection;
+    this.humanReadableText = '';
+    this.marchType = marchType;
+  }
+
+  getHumanReadableText(): string {
+    if (this.humanReadableText !== '') return this.humanReadableText;
+    // TODO: Implement
+    return '';
+  }
+
+  addToFlow(flow: FlowBeat[], startDot: StuntSheetDot, endDot?: StuntSheetDot): void {
+    if (endDot === undefined) return;
+    // TODO: Implement
+  }
+}

--- a/src/models/continuity/ContinuityEven.ts
+++ b/src/models/continuity/ContinuityEven.ts
@@ -1,0 +1,34 @@
+import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import { MARCH_TYPES } from '../util/constants';
+import { FlowBeat } from '../util/types';
+import StuntSheetDot from '../StuntSheetDot';
+
+/**
+ * Moves in even steps for the entirety of the specified duration to the end position.
+ * Accepts HS, MM, and Military.
+ */
+export default class ContinuityEven implements BaseContinuity {
+  continuityId: CONTINUITY_IDS;
+
+  duration: number;
+
+  marchType: MARCH_TYPES;
+
+  humanReadableText: string;
+
+  constructor(duration: number, marchType: MARCH_TYPES) {
+    this.continuityId = CONTINUITY_IDS.EVEN;
+    this.duration = duration;
+    this.marchType = marchType;
+    this.humanReadableText = '';
+  }
+
+  getHumanReadableText(): string {
+    return this.humanReadableText === undefined ? `Even ${this.duration}` : this.humanReadableText;
+  }
+
+  addToFlow(flow: FlowBeat[], startDot: StuntSheetDot, endDot?: StuntSheetDot): void {
+    if (endDot === undefined) return;
+    // TODO: Implement
+  }
+}

--- a/src/models/continuity/ContinuityFollowTheLeader.ts
+++ b/src/models/continuity/ContinuityFollowTheLeader.ts
@@ -1,29 +1,30 @@
 import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
 import { MARCH_TYPES } from '../util/constants';
 import { FlowBeat } from '../util/types';
-import StuntSheetDot from '../StuntSheetDot';
 
 /**
- * Moves in even steps for the entirety of the specified duration to the end position.
- * Accepts HS, MM, and Military.
+ * Defines the path that the leader takes, which the other bandsmen follow.
  * 
- * - Even HS 16
- * - Even MM 8
+ * @property leaderPath - Defines the flow that the leader will take
  */
-export default class ContinuityEven implements BaseContinuity {
+export default class ContinuityFollowTheLeader implements BaseContinuity {
   continuityId: CONTINUITY_IDS;
 
   duration: number;
 
-  marchType: MARCH_TYPES;
+  leaderPath: FlowBeat[];
 
   humanReadableText: string;
 
-  constructor(duration: number, marchType: MARCH_TYPES) {
-    this.continuityId = CONTINUITY_IDS.EVEN;
-    this.duration = duration;
-    this.marchType = marchType;
+  marchType: MARCH_TYPES;
+
+  constructor(marchType: MARCH_TYPES) {
+    this.continuityId = CONTINUITY_IDS.FOLLOW_THE_LEADER;
+    this.duration = 0;
+    this.leaderPath = [];
     this.humanReadableText = '';
+    this.marchType = marchType;
   }
 
   getHumanReadableText(): string {

--- a/src/models/continuity/ContinuityGateTurn.ts
+++ b/src/models/continuity/ContinuityGateTurn.ts
@@ -1,29 +1,30 @@
 import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
 import { MARCH_TYPES } from '../util/constants';
 import { FlowBeat } from '../util/types';
-import StuntSheetDot from '../StuntSheetDot';
 
 /**
- * Moves in even steps for the entirety of the specified duration to the end position.
- * Accepts HS, MM, and Military.
+ * Defines a gate turn continuity.
  * 
- * - Even HS 16
- * - Even MM 8
+ * @property centerPoints - [x, y] values for the center of each gate turn group
  */
-export default class ContinuityEven implements BaseContinuity {
+export default class ContinuityGateTurn implements BaseContinuity {
   continuityId: CONTINUITY_IDS;
 
   duration: number;
 
-  marchType: MARCH_TYPES;
+  centerPoints: [number, number][];
 
   humanReadableText: string;
 
+  marchType: MARCH_TYPES;
+
   constructor(duration: number, marchType: MARCH_TYPES) {
-    this.continuityId = CONTINUITY_IDS.EVEN;
+    this.continuityId = CONTINUITY_IDS.FOLLOW_THE_LEADER;
     this.duration = duration;
-    this.marchType = marchType;
+    this.centerPoints = [];
     this.humanReadableText = '';
+    this.marchType = marchType;
   }
 
   getHumanReadableText(): string {

--- a/src/models/continuity/ContinuityInPlace.ts
+++ b/src/models/continuity/ContinuityInPlace.ts
@@ -1,28 +1,28 @@
 import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
 import StuntSheetDot from '../StuntSheetDot';
-import { MARCH_TYPES, DIRECTIONS } from '../util/constants';
+import { MARCH_TYPES, DIRECTION_TO_DEGREES } from '../util/constants';
 import { FlowBeat } from '../util/types';
 import { startPositionHelper } from './continuity-util';
 
 /**
  * Stay in the same position for the specified duration, direction, and march type.
- *  - MTHS
- *  - MTMM
- *  - Close
- *  - Vamp
+ *  - MTHS 8 E
+ *  - MTMM 4 SW
+ *  - [Close N]
+ *  - Vamp E
  */
 export default class ContinuityInPlace implements BaseContinuity {
   continuityId: CONTINUITY_IDS;
 
   duration: number;
 
-  direction: DIRECTIONS;
+  direction: DIRECTION_TO_DEGREES;
 
   marchType: MARCH_TYPES;
 
   humanReadableText: string;
 
-  constructor(duration: number, direction: DIRECTIONS, marchType: MARCH_TYPES) {
+  constructor(duration: number, direction: DIRECTION_TO_DEGREES, marchType: MARCH_TYPES) {
     this.continuityId = CONTINUITY_IDS.IN_PLACE;
     this.duration = duration;
     this.direction = direction;
@@ -33,7 +33,7 @@ export default class ContinuityInPlace implements BaseContinuity {
   getHumanReadableText(): string {
     if (this.humanReadableText !== '') return this.humanReadableText;
 
-    const directionText: string = DIRECTIONS[this.direction];
+    const directionText: string = DIRECTION_TO_DEGREES[this.direction];
 
     let prefix: string = '';
     if (this.marchType === MARCH_TYPES.HS || this.marchType === MARCH_TYPES.MINI_MILITARY) {

--- a/src/models/continuity/ContinuityInPlace.ts
+++ b/src/models/continuity/ContinuityInPlace.ts
@@ -1,0 +1,59 @@
+import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
+import { MARCH_TYPES, DIRECTIONS } from '../util/constants';
+import { FlowBeat } from '../util/types';
+import { startPositionHelper } from './continuity-util';
+
+/**
+ * Stay in the same position for the specified duration, direction, and march type.
+ *  - MTHS
+ *  - MTMM
+ *  - Close
+ *  - Vamp
+ */
+export default class ContinuityInPlace implements BaseContinuity {
+  continuityId: CONTINUITY_IDS;
+
+  duration: number;
+
+  direction: DIRECTIONS;
+
+  marchType: MARCH_TYPES;
+
+  humanReadableText: string;
+
+  constructor(duration: number, direction: DIRECTIONS, marchType: MARCH_TYPES) {
+    this.continuityId = CONTINUITY_IDS.IN_PLACE;
+    this.duration = duration;
+    this.direction = direction;
+    this.marchType = marchType;
+    this.humanReadableText = '';
+  }
+
+  getHumanReadableText(): string {
+    if (this.humanReadableText !== '') return this.humanReadableText;
+
+    const directionText: string = DIRECTIONS[this.direction];
+
+    let prefix: string = '';
+    if (this.marchType === MARCH_TYPES.HS || this.marchType === MARCH_TYPES.MINI_MILITARY) {
+      prefix = 'MT';
+    }
+
+    return this.duration === 0 ? `[${prefix}${this.marchType} ${directionText}]` : `${prefix}${this.marchType} ${this.duration} ${directionText}`
+  }
+
+  addToFlow(flow: FlowBeat[], startDot: StuntSheetDot): void {
+    const [x, y]: [number, number] = startPositionHelper(flow, startDot);
+    const flowBeat: FlowBeat = {
+      x,
+      y,
+      direction: this.direction,
+      marchType: this.marchType
+    };
+
+    for (let beat = 1; beat <= Math.max(this.duration, 1); beat += 1) {
+      flow.push(flowBeat);
+    }
+  }
+}

--- a/src/models/continuity/ContinuityStepTwo.ts
+++ b/src/models/continuity/ContinuityStepTwo.ts
@@ -1,0 +1,44 @@
+import BaseContinuity, { CONTINUITY_IDS } from './BaseContinuity';
+import StuntSheetDot from '../StuntSheetDot';
+import { MARCH_TYPES } from '../util/constants';
+import { FlowBeat } from '../util/types';
+
+/**
+ * Defines the path that the leader takes, which the other bandsmen follow.
+ * - Step Two
+ *   - FMHS 4 E
+ *   - FMHS 4 W
+ *   - [MTHS E]
+ * 
+ * @property continuities - Execute this list of continuities after waiting a certain amount of time
+ */
+export default class ContinuityStepTwo implements BaseContinuity {
+  continuityId: CONTINUITY_IDS;
+
+  duration: number;
+
+  continuities: BaseContinuity[];
+
+  humanReadableText: string;
+
+  marchType: MARCH_TYPES;
+
+  constructor(marchType: MARCH_TYPES) {
+    this.continuityId = CONTINUITY_IDS.FOLLOW_THE_LEADER;
+    this.duration = 0;
+    this.continuities = [];
+    this.humanReadableText = '';
+    this.marchType = marchType;
+  }
+
+  getHumanReadableText(): string {
+    if (this.humanReadableText !== '') return this.humanReadableText;
+    // TODO: Implement
+    return '';
+  }
+
+  addToFlow(flow: FlowBeat[], startDot: StuntSheetDot, endDot?: StuntSheetDot): void {
+    if (endDot === undefined) return;
+    // TODO: Implement
+  }
+}

--- a/src/models/continuity/continuity-util.ts
+++ b/src/models/continuity/continuity-util.ts
@@ -2,10 +2,10 @@ import { FlowBeat } from "../util/types";
 
 import StuntSheetDot from "../StuntSheetDot";
 
-import { MARCH_TYPES, DIRECTIONS } from "../util/constants";
+import { MARCH_TYPES, DIRECTION_TO_DEGREES } from "../util/constants";
 
 /**
- * Decides where the next continuity starts from, either the end of the flow or the position of the dot.
+ * Decides the starting position for the upcoming continuity
  * @returns [x, y]
  */
 export const startPositionHelper = (flow: FlowBeat[], startDot: StuntSheetDot): [number, number] => {
@@ -24,13 +24,14 @@ export const startPositionHelper = (flow: FlowBeat[], startDot: StuntSheetDot): 
 
 /**
  * Helper function to march in either north or south (eight to five)
+ * 
  * @param offsetX    - How many steps to march. Positive is north, negative is south.
  * @param direction? - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
  * @returns [x, y] ending coordinates
  */
 export const nsHelper = (flow: FlowBeat[], startX: number, startY: number, offsetX: number, marchType: MARCH_TYPES, direction?: number): [number, number] => {
   if (direction === undefined) {
-    direction = Math.sign(offsetX) ? DIRECTIONS.N : DIRECTIONS.S;
+    direction = Math.sign(offsetX) ? DIRECTION_TO_DEGREES.N : DIRECTION_TO_DEGREES.S;
   }
 
   for (let step = 1; step <= Math.abs(offsetX); step += 1) {
@@ -47,13 +48,14 @@ export const nsHelper = (flow: FlowBeat[], startX: number, startY: number, offse
 
 /**
  * Helper function to march in either north or south (eight to five)
+ * 
  * @param offsetY    - How many steps to march. Positive is east, negative is west.
  * @param direction? - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
  * @returns [x, y] ending coordinates
  */
 export const ewHelper = (flow: FlowBeat[], startX: number, startY: number, offsetY: number, marchType: MARCH_TYPES, direction?: number): [number, number] => {
   if (direction === undefined) {
-    direction = Math.sign(offsetY) ? DIRECTIONS.E : DIRECTIONS.W;
+    direction = Math.sign(offsetY) ? DIRECTION_TO_DEGREES.E : DIRECTION_TO_DEGREES.W;
   }
 
   for (let step = 1; step <= Math.abs(offsetY); step += 1) {
@@ -70,9 +72,10 @@ export const ewHelper = (flow: FlowBeat[], startX: number, startY: number, offse
 
 /**
  * Helper function to march in a diagonal (eight to five)
+ * 
  * @param offsetX    - Positive is north, negative is south.
  * @param offsetY    - Positive is east, negative is west.
- * @param direction? - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
+ * @param direction  - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
  * @returns [x, y] ending coordinates
  */
 export const diagonalHelper = (flow: FlowBeat[], startX: number, startY: number, offsetX: number, offsetY: number, marchType: MARCH_TYPES, direction?: number): [number, number] => {
@@ -82,9 +85,9 @@ export const diagonalHelper = (flow: FlowBeat[], startX: number, startY: number,
 
   if (direction === undefined) {
     if (Math.sign(offsetX) > 0) {
-      direction = Math.sign(offsetY) ? DIRECTIONS.NE : DIRECTIONS.NW;
+      direction = Math.sign(offsetY) ? DIRECTION_TO_DEGREES.NE : DIRECTION_TO_DEGREES.NW;
     } else {
-      direction = Math.sign(offsetY) ? DIRECTIONS.SE : DIRECTIONS.SW;
+      direction = Math.sign(offsetY) ? DIRECTION_TO_DEGREES.SE : DIRECTION_TO_DEGREES.SW;
     }
   }
 

--- a/src/models/continuity/continuity-util.ts
+++ b/src/models/continuity/continuity-util.ts
@@ -1,0 +1,101 @@
+import { FlowBeat } from "../util/types";
+
+import StuntSheetDot from "../StuntSheetDot";
+
+import { MARCH_TYPES, DIRECTIONS } from "../util/constants";
+
+/**
+ * Decides where the next continuity starts from, either the end of the flow or the position of the dot.
+ * @returns [x, y]
+ */
+export const startPositionHelper = (flow: FlowBeat[], startDot: StuntSheetDot): [number, number] => {
+  let startX: number;
+  let startY: number;
+  if (flow.length === 0) {
+    startX = startDot.x;
+    startY = startDot.y;
+  } else {
+    const lastFlowBeat: FlowBeat = flow[flow.length - 1];
+    startX = lastFlowBeat.x;
+    startY = lastFlowBeat.y;
+  }
+  return [startX, startY];
+}
+
+/**
+ * Helper function to march in either north or south (eight to five)
+ * @param offsetX    - How many steps to march. Positive is north, negative is south.
+ * @param direction? - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
+ * @returns [x, y] ending coordinates
+ */
+export const nsHelper = (flow: FlowBeat[], startX: number, startY: number, offsetX: number, marchType: MARCH_TYPES, direction?: number): [number, number] => {
+  if (direction === undefined) {
+    direction = Math.sign(offsetX) ? DIRECTIONS.N : DIRECTIONS.S;
+  }
+
+  for (let step = 1; step <= Math.abs(offsetX); step += 1) {
+    flow.push({
+      x: startX + Math.sign(offsetX) * step,
+      y: startY,
+      direction: direction,
+      marchType: marchType
+    });
+  }
+
+  return [startX + offsetX, startY];
+}
+
+/**
+ * Helper function to march in either north or south (eight to five)
+ * @param offsetY    - How many steps to march. Positive is east, negative is west.
+ * @param direction? - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
+ * @returns [x, y] ending coordinates
+ */
+export const ewHelper = (flow: FlowBeat[], startX: number, startY: number, offsetY: number, marchType: MARCH_TYPES, direction?: number): [number, number] => {
+  if (direction === undefined) {
+    direction = Math.sign(offsetY) ? DIRECTIONS.E : DIRECTIONS.W;
+  }
+
+  for (let step = 1; step <= Math.abs(offsetY); step += 1) {
+    flow.push({
+      x: startX,
+      y: startY + Math.sign(offsetY) * step,
+      direction: direction,
+      marchType: marchType
+    });
+  }
+
+  return [startX, startY + offsetY];
+}
+
+/**
+ * Helper function to march in a diagonal (eight to five)
+ * @param offsetX    - Positive is north, negative is south.
+ * @param offsetY    - Positive is east, negative is west.
+ * @param direction? - To enforce a direction to face, set this parameter. If undefined, the marcher will face the direction they are marching.
+ * @returns [x, y] ending coordinates
+ */
+export const diagonalHelper = (flow: FlowBeat[], startX: number, startY: number, offsetX: number, offsetY: number, marchType: MARCH_TYPES, direction?: number): [number, number] => {
+  if (Math.abs(offsetX) !== Math.abs(offsetY)) {
+    throw `offsetX (${offsetX}) and offsetY (${offsetY}) are not equal!`
+  }
+
+  if (direction === undefined) {
+    if (Math.sign(offsetX) > 0) {
+      direction = Math.sign(offsetY) ? DIRECTIONS.NE : DIRECTIONS.NW;
+    } else {
+      direction = Math.sign(offsetY) ? DIRECTIONS.SE : DIRECTIONS.SW;
+    }
+  }
+
+  for (let step = 1; step <= Math.abs(offsetX); step += 1) {
+    flow.push({
+      x: startX + Math.sign(offsetX) * step,
+      y: startY + Math.sign(offsetY) * step,
+      direction: direction,
+      marchType: marchType
+    });
+  }
+
+  return [startX + offsetX, startY + offsetY];
+}

--- a/src/models/util/constants.ts
+++ b/src/models/util/constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Helper for direction name to degrees.
+ */
+export enum DIRECTIONS {
+  N = 0,
+  NE = 45,
+  E = 90,
+  SE = 135,
+  S = 180,
+  SW = 225,
+  W = 270,
+  NW = 315
+}
+
+/**
+ * Defines the different types of marching that Cal Band performs.
+ */
+export enum MARCH_TYPES {
+  HS = 'HS',
+  MINI_MILITARY = 'MM',
+  MILITARY = 'Military',
+  CLOSE = 'Close',
+  VAMP = 'Vamp',
+}

--- a/src/models/util/constants.ts
+++ b/src/models/util/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Helper for direction name to degrees.
  */
-export enum DIRECTIONS {
+export enum DIRECTION_TO_DEGREES {
   N = 0,
   NE = 45,
   E = 90,

--- a/src/models/util/load-show.ts
+++ b/src/models/util/load-show.ts
@@ -1,0 +1,71 @@
+import Show from '../Show';
+import BaseContinuity, { CONTINUITY_IDS } from '../continuity/BaseContinuity';
+import Field from '../Field';
+import StuntSheet from '../StuntSheet';
+import StuntSheetDot from '../StuntSheetDot';
+import ContinuityInPlace from '../continuity/ContinuityInPlace';
+import ContinuityEightToFiveDynamic from '../continuity/ContinuityEightToFiveDynamic';
+import ContinuityEven from '../continuity/ContinuityEven';
+
+/**
+ * Helper that creates a new object with Typescript class defined in proto.
+ * Inspired by: http://choly.ca/post/typescript-json/
+ */
+export const typeHelper = (value: any, proto: any): Object => {
+  let typed = Object.create(proto);
+  return Object.assign(typed, value);
+}
+
+export const typeArrayHelper = (array: any[], proto: any): Object[] => {
+  array.forEach((value: Object, index: number, array: Array<Object>) => {
+    array[index] = typeHelper(value, proto);
+  });
+  return array;
+}
+
+/**
+ * Helper function to get the class prototype of a continuity.
+ */
+const getContinuityProto = (continuity: BaseContinuity) => {
+  switch (continuity.continuityId) {
+    case CONTINUITY_IDS.IN_PLACE:
+      return ContinuityInPlace.prototype;
+    
+    case CONTINUITY_IDS.EIGHT_TO_FIVE_DYNAMIC:
+      return ContinuityEightToFiveDynamic.prototype;
+    
+    case CONTINUITY_IDS.EVEN:
+      return ContinuityEven.prototype;
+  }
+}
+
+/**
+ * reviver function to be used in JSON.parse. Makes sure that parsed objects have the correct Typescript class.
+ * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+ * 
+ * This must be done in for any field that is not a primitive type.
+ */
+export const showReviver = (key: string, value: any): any => {
+  switch (key) {
+    case 'dotTypes': // StuntSheet
+      let dotTypes: BaseContinuity[][] = value;
+      return dotTypes.map((continuities: BaseContinuity[]) => {
+        return continuities.map((continuity: BaseContinuity) => {
+          const proto = getContinuityProto(continuity);
+          return typeHelper(continuity, proto);
+        });
+      });
+
+    case 'stuntSheetDots': // StuntSheet
+      return typeArrayHelper(value, StuntSheetDot.prototype);
+
+    case 'field': // Show
+      return typeHelper(value, Field.prototype);
+
+    case 'stuntSheets': // Show
+      return typeArrayHelper(value, StuntSheet.prototype);
+
+    default:
+      return value;
+  }
+};

--- a/src/models/util/load-show.ts
+++ b/src/models/util/load-show.ts
@@ -6,6 +6,11 @@ import StuntSheetDot from '../StuntSheetDot';
 import ContinuityInPlace from '../continuity/ContinuityInPlace';
 import ContinuityEightToFiveDynamic from '../continuity/ContinuityEightToFiveDynamic';
 import ContinuityEven from '../continuity/ContinuityEven';
+import ContinuityEightToFiveStatic from '../continuity/ContinuityEightToFiveStatic';
+import ContinuityFollowTheLeader from '../continuity/ContinuityFollowTheLeader';
+import ContinuityCounterMarch from '../continuity/ContinuityCounterMarch';
+import ContinuityGateTurn from '../continuity/ContinuityGateTurn';
+import ContinuityStepTwo from '../continuity/ContinuityStepTwo';
 
 /**
  * Helper that creates a new object with Typescript class defined in proto.
@@ -26,21 +31,39 @@ export const typeArrayHelper = (array: any[], proto: any): Object[] => {
 /**
  * Helper function to get the class prototype of a continuity.
  */
-const getContinuityProto = (continuity: BaseContinuity) => {
+export const getContinuityProto = (continuity: BaseContinuity) => {
   switch (continuity.continuityId) {
     case CONTINUITY_IDS.IN_PLACE:
       return ContinuityInPlace.prototype;
+
+    case CONTINUITY_IDS.EIGHT_TO_FIVE_STATIC:
+      return ContinuityEightToFiveStatic.prototype;
     
     case CONTINUITY_IDS.EIGHT_TO_FIVE_DYNAMIC:
       return ContinuityEightToFiveDynamic.prototype;
     
     case CONTINUITY_IDS.EVEN:
       return ContinuityEven.prototype;
+
+    case CONTINUITY_IDS.FOLLOW_THE_LEADER:
+      return ContinuityFollowTheLeader.prototype;
+    
+    case CONTINUITY_IDS.COUNTER_MARCH:
+      return ContinuityCounterMarch.prototype;
+
+    case CONTINUITY_IDS.GATE_TURN:
+      return ContinuityGateTurn.prototype;
+
+    case CONTINUITY_IDS.STEP_TWO:
+      return ContinuityStepTwo.prototype;
+
+    default:
+      return Object.prototype;
   }
 }
 
 /**
- * reviver function to be used in JSON.parse. Makes sure that parsed objects have the correct Typescript class.
+ * The reviver function to be used in JSON.parse. Makes sure that parsed objects have the correct Typescript class.
  * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
  * 
  * This must be done in for any field that is not a primitive type.

--- a/src/models/util/types.ts
+++ b/src/models/util/types.ts
@@ -1,0 +1,11 @@
+import { MARCH_TYPES } from './constants';
+
+/**
+ * Defines what a bandsman is doing at a specified beat.
+ */
+export interface FlowBeat {
+  x: number;
+  y: number;
+  direction: number;
+  marchType: MARCH_TYPES;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,13 +7,7 @@ import Show from '@/models/Show';
 
 Vue.use(Vuex);
 
-// TODO: Is there a better way to do defaults?
-interface assignedStateType {
-  show?: Show;
-  fourStepGrid?: boolean;
-}
-
-const initialState = (assignedState?: assignedStateType): stateType => {
+const initialState = (assignedState: Partial<stateType>): stateType => {
   const defaultState: stateType = {
     show: new Show(),
     fourStepGrid: true,
@@ -22,11 +16,11 @@ const initialState = (assignedState?: assignedStateType): stateType => {
 };
 
 export const generateStore = (
-  assignedState?: assignedStateType,
+  assignedState: Partial<stateType>,
 ): Store<stateType> => new Vuex.Store({
   state: initialState(assignedState),
   mutations,
   getters,
 });
 
-export default generateStore();
+export default generateStore({});

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -71,7 +71,7 @@ describe('components/grapher/Grapher.vue', () => {
     let store: Store<stateType>;
     let wrapper: Wrapper<Vue>;
     beforeAll(() => {
-      store = generateStore();
+      store = generateStore({});
       wrapper = mount(Grapher, {
         store,
         localVue,

--- a/tests/unit/components/menu-top/FileModal.spec.ts
+++ b/tests/unit/components/menu-top/FileModal.spec.ts
@@ -15,7 +15,7 @@ describe('components/menu-top/FileModal', () => {
     localVue = createLocalVue();
     localVue.use(Vuex);
     localVue.use(Buefy);
-    store = generateStore();
+    store = generateStore({});
     wrapper = mount(FileModal, {
       store,
       localVue,

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -15,7 +15,7 @@ describe('components/menu-top/MenuTop', () => {
     localVue = createLocalVue();
     localVue.use(Vuex);
     localVue.use(Buefy);
-    store = generateStore();
+    store = generateStore({});
     wrapper = mount(MenuTop, {
       store,
       localVue,

--- a/tests/unit/models/Show.spec.ts
+++ b/tests/unit/models/Show.spec.ts
@@ -1,0 +1,183 @@
+import Show from "@/models/Show";
+import StuntSheet from '@/models/StuntSheet';
+import ContinuityEightToFiveDynamic from '@/models/continuity/ContinuityEightToFiveDynamic';
+import ContinuityInPlace from '@/models/continuity/ContinuityInPlace';
+import StuntSheetDot from '@/models/StuntSheetDot';
+import { MARCH_TYPES } from '@/models/util/constants';
+import { FlowBeat } from '@/models/util/types';
+
+// Mock ContinuityEightToFiveDynamic to add the start and end dot positions to the flow
+jest.mock('@/models/continuity/ContinuityEightToFiveDynamic', () => {
+  return jest.fn().mockImplementation((_, marchType: MARCH_TYPES) => {
+    return {
+      addToFlow: jest.fn().mockImplementation((flow: FlowBeat[], startDot: StuntSheetDot, endDot?: StuntSheetDot) => {
+        if (endDot === undefined) return;
+        flow.push(
+          {
+            x: startDot.x,
+            y: startDot.y,
+            direction: 45,
+            marchType: marchType
+          },
+          {
+            x: endDot.x,
+            y: endDot.y,
+            direction: 45,
+            marchType: marchType
+          },
+        );
+      })
+    }
+  });
+});
+
+// Mock ContinuityInPlace to add the start dot position to the flow
+jest.mock('@/models/continuity/ContinuityInPlace', () => {
+  return jest.fn().mockImplementation((_, direction: number, marchType: MARCH_TYPES) => {
+    return {
+      addToFlow: jest.fn().mockImplementation((flow: FlowBeat[], startDot: StuntSheetDot) => {
+        flow.push({
+          x: startDot.x,
+          y: startDot.y,
+          direction: direction,
+          marchType: marchType
+        });
+      })
+    }
+  });
+});
+
+describe('models/Show', () => {
+  describe('generateFlows', () => {
+    let show: Show;
+
+    beforeAll(() => {
+      show = new Show();
+      show.dotLabels = ['A0', 'A1', 'A2'];
+      
+      const startSS: StuntSheet = new StuntSheet();
+      startSS.stuntSheetDots = [
+        new StuntSheetDot(0, 0, 0),
+        new StuntSheetDot(2, 2, 1),
+        new StuntSheetDot(4, 4, 2)
+      ];
+      startSS.stuntSheetDots[2].dotTypeIndex = 1;
+  
+      startSS.dotTypes = [
+        [
+          new ContinuityEightToFiveDynamic(0, MARCH_TYPES.HS),
+          new ContinuityInPlace(0, 90, MARCH_TYPES.HS)
+        ],
+        [
+          new ContinuityInPlace(2, 180, MARCH_TYPES.HS),
+          new ContinuityEightToFiveDynamic(0, MARCH_TYPES.HS),
+          new ContinuityInPlace(0, 270, MARCH_TYPES.HS)
+        ]
+      ];
+  
+      const endSS: StuntSheet = new StuntSheet();
+      endSS.stuntSheetDots = [
+        new StuntSheetDot(2, 2, 0),
+        new StuntSheetDot(4, 4, 1),
+        new StuntSheetDot(6, 6, 2)
+      ];
+  
+      show.stuntSheets = [startSS, endSS];
+  
+      show.generateFlows(0);
+    });
+
+    it('First dot type calls all continuities for the two dots', () => {
+      const firstDotType = show.stuntSheets[0].dotTypes[0];
+      expect(firstDotType[0].addToFlow).toHaveBeenCalledTimes(2);
+      expect(firstDotType[1].addToFlow).toHaveBeenCalledTimes(2);
+    });
+
+    it('Second dot type calls all continuities for the one dot', () => {
+      const secondDotType = show.stuntSheets[0].dotTypes[1];
+      expect(secondDotType[0].addToFlow).toHaveBeenCalledTimes(1);
+      expect(secondDotType[1].addToFlow).toHaveBeenCalledTimes(1);
+      expect(secondDotType[2].addToFlow).toHaveBeenCalledTimes(1);
+    });
+
+    it('First dot has correct cachedFlow', () => {
+      const firstStartDot: StuntSheetDot = show.stuntSheets[0].stuntSheetDots[0];
+      expect(firstStartDot.cachedFlow).toStrictEqual([
+        {
+          x: 0,
+          y: 0,
+          direction: 45,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 2,
+          y: 2,
+          direction: 45,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 0,
+          y: 0,
+          direction: 90,
+          marchType: MARCH_TYPES.HS
+        },
+      ]);
+    });
+
+    it('Second dot has correct cachedFlow', () => {
+      const secondStartDot: StuntSheetDot = show.stuntSheets[0].stuntSheetDots[1];
+      expect(secondStartDot.cachedFlow).toStrictEqual([
+        {
+          x: 2,
+          y: 2,
+          direction: 45,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 4,
+          y: 4,
+          direction: 45,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 2,
+          y: 2,
+          direction: 90,
+          marchType: MARCH_TYPES.HS
+        },
+      ]);
+    });
+
+    it('Third dot has correct cachedFlow', () => {
+      const thirdStartDot: StuntSheetDot = show.stuntSheets[0].stuntSheetDots[2];
+      const thirdEndDot: StuntSheetDot = show.stuntSheets[1].stuntSheetDots[2];
+      expect(thirdStartDot.cachedFlow).toStrictEqual([
+        {
+          x: 4,
+          y: 4,
+          direction: 180,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 4,
+          y: 4,
+          direction: 45,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 6,
+          y: 6,
+          direction: 45,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 4,
+          y: 4,
+          direction: 270,
+          marchType: MARCH_TYPES.HS
+        },
+      ]);
+    });
+
+  });
+});

--- a/tests/unit/models/continuity/ContinuityEightToFiveDynamic.spec.ts
+++ b/tests/unit/models/continuity/ContinuityEightToFiveDynamic.spec.ts
@@ -1,6 +1,6 @@
 import StuntSheetDot from '@/models/StuntSheetDot';
 import ContinuityEightToFiveDynamic, { EIGHT_TO_FIVE_DYNAMIC_TYPES } from '@/models/continuity/ContinuityEightToFiveDynamic';
-import { MARCH_TYPES, DIRECTIONS } from '@/models/util/constants';
+import { MARCH_TYPES, DIRECTION_TO_DEGREES } from '@/models/util/constants';
 import { FlowBeat } from '@/models/util/types';
 
 describe('models/continuity/ContinuityEightToFiveDynamic', () => {
@@ -65,25 +65,25 @@ describe('models/continuity/ContinuityEightToFiveDynamic', () => {
           {
             x: 2,
             y: 3,
-            direction: DIRECTIONS.E,
+            direction: DIRECTION_TO_DEGREES.E,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 2,
             y: 4,
-            direction: DIRECTIONS.E,
+            direction: DIRECTION_TO_DEGREES.E,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 3,
             y: 4,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 4,
             y: 4,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           }
         ]);
@@ -100,25 +100,25 @@ describe('models/continuity/ContinuityEightToFiveDynamic', () => {
           {
             x: 3,
             y: 2,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 4,
             y: 2,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 4,
             y: 3,
-            direction: DIRECTIONS.E,
+            direction: DIRECTION_TO_DEGREES.E,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 4,
             y: 4,
-            direction: DIRECTIONS.E,
+            direction: DIRECTION_TO_DEGREES.E,
             marchType: MARCH_TYPES.HS,
           }
         ]);
@@ -140,25 +140,25 @@ describe('models/continuity/ContinuityEightToFiveDynamic', () => {
           {
             x: 3,
             y: 3,
-            direction: DIRECTIONS.NE,
+            direction: DIRECTION_TO_DEGREES.NE,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 4,
             y: 4,
-            direction: DIRECTIONS.NE,
+            direction: DIRECTION_TO_DEGREES.NE,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 5,
             y: 4,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 6,
             y: 4,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           }
         ]);
@@ -175,25 +175,25 @@ describe('models/continuity/ContinuityEightToFiveDynamic', () => {
           {
             x: 3,
             y: 2,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 4,
             y: 2,
-            direction: DIRECTIONS.N,
+            direction: DIRECTION_TO_DEGREES.N,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 5,
             y: 3,
-            direction: DIRECTIONS.NE,
+            direction: DIRECTION_TO_DEGREES.NE,
             marchType: MARCH_TYPES.HS,
           },
           {
             x: 6,
             y: 4,
-            direction: DIRECTIONS.NE,
+            direction: DIRECTION_TO_DEGREES.NE,
             marchType: MARCH_TYPES.HS,
           }
         ]);

--- a/tests/unit/models/continuity/ContinuityEightToFiveDynamic.spec.ts
+++ b/tests/unit/models/continuity/ContinuityEightToFiveDynamic.spec.ts
@@ -1,0 +1,203 @@
+import StuntSheetDot from '@/models/StuntSheetDot';
+import ContinuityEightToFiveDynamic, { EIGHT_TO_FIVE_DYNAMIC_TYPES } from '@/models/continuity/ContinuityEightToFiveDynamic';
+import { MARCH_TYPES, DIRECTIONS } from '@/models/util/constants';
+import { FlowBeat } from '@/models/util/types';
+
+describe('models/continuity/ContinuityEightToFiveDynamic', () => {
+  describe('getHumanReadableText', () => {
+    it('generates EW/NS FMHS', () => {
+      const continuity = new ContinuityEightToFiveDynamic(
+        EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS,
+        MARCH_TYPES.HS
+      );
+      expect(continuity.getHumanReadableText()).toBe('EW/NS FMHS');
+    });
+
+    it('generates NS/EW FMMM', () => {
+      const continuity = new ContinuityEightToFiveDynamic(
+        EIGHT_TO_FIVE_DYNAMIC_TYPES.NSEW,
+        MARCH_TYPES.MINI_MILITARY
+      );
+      expect(continuity.getHumanReadableText()).toBe('NS/EW FMMM');
+    });
+
+    it('generates DHS/FMHS', () => {
+      const continuity = new ContinuityEightToFiveDynamic(
+        EIGHT_TO_FIVE_DYNAMIC_TYPES.DFM,
+        MARCH_TYPES.HS
+      );
+      expect(continuity.getHumanReadableText()).toBe('DHS/FMHS');
+    });
+
+    it('generates FMMM/DMM', () => {
+      const continuity = new ContinuityEightToFiveDynamic(
+        EIGHT_TO_FIVE_DYNAMIC_TYPES.FMD,
+        MARCH_TYPES.MINI_MILITARY
+      );
+      expect(continuity.getHumanReadableText()).toBe('FMMM/DMM');
+    });
+  });
+
+  describe('addToFlow', () => {
+    it('does not generate flow if endDot is undefined', () => {
+      const continuity = new ContinuityEightToFiveDynamic(
+        EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS,
+        MARCH_TYPES.HS
+      );
+      const startDot = new StuntSheetDot(2, 2);
+      let flow: FlowBeat[] = [];
+      continuity.addToFlow(flow, startDot, undefined);
+      expect(flow).toStrictEqual([]);
+    });
+
+    describe('No diagonals', () => {
+      const startDot = new StuntSheetDot(2, 2);
+      const endDot = new StuntSheetDot(4, 4);
+
+      it('generates flow for EW/NS', () => {
+        const continuity = new ContinuityEightToFiveDynamic(
+          EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS,
+          MARCH_TYPES.HS
+        );
+        let flow: FlowBeat[] = [];
+        continuity.addToFlow(flow, startDot, endDot);
+        expect(flow).toStrictEqual([
+          {
+            x: 2,
+            y: 3,
+            direction: DIRECTIONS.E,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 2,
+            y: 4,
+            direction: DIRECTIONS.E,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 3,
+            y: 4,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 4,
+            y: 4,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          }
+        ]);
+      });
+
+      it('generates flow for NS/EW', () => {
+        const continuity = new ContinuityEightToFiveDynamic(
+          EIGHT_TO_FIVE_DYNAMIC_TYPES.NSEW,
+          MARCH_TYPES.HS
+        );
+        let flow: FlowBeat[] = [];
+        continuity.addToFlow(flow, startDot, endDot);
+        expect(flow).toStrictEqual([
+          {
+            x: 3,
+            y: 2,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 4,
+            y: 2,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 4,
+            y: 3,
+            direction: DIRECTIONS.E,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 4,
+            y: 4,
+            direction: DIRECTIONS.E,
+            marchType: MARCH_TYPES.HS,
+          }
+        ]);
+      });
+    });
+
+    describe('Diagonals', () => {
+      const startDot = new StuntSheetDot(2, 2);
+      const endDot = new StuntSheetDot(6, 4);
+
+      it('generates flow for DHS/FMHS', () => {
+        const continuity = new ContinuityEightToFiveDynamic(
+          EIGHT_TO_FIVE_DYNAMIC_TYPES.DFM,
+          MARCH_TYPES.HS
+        );
+        let flow: FlowBeat[] = [];
+        continuity.addToFlow(flow, startDot, endDot);
+        expect(flow).toStrictEqual([
+          {
+            x: 3,
+            y: 3,
+            direction: DIRECTIONS.NE,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 4,
+            y: 4,
+            direction: DIRECTIONS.NE,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 5,
+            y: 4,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 6,
+            y: 4,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          }
+        ]);
+      });
+
+      it('generates flow for FMHS/DHS', () => {
+        const continuity = new ContinuityEightToFiveDynamic(
+          EIGHT_TO_FIVE_DYNAMIC_TYPES.FMD,
+          MARCH_TYPES.HS
+        );
+        let flow: FlowBeat[] = [];
+        continuity.addToFlow(flow, startDot, endDot);
+        expect(flow).toStrictEqual([
+          {
+            x: 3,
+            y: 2,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 4,
+            y: 2,
+            direction: DIRECTIONS.N,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 5,
+            y: 3,
+            direction: DIRECTIONS.NE,
+            marchType: MARCH_TYPES.HS,
+          },
+          {
+            x: 6,
+            y: 4,
+            direction: DIRECTIONS.NE,
+            marchType: MARCH_TYPES.HS,
+          }
+        ]);
+      });
+    });
+  });
+});

--- a/tests/unit/models/continuity/ContinuityInPlace.spec.ts
+++ b/tests/unit/models/continuity/ContinuityInPlace.spec.ts
@@ -1,0 +1,70 @@
+import StuntSheetDot from "@/models/StuntSheetDot";
+import ContinuityInPlace from '@/models/continuity/ContinuityInPlace';
+import { DIRECTIONS, MARCH_TYPES } from '@/models/util/constants';
+import { FlowBeat } from '@/models/util/types';
+
+describe('models/continuity/ContinuityInPlace', () => {
+  const startDot = new StuntSheetDot(2, 4);
+
+  describe('getHumanReadableText', () => {
+    it('generates [MTHS E]', () => {
+      const continuity = new ContinuityInPlace(0, DIRECTIONS.E, MARCH_TYPES.HS);
+      expect(continuity.getHumanReadableText()).toBe('[MTHS E]');
+    });
+
+    it('generates [MTMM W]', () => {
+      const continuity = new ContinuityInPlace(0, DIRECTIONS.W, MARCH_TYPES.MINI_MILITARY);
+      expect(continuity.getHumanReadableText()).toBe('[MTMM W]');
+    });
+
+    it('generates MTHS 8 N', () => {
+      const continuity = new ContinuityInPlace(8, DIRECTIONS.N, MARCH_TYPES.HS);
+      expect(continuity.getHumanReadableText()).toBe('MTHS 8 N');
+    });
+
+    it('generates Close 8 S', () => {
+      const continuity = new ContinuityInPlace(8, DIRECTIONS.S, MARCH_TYPES.CLOSE);
+      expect(continuity.getHumanReadableText()).toBe('Close 8 S');
+    });
+
+    it('uses user made text if available', () => {
+      const continuity = new ContinuityInPlace(8, DIRECTIONS.S, MARCH_TYPES.CLOSE);
+      continuity.humanReadableText = 'Kneel 8 E';
+      expect(continuity.getHumanReadableText()).toBe('Kneel 8 E');
+    });
+  });
+
+  describe('addToFlow', () => {
+    it('if duration is 0 adds one FlowBeat', () => {
+      const continuity = new ContinuityInPlace(0, DIRECTIONS.E, MARCH_TYPES.HS);
+      const flow: FlowBeat[] = [];
+      continuity.addToFlow(flow, startDot);
+      expect(flow).toStrictEqual([{
+        x: 2,
+        y: 4,
+        direction: DIRECTIONS.E,
+        marchType: MARCH_TYPES.HS
+      }]);
+    });
+
+    it('if duration is 2 adds two FlowBeats', () => {
+      const continuity = new ContinuityInPlace(2, DIRECTIONS.E, MARCH_TYPES.HS);
+      const flow: FlowBeat[] = [];
+      continuity.addToFlow(flow, startDot);
+      expect(flow).toStrictEqual([
+        {
+          x: 2,
+          y: 4,
+          direction: DIRECTIONS.E,
+          marchType: MARCH_TYPES.HS
+        },
+        {
+          x: 2,
+          y: 4,
+          direction: DIRECTIONS.E,
+          marchType: MARCH_TYPES.HS
+        }
+      ]);
+    });
+  });
+});

--- a/tests/unit/models/continuity/ContinuityInPlace.spec.ts
+++ b/tests/unit/models/continuity/ContinuityInPlace.spec.ts
@@ -1,6 +1,6 @@
 import StuntSheetDot from "@/models/StuntSheetDot";
 import ContinuityInPlace from '@/models/continuity/ContinuityInPlace';
-import { DIRECTIONS, MARCH_TYPES } from '@/models/util/constants';
+import { DIRECTION_TO_DEGREES, MARCH_TYPES } from '@/models/util/constants';
 import { FlowBeat } from '@/models/util/types';
 
 describe('models/continuity/ContinuityInPlace', () => {
@@ -8,27 +8,27 @@ describe('models/continuity/ContinuityInPlace', () => {
 
   describe('getHumanReadableText', () => {
     it('generates [MTHS E]', () => {
-      const continuity = new ContinuityInPlace(0, DIRECTIONS.E, MARCH_TYPES.HS);
+      const continuity = new ContinuityInPlace(0, DIRECTION_TO_DEGREES.E, MARCH_TYPES.HS);
       expect(continuity.getHumanReadableText()).toBe('[MTHS E]');
     });
 
     it('generates [MTMM W]', () => {
-      const continuity = new ContinuityInPlace(0, DIRECTIONS.W, MARCH_TYPES.MINI_MILITARY);
+      const continuity = new ContinuityInPlace(0, DIRECTION_TO_DEGREES.W, MARCH_TYPES.MINI_MILITARY);
       expect(continuity.getHumanReadableText()).toBe('[MTMM W]');
     });
 
     it('generates MTHS 8 N', () => {
-      const continuity = new ContinuityInPlace(8, DIRECTIONS.N, MARCH_TYPES.HS);
+      const continuity = new ContinuityInPlace(8, DIRECTION_TO_DEGREES.N, MARCH_TYPES.HS);
       expect(continuity.getHumanReadableText()).toBe('MTHS 8 N');
     });
 
     it('generates Close 8 S', () => {
-      const continuity = new ContinuityInPlace(8, DIRECTIONS.S, MARCH_TYPES.CLOSE);
+      const continuity = new ContinuityInPlace(8, DIRECTION_TO_DEGREES.S, MARCH_TYPES.CLOSE);
       expect(continuity.getHumanReadableText()).toBe('Close 8 S');
     });
 
     it('uses user made text if available', () => {
-      const continuity = new ContinuityInPlace(8, DIRECTIONS.S, MARCH_TYPES.CLOSE);
+      const continuity = new ContinuityInPlace(8, DIRECTION_TO_DEGREES.S, MARCH_TYPES.CLOSE);
       continuity.humanReadableText = 'Kneel 8 E';
       expect(continuity.getHumanReadableText()).toBe('Kneel 8 E');
     });
@@ -36,32 +36,32 @@ describe('models/continuity/ContinuityInPlace', () => {
 
   describe('addToFlow', () => {
     it('if duration is 0 adds one FlowBeat', () => {
-      const continuity = new ContinuityInPlace(0, DIRECTIONS.E, MARCH_TYPES.HS);
+      const continuity = new ContinuityInPlace(0, DIRECTION_TO_DEGREES.E, MARCH_TYPES.HS);
       const flow: FlowBeat[] = [];
       continuity.addToFlow(flow, startDot);
       expect(flow).toStrictEqual([{
         x: 2,
         y: 4,
-        direction: DIRECTIONS.E,
+        direction: DIRECTION_TO_DEGREES.E,
         marchType: MARCH_TYPES.HS
       }]);
     });
 
     it('if duration is 2 adds two FlowBeats', () => {
-      const continuity = new ContinuityInPlace(2, DIRECTIONS.E, MARCH_TYPES.HS);
+      const continuity = new ContinuityInPlace(2, DIRECTION_TO_DEGREES.E, MARCH_TYPES.HS);
       const flow: FlowBeat[] = [];
       continuity.addToFlow(flow, startDot);
       expect(flow).toStrictEqual([
         {
           x: 2,
           y: 4,
-          direction: DIRECTIONS.E,
+          direction: DIRECTION_TO_DEGREES.E,
           marchType: MARCH_TYPES.HS
         },
         {
           x: 2,
           y: 4,
-          direction: DIRECTIONS.E,
+          direction: DIRECTION_TO_DEGREES.E,
           marchType: MARCH_TYPES.HS
         }
       ]);

--- a/tests/unit/models/util/load-show.spec.ts
+++ b/tests/unit/models/util/load-show.spec.ts
@@ -1,27 +1,20 @@
 import Show from "@/models/Show";
-import { showReviver, typeHelper, typeArrayHelper } from '@/models/util/load-show';
+import { showReviver, typeHelper, typeArrayHelper, getContinuityProto } from '@/models/util/load-show';
 import Field from '@/models/Field';
 import StuntSheet from '@/models/StuntSheet';
 import StuntSheetDot from '@/models/StuntSheetDot';
 import ContinuityInPlace from '@/models/continuity/ContinuityInPlace';
-import { DIRECTIONS, MARCH_TYPES } from '@/models/util/constants';
+import { DIRECTION_TO_DEGREES, MARCH_TYPES } from '@/models/util/constants';
 import ContinuityEightToFiveDynamic, { EIGHT_TO_FIVE_DYNAMIC_TYPES } from '@/models/continuity/ContinuityEightToFiveDynamic';
+import ContinuityEven from '@/models/continuity/ContinuityEven';
+import BaseContinuity, { CONTINUITY_IDS } from '@/models/continuity/BaseContinuity';
+import ContinuityEightToFiveStatic from '@/models/continuity/ContinuityEightToFiveStatic';
+import ContinuityFollowTheLeader from '@/models/continuity/ContinuityFollowTheLeader';
+import ContinuityCounterMarch from '@/models/continuity/ContinuityCounterMarch';
+import ContinuityGateTurn from '@/models/continuity/ContinuityGateTurn';
+import ContinuityStepTwo from '@/models/continuity/ContinuityStepTwo';
 
 describe('models/util/load-show', () => {
-  let show: Show;
-  let showJson: string;
-
-  beforeEach(() => {
-    show = new Show();
-    show.stuntSheets = [new StuntSheet()];
-    show.stuntSheets[0].dotTypes = [[
-      new ContinuityInPlace(8, DIRECTIONS.E, MARCH_TYPES.MINI_MILITARY),
-      new ContinuityEightToFiveDynamic(EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS, MARCH_TYPES.HS)
-    ]];
-    show.stuntSheets[0].stuntSheetDots = [new StuntSheetDot(0, 0)];
-    showJson = JSON.stringify(show);
-  });
-
   it('typeHelper returns an object with correct type', () => {
     const field: Field = new Field();
     const fieldJson: string = JSON.stringify(field);
@@ -46,16 +39,77 @@ describe('models/util/load-show', () => {
     });
   });
 
-  it('loads show from json string with correct types', () => {
-    const showParsed: Show = JSON.parse(showJson, showReviver);
-    expect(showParsed.field instanceof Field).toBeTruthy();
-    expect(showParsed.stuntSheets instanceof Array).toBeTruthy();
-    expect(showParsed.stuntSheets[0] instanceof StuntSheet).toBeTruthy();
-    expect(showParsed.stuntSheets[0].dotTypes instanceof Array).toBeTruthy();
-    expect(showParsed.stuntSheets[0].dotTypes[0] instanceof Array).toBeTruthy();
-    expect(showParsed.stuntSheets[0].dotTypes[0][0] instanceof ContinuityInPlace).toBeTruthy();
-    expect(showParsed.stuntSheets[0].dotTypes[0][1] instanceof ContinuityEightToFiveDynamic).toBeTruthy();
-    expect(showParsed.stuntSheets[0].stuntSheetDots instanceof Array).toBeTruthy();
-    expect(showParsed.stuntSheets[0].stuntSheetDots[0] instanceof StuntSheetDot).toBeTruthy();
+  describe('getContinuityProto', () => {
+    const mockContinuity = (continuityId: CONTINUITY_IDS): BaseContinuity => {
+      return {
+        continuityId,
+        duration: 0,
+        marchType: MARCH_TYPES.HS,
+        humanReadableText: '',
+        getHumanReadableText: () => '',
+        addToFlow: () => {},
+      }
+    }
+
+    it('IN_PLACE', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.IN_PLACE))).toBe(ContinuityInPlace.prototype);
+    });
+
+    it('EIGHT_TO_FIVE_DYNAMIC', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.EIGHT_TO_FIVE_STATIC))).toBe(ContinuityEightToFiveStatic.prototype);
+    });
+
+    it('EIGHT_TO_FIVE_STATIC', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.EIGHT_TO_FIVE_DYNAMIC))).toBe(ContinuityEightToFiveDynamic.prototype);
+    });
+
+    it('EVEN', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.EVEN))).toBe(ContinuityEven.prototype);
+    });
+
+    it('FOLLOW_THE_LEADER', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.FOLLOW_THE_LEADER))).toBe(ContinuityFollowTheLeader.prototype);
+    });
+
+    it('COUNTER_MARCH', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.COUNTER_MARCH))).toBe(ContinuityCounterMarch.prototype);
+    });
+
+    it('GATE_TURN', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.GATE_TURN))).toBe(ContinuityGateTurn.prototype);
+    });
+
+    it('STEP_TWO', () => {
+      expect(getContinuityProto(mockContinuity(CONTINUITY_IDS.STEP_TWO))).toBe(ContinuityStepTwo.prototype);
+    });
+  });
+
+  describe('showReviver', () => {
+    let show: Show;
+    let showJson: string;
+  
+    beforeAll(() => {
+      show = new Show();
+      show.stuntSheets = [new StuntSheet()];
+      show.stuntSheets[0].dotTypes = [[
+        new ContinuityInPlace(8, DIRECTION_TO_DEGREES.E, MARCH_TYPES.MINI_MILITARY),
+        new ContinuityEightToFiveDynamic(EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS, MARCH_TYPES.HS)
+      ]];
+      show.stuntSheets[0].stuntSheetDots = [new StuntSheetDot(0, 0)];
+      showJson = JSON.stringify(show);
+    });
+
+    it('loads show from json string with correct types', () => {
+      const showParsed: Show = JSON.parse(showJson, showReviver);
+      expect(showParsed.field instanceof Field).toBeTruthy();
+      expect(showParsed.stuntSheets instanceof Array).toBeTruthy();
+      expect(showParsed.stuntSheets[0] instanceof StuntSheet).toBeTruthy();
+      expect(showParsed.stuntSheets[0].dotTypes instanceof Array).toBeTruthy();
+      expect(showParsed.stuntSheets[0].dotTypes[0] instanceof Array).toBeTruthy();
+      expect(showParsed.stuntSheets[0].dotTypes[0][0] instanceof ContinuityInPlace).toBeTruthy();
+      expect(showParsed.stuntSheets[0].dotTypes[0][1] instanceof ContinuityEightToFiveDynamic).toBeTruthy();
+      expect(showParsed.stuntSheets[0].stuntSheetDots instanceof Array).toBeTruthy();
+      expect(showParsed.stuntSheets[0].stuntSheetDots[0] instanceof StuntSheetDot).toBeTruthy();
+    });
   });
 });

--- a/tests/unit/models/util/load-show.spec.ts
+++ b/tests/unit/models/util/load-show.spec.ts
@@ -1,0 +1,61 @@
+import Show from "@/models/Show";
+import { showReviver, typeHelper, typeArrayHelper } from '@/models/util/load-show';
+import Field from '@/models/Field';
+import StuntSheet from '@/models/StuntSheet';
+import StuntSheetDot from '@/models/StuntSheetDot';
+import ContinuityInPlace from '@/models/continuity/ContinuityInPlace';
+import { DIRECTIONS, MARCH_TYPES } from '@/models/util/constants';
+import ContinuityEightToFiveDynamic, { EIGHT_TO_FIVE_DYNAMIC_TYPES } from '@/models/continuity/ContinuityEightToFiveDynamic';
+
+describe('models/util/load-show', () => {
+  let show: Show;
+  let showJson: string;
+
+  beforeEach(() => {
+    show = new Show();
+    show.stuntSheets = [new StuntSheet()];
+    show.stuntSheets[0].dotTypes = [[
+      new ContinuityInPlace(8, DIRECTIONS.E, MARCH_TYPES.MINI_MILITARY),
+      new ContinuityEightToFiveDynamic(EIGHT_TO_FIVE_DYNAMIC_TYPES.EWNS, MARCH_TYPES.HS)
+    ]];
+    show.stuntSheets[0].stuntSheetDots = [new StuntSheetDot(0, 0)];
+    showJson = JSON.stringify(show);
+  });
+
+  it('typeHelper returns an object with correct type', () => {
+    const field: Field = new Field();
+    const fieldJson: string = JSON.stringify(field);
+    const fieldParsedWithoutHelper: Object = JSON.parse(fieldJson);
+    expect(fieldParsedWithoutHelper instanceof Field).toBeFalsy();
+    const fieldParsed: Object = typeHelper(fieldParsedWithoutHelper, Field.prototype);
+    expect(fieldParsed instanceof Field).toBeTruthy();
+  });
+
+  it('typeArrayHelper returns an array with the correct type', () => {
+    const stuntSheetDots: StuntSheetDot[] = [new StuntSheetDot(0, 0), new StuntSheetDot(2, 2)];
+    const stuntSheetDotsJson: string = JSON.stringify(stuntSheetDots);
+    const parsedWithoutHelper: Object[] = JSON.parse(stuntSheetDotsJson);
+    expect(parsedWithoutHelper instanceof Array).toBeTruthy();
+    parsedWithoutHelper.forEach((dot: Object) => {
+      expect(dot instanceof StuntSheetDot).toBeFalsy();
+    });
+    const parsed = typeArrayHelper(parsedWithoutHelper, StuntSheetDot.prototype);
+    expect(parsed instanceof Array).toBeTruthy();
+    parsed.forEach((dot: Object) => {
+      expect(dot instanceof StuntSheetDot).toBeTruthy();
+    });
+  });
+
+  it('loads show from json string with correct types', () => {
+    const showParsed: Show = JSON.parse(showJson, showReviver);
+    expect(showParsed.field instanceof Field).toBeTruthy();
+    expect(showParsed.stuntSheets instanceof Array).toBeTruthy();
+    expect(showParsed.stuntSheets[0] instanceof StuntSheet).toBeTruthy();
+    expect(showParsed.stuntSheets[0].dotTypes instanceof Array).toBeTruthy();
+    expect(showParsed.stuntSheets[0].dotTypes[0] instanceof Array).toBeTruthy();
+    expect(showParsed.stuntSheets[0].dotTypes[0][0] instanceof ContinuityInPlace).toBeTruthy();
+    expect(showParsed.stuntSheets[0].dotTypes[0][1] instanceof ContinuityEightToFiveDynamic).toBeTruthy();
+    expect(showParsed.stuntSheets[0].stuntSheetDots instanceof Array).toBeTruthy();
+    expect(showParsed.stuntSheets[0].stuntSheetDots[0] instanceof StuntSheetDot).toBeTruthy();
+  });
+});

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   lintOnSave: process.env.NODE_ENV !== 'production',
+  publicPath: '',
   css: {
     loaderOptions: {
       scss: {


### PR DESCRIPTION
- Add all continuities in the Figma design document.
  - Implemented `ContinuityInPlace` and `ContinuityEightToFiveDynamic`.
  - The rest can be done in the future.
- Add show importing functionality in `load-show.ts`. This gives us assurance that we can save/load shows in the future.
- Can generate flows for dots with continuities.