### PR TITLE
Add/Remove a single dot tool and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ npm install
 
 Please use the LTS version of [NodeJS/npm](https://nodejs.org/en/) for this project.
 
-We recommend using [Visual Studio Code](https://code.visualstudio.com/) as your IDE. This integrates well with Typescript. We recommend installing the following extensions: ESLint, and Vetur.
+We recommend using [Visual Studio Code](https://code.visualstudio.com/) as your IDE. This integrates well with Typescript. We recommend installing the following extensions: ESLint, Vetur, Debugger for Chrome, Debugger for Firefox.
+
+To set up debugging in vscode, please see [Vue CLI docs](https://vuejs.org/v2/cookbook/debugging-in-vscode.html).
 
 ## Compiles and hot-reloads for development
 ```

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -4,7 +4,7 @@
       class="grapher--svg"
       data-test="grapher--svg"
       @click.prevent="onClick"
-      @mouseover.prevent="onMouseover"
+      @mousemove="onMousemove"
     >
       <g class="grapher--wrapper">
         <!-- Note:Inside svg, 1px = 1 eight-to-five step -->
@@ -235,18 +235,22 @@ export default Vue.extend({
     });
     this.$store.commit('setGrapherSvgPanZoom', svgPanZoomInstance);
 
-    window.addEventListener('resize', function() {
-      svgPanZoomInstance.resize();
-    });
+    window.addEventListener('resize', this.onResize);
+  },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.onResize);
   },
   methods: {
+    onResize(): void {
+      this.$store.state.grapherSvgPanZoom.resize();
+    },
     onClick(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
       toolSelected.onClick(event, this.$store);
     },
-    onMouseover(event: MouseEvent): void {
+    onMousemove(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
-      toolSelected.onMouseover(event, this.$store);
+      toolSelected.onMousemove(event, this.$store);
     },
   },
 });

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -73,8 +73,8 @@
           <!-- Bottom of the yard line numbers is approximately 11 steps from
               the sideline -->
           <text
-            v-for="(numberAndOffsetX, index) in yardLineNumberAndOffsetX"
-            :key="index + '-yardNum'"
+            v-for="numberAndOffsetX in yardLineNumberAndOffsetX"
+            :key="`${numberAndOffsetX}-yardNum`"
             :x="numberAndOffsetX[1]"
             :y="fieldHeight - 11"
             data-test="grapher--yard-number"
@@ -82,8 +82,8 @@
             {{ numberAndOffsetX[0] }}
           </text>
           <text
-            v-for="(numberAndOffsetX, index) in yardLineNumberAndOffsetX"
-            :key="index + '-yardNumRotated'"
+            v-for="numberAndOffsetX in yardLineNumberAndOffsetX"
+            :key="`${numberAndOffsetX[1]}-yardNumRotated`"
             :x="numberAndOffsetX[1]"
             :y="11"
             :transform="'rotate(180 ' + numberAndOffsetX[1] + ' 11)'"
@@ -94,21 +94,21 @@
         </g>
         <g class="grapher--dots-container">
           <circle
-            v-for="(dot, index) in stuntSheetDots"
-            :key="index + '-dot'"
+            v-for="dot in stuntSheetDots"
+            :key="`${dot.x}-${dot.y}-tool-dot`"
             :cx="dot.x"
             :cy="dot.y"
-            r="0.8"
+            r="0.7"
             data-test="grapher--dot"
           />
         </g>
         <g class="grapher--tool-dots-container">
           <circle
-            v-for="(dot, index) in grapherToolDots"
-            :key="index + '-dot'"
+            v-for="dot in grapherToolDots"
+            :key="`${dot.x}-${dot.y}-tool-dot`"
             :cx="dot.x"
             :cy="dot.y"
-            r="0.8"
+            r="0.7"
             data-test="grapher--tool-dot"
             :style="{ opacity: '0.5' }"
           />
@@ -122,8 +122,8 @@
 import Vue from 'vue';
 import svgPanZoom from 'svg-pan-zoom';
 import BaseTool from '@/tools/BaseTool';
-import StuntSheetDot from '../../models/StuntSheetDot';
-import StuntSheet from '../../models/StuntSheet';
+import StuntSheetDot from '@/models/StuntSheetDot';
+import StuntSheet from '@/models/StuntSheet';
 
 /**
  * Renders the field, the dots of the current stunt sheet, and pending dots

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -2,7 +2,9 @@
   <div class="grapher">
     <svg
       class="grapher--svg"
+      data-test="grapher--svg"
       @click.prevent="onClick"
+      @mouseover.prevent="onMouseover"
     >
       <g class="grapher--wrapper">
         <!-- Note:Inside svg, 1px = 1 eight-to-five step -->
@@ -100,6 +102,17 @@
             data-test="grapher--dot"
           />
         </g>
+        <g class="grapher--tool-dots-container">
+          <circle
+            v-for="(dot, index) in grapherToolDots"
+            :key="index + '-dot'"
+            :cx="dot.x"
+            :cy="dot.y"
+            r="0.8"
+            data-test="grapher--tool-dot"
+            :style="{ opacity: '0.5' }"
+          />
+        </g>
       </g>
     </svg>
   </div>
@@ -112,6 +125,10 @@ import BaseTool from '@/tools/BaseTool';
 import StuntSheetDot from '../../models/StuntSheetDot';
 import StuntSheet from '../../models/StuntSheet';
 
+/**
+ * Renders the field, the dots of the current stunt sheet, and pending dots
+ * generated from the tool in use
+ */
 export default Vue.extend({
   name: 'Grapher',
   computed: {
@@ -204,6 +221,9 @@ export default Vue.extend({
         = this.$store.getters.getSelectedStuntSheet;
       return currentSS.stuntSheetDots;
     },
+    grapherToolDots(): StuntSheetDot[] {
+      return this.$store.state.grapherToolDots;
+    },
   },
   mounted() {
     const svgPanZoomInstance = svgPanZoom('.grapher--svg', {
@@ -223,6 +243,10 @@ export default Vue.extend({
     onClick(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
       toolSelected.onClick(event, this.$store);
+    },
+    onMouseover(event: MouseEvent): void {
+      const toolSelected: BaseTool = this.$store.state.toolSelected;
+      toolSelected.onMouseover(event, this.$store);
     },
   },
 });

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -74,7 +74,7 @@
               the sideline -->
           <text
             v-for="numberAndOffsetX in yardLineNumberAndOffsetX"
-            :key="`${numberAndOffsetX}-yardNum`"
+            :key="`${numberAndOffsetX[1]}-yardNum`"
             :x="numberAndOffsetX[1]"
             :y="fieldHeight - 11"
             data-test="grapher--yard-number"
@@ -95,7 +95,8 @@
         <g class="grapher--dots-container">
           <circle
             v-for="dot in stuntSheetDots"
-            :key="`${dot.x}-${dot.y}-tool-dot`"
+            :key="`${dot.x}-${dot.y}-dot`"
+            class="grapher--dot"
             :cx="dot.x"
             :cy="dot.y"
             r="0.7"
@@ -106,11 +107,11 @@
           <circle
             v-for="dot in grapherToolDots"
             :key="`${dot.x}-${dot.y}-tool-dot`"
+            class="grapher--dot grapher--tool-dot"
             :cx="dot.x"
             :cy="dot.y"
             r="0.7"
             data-test="grapher--tool-dot"
-            :style="{ opacity: '0.5' }"
           />
         </g>
       </g>
@@ -246,11 +247,11 @@ export default Vue.extend({
     },
     onClick(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
-      toolSelected.onClick(event, this.$store);
+      toolSelected.onClick(event);
     },
     onMousemove(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
-      toolSelected.onMousemove(event, this.$store);
+      toolSelected.onMousemove(event);
     },
   },
 });
@@ -291,6 +292,12 @@ export default Vue.extend({
   fill: $white;
   font-size: 4px;
   text-anchor: middle;
+}
+
+.grapher--dot {
+  &.grapher--tool-dot {
+    opacity: 0.5;
+  }
 }
 
 </style>

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="grapher">
-    <svg class="grapher-svg">
-      <g>
+    <svg
+      class="grapher--svg"
+      @click.prevent="onClick"
+    >
+      <g class="grapher--wrapper">
         <!-- Note:Inside svg, 1px = 1 eight-to-five step -->
         <rect
           class="grapher--field-rect"
@@ -87,6 +90,16 @@
             {{ numberAndOffsetX[0] }}
           </text>
         </g>
+        <g class="grapher--dots-container">
+          <circle
+            v-for="(dot, index) in stuntSheetDots"
+            :key="index + '-dot'"
+            :cx="dot.x"
+            :cy="dot.y"
+            r="0.8"
+            data-test="grapher--dot"
+          />
+        </g>
       </g>
     </svg>
   </div>
@@ -95,6 +108,9 @@
 <script lang="ts">
 import Vue from 'vue';
 import svgPanZoom from 'svg-pan-zoom';
+import BaseTool from '@/tools/BaseTool';
+import StuntSheetDot from '../../models/StuntSheetDot';
+import StuntSheet from '../../models/StuntSheet';
 
 export default Vue.extend({
   name: 'Grapher',
@@ -183,12 +199,31 @@ export default Vue.extend({
       }
       return retVal;
     },
+    stuntSheetDots(): StuntSheetDot[] {
+      const currentSS: StuntSheet
+        = this.$store.getters.getSelectedStuntSheet;
+      return currentSS.stuntSheetDots;
+    },
   },
-  mounted: () => {
-    svgPanZoom('.grapher-svg', {
+  mounted() {
+    const svgPanZoomInstance = svgPanZoom('.grapher--svg', {
+      viewportSelector: '.grapher--wrapper',
+      panEnabled: true,
+      zoomEnabled: true,
       controlIconsEnabled: true,
       dblClickZoomEnabled: false,
     });
+    this.$store.commit('setGrapherSvgPanZoom', svgPanZoomInstance);
+
+    window.addEventListener('resize', function() {
+      svgPanZoomInstance.resize();
+    });
+  },
+  methods: {
+    onClick(event: MouseEvent): void {
+      const toolSelected: BaseTool = this.$store.state.toolSelected;
+      toolSelected.onClick(event, this.$store);
+    },
   },
 });
 </script>
@@ -200,7 +235,7 @@ export default Vue.extend({
   position: relative;
 }
 
-.grapher-svg {
+.grapher--svg {
   width: 100%;
   height: 100%;
   // See PR#9

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -218,8 +218,7 @@ export default Vue.extend({
       return retVal;
     },
     stuntSheetDots(): StuntSheetDot[] {
-      const currentSS: StuntSheet
-        = this.$store.getters.getSelectedStuntSheet;
+      const currentSS: StuntSheet = this.$store.getters.getSelectedStuntSheet;
       return currentSS.stuntSheetDots;
     },
     grapherToolDots(): StuntSheetDot[] {

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -60,6 +60,19 @@ export default Vue.extend({
   }),
   watch: {
     toolSelectedIndex(newIndex: number, oldIndex: number) {
+      /**
+       * Calculate inverted CTM matrix that is used to convert ClientX/Y to
+       * X/Y of the SVG
+       */
+      const wrapper = document
+        .getElementsByClassName('grapher--wrapper')[0] as SVGGElement;
+      const ctm = wrapper.getScreenCTM();
+      if (!ctm) {
+        throw 'Unable to retrieve wrapper CTM';
+      }
+      const invertedMatrix = ctm.inverse();
+      this.$store.commit('setInvertedCTMMatrix', invertedMatrix);
+
       // Enable or disable pan/zoom depending on tool selected
       const grapherSvgPanZoom: SvgPanZoom.Instance | undefined
         = this.$store.state.grapherSvgPanZoom;
@@ -75,19 +88,6 @@ export default Vue.extend({
         grapherSvgPanZoom.disablePan();
         grapherSvgPanZoom.disableZoom();
         grapherSvgPanZoom.disableControlIcons();
-
-        /**
-         * Calculate inverted CTM matrix that is used to convert ClientX/Y to
-         * X/Y of the SVG
-         */
-        const wrapper = document
-          .getElementsByClassName('grapher--wrapper')[0] as SVGGElement;
-        const ctm = wrapper.getScreenCTM();
-        if (!ctm) {
-          throw 'Unable to retrieve wrapper CTM';
-        }
-        const invertedMatrix = ctm.inverse();
-        this.$store.commit('setInvertedCTMMatrix', invertedMatrix);
       }
     },
   },
@@ -106,8 +106,7 @@ export default Vue.extend({
       this.$data.toolSelectedIndex = toolIndex;
       const ToolConstructor: ToolConstructor
         = this.$data.toolDataList[toolIndex].tool;
-      const tool: BaseTool
-        = new ToolConstructor(this.$store);
+      const tool: BaseTool = new ToolConstructor();
       this.$store.commit('setToolSelected', tool);
     },
     isCtrl(event: KeyboardEvent): boolean {

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -1,19 +1,102 @@
 <template>
   <div class="menu-bottom">
-    <h3>Menu bottom</h3>
+    <div class="buttons">
+      <b-tooltip
+        v-for="(toolData, index) in toolDataList"
+        :key="index + 'toolData'"
+        :label="toolData.label"
+        :delay="500"
+      >
+        <b-button
+          :type="toolSelectedIndex === index ? 'is-primary' : 'is-light'"
+          :icon-left="toolData.icon"
+          data-test="menu-bottom--tool-button"
+          @click="setTool(index)"
+        />
+      </b-tooltip>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import BaseTool, { ToolConstructor } from '@/tools/BaseTool';
+import ToolPanZoom from '../../tools/ToolPanZoom';
+import ToolSingleDot from '../../tools/ToolSingleDot';
+
+interface ToolData {
+  label: string;
+  icon: string;
+  tool: ToolConstructor;
+}
 
 export default Vue.extend({
   name: 'MenuBottom',
+  data: (): {
+    toolDataList: ToolData[];
+    toolSelectedIndex: number;
+  } => ({
+    toolDataList: [
+      {
+        label: 'Pan and Zoom',
+        icon: 'hand-right',
+        tool: ToolPanZoom,
+      },
+      {
+        label: 'Add and Remove Single Dot',
+        icon: 'plus-minus',
+        tool: ToolSingleDot,
+      },
+    ],
+    toolSelectedIndex: 0, // Assume that 0 is the pan/zoom tool
+  }),
+  watch: {
+    toolSelectedIndex(newIndex: number, oldIndex: number) {
+      // Enable or disable pan/zoom depending on tool selected
+      const grapherSvgPanZoom: SvgPanZoom.Instance | undefined
+        = this.$store.state.grapherSvgPanZoom;
+      if (grapherSvgPanZoom === undefined) {
+        return;
+      }
+
+      if (newIndex === 0 && oldIndex !== 0) {
+        grapherSvgPanZoom.enablePan();
+        grapherSvgPanZoom.enableZoom();
+        grapherSvgPanZoom.enableControlIcons();
+      } else if (oldIndex === 0 && newIndex !== 0) {
+        grapherSvgPanZoom.disablePan();
+        grapherSvgPanZoom.disableZoom();
+        grapherSvgPanZoom.disableControlIcons();
+
+        // Calculate inverted CTM matrix that is used to convert ClientX/Y to
+        // X/Y of the SVG
+        const wrapper = document
+          .getElementsByClassName('grapher--wrapper')[0] as SVGGElement;
+        const ctm = wrapper.getScreenCTM();
+        if (!ctm) {
+          throw 'Unable to retrieve wrapper CTM';
+        }
+        const invertedMatrix = ctm.inverse();
+        this.$store.commit('setInvertedCTMMatrix', invertedMatrix);
+      }
+    },
+  },
+  mounted () {
+    this.setTool(this.$data.toolSelectedIndex);
+  },
+  methods: {
+    setTool(toolIndex: number): void {
+      this.$data.toolSelectedIndex = toolIndex;
+      const ToolConstructor: ToolConstructor
+        = this.$data.toolDataList[toolIndex].tool;
+      const tool: BaseTool
+        = new ToolConstructor(this.$store);
+      this.$store.commit('setToolSelected', tool);
+    },
+  },
 });
 </script>
 
 <style scoped lang="scss">
-.menu-bottom {
-  flex: 0 0 35px;
-}
+
 </style>

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -77,7 +77,7 @@ export default Vue.extend({
       const grapherSvgPanZoom: SvgPanZoom.Instance | undefined
         = this.$store.state.grapherSvgPanZoom;
       if (grapherSvgPanZoom === undefined) {
-        return;
+        throw 'There is no grapher pan zoom instance';
       }
 
       if (newIndex === 0 && oldIndex !== 0) {

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -3,14 +3,14 @@
     <div class="buttons">
       <b-tooltip
         v-for="(toolData, index) in toolDataList"
-        :key="index + 'toolData'"
+        :key="`${toolData.icon}-toolData`"
         :label="toolData.label"
-        :delay="500"
+        data-test="menu-bottom--tooltip"
       >
         <b-button
           :type="toolSelectedIndex === index ? 'is-primary' : 'is-light'"
           :icon-left="toolData.icon"
-          data-test="menu-bottom--tool-button"
+          :data-test="`menu-bottom-tool--${toolData['data-test']}`"
           @click="setTool(index)"
         />
       </b-tooltip>
@@ -24,13 +24,14 @@
  */
 import Vue from 'vue';
 import BaseTool, { ToolConstructor } from '@/tools/BaseTool';
-import ToolPanZoom from '../../tools/ToolPanZoom';
-import ToolSingleDot from '../../tools/ToolSingleDot';
+import ToolPanZoom from '@/tools/ToolPanZoom';
+import ToolSingleDot from '@/tools/ToolSingleDot';
 
 interface ToolData {
   label: string;
   icon: string;
   tool: ToolConstructor;
+  'data-test': string;
 }
 
 export default Vue.extend({
@@ -42,14 +43,16 @@ export default Vue.extend({
   } => ({
     toolDataList: [
       {
-        label: 'Pan and Zoom (Hold Ctrl/Meta to toggle)',
+        label: 'Pan and Zoom (Hold Ctrl/Meta to turn on)',
         icon: 'hand-right',
         tool: ToolPanZoom,
+        'data-test': 'pan-zoom',
       },
       {
         label: 'Add and Remove Single Dot',
         icon: 'plus-minus',
         tool: ToolSingleDot,
+        'data-test': 'add-rm',
       },
     ],
     toolSelectedIndex: 0, // Assume that 0 is the pan/zoom tool
@@ -73,8 +76,10 @@ export default Vue.extend({
         grapherSvgPanZoom.disableZoom();
         grapherSvgPanZoom.disableControlIcons();
 
-        // Calculate inverted CTM matrix that is used to convert ClientX/Y to
-        // X/Y of the SVG
+        /**
+         * Calculate inverted CTM matrix that is used to convert ClientX/Y to
+         * X/Y of the SVG
+         */
         const wrapper = document
           .getElementsByClassName('grapher--wrapper')[0] as SVGGElement;
         const ctm = wrapper.getScreenCTM();
@@ -86,13 +91,13 @@ export default Vue.extend({
       }
     },
   },
-  mounted () {
+  mounted() {
     this.setTool(this.$data.toolSelectedIndex);
 
     document.addEventListener('keydown', this.onKeyDown);
     document.addEventListener('keyup', this.onKeyUp);
   },
-  beforeDestroy () {
+  beforeDestroy() {
     document.removeEventListener('keydown', this.onKeyDown);
     document.removeEventListener('keyup', this.onKeyUp);
   },

--- a/src/components/menu-top/FileModal.vue
+++ b/src/components/menu-top/FileModal.vue
@@ -61,6 +61,9 @@
 <script lang="ts">
 import Vue from 'vue';
 
+/**
+ * Show and modify values in the current Show model
+ */
 export default Vue.extend({
   name: 'FileModal',
   computed: {

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -91,6 +91,9 @@ import Vue from 'vue';
 import FileModal from './FileModal.vue';
 import LoadModal from './LoadModal.vue';
 
+/**
+ * Contains menus and options that control the application's state
+ */
 export default Vue.extend({
   name: 'MenuTop',
   components: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,12 @@ Vue.config.productionTip = false;
 
 Vue.use(Buefy);
 
-new Vue({
+const app = new Vue({
   store,
   render: h => h(App),
 }).$mount('#app');
+
+if ((window as any).Cypress) {
+  // Make Vue instance accesible to Cypress tests
+  (window as any).app = app;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,13 @@
 import Vue from 'vue';
 import Buefy from 'buefy';
 import App from './App.vue';
-import store from './store';
+import { GlobalStore } from './store';
 
 Vue.config.productionTip = false;
 
 Vue.use(Buefy);
 
-const app = new Vue({
-  store,
+new Vue({
+  store: GlobalStore,
   render: h => h(App),
 }).$mount('#app');
-
-if ((window as any).Cypress) {
-  // Make Vue instance accesible to Cypress tests
-  (window as any).app = app;
-}

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -40,4 +40,12 @@ export default class StuntSheet extends Serializable<StuntSheet> {
     }
     this.fromJson(json);
   }
+
+  addDot(dot: StuntSheetDot): void {
+    this.stuntSheetDots.push(dot);
+  }
+
+  removeDot(index: number): void {
+    this.stuntSheetDots.splice(index, 1);
+  }
 }

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,14 +1,22 @@
 import { CalChartState } from '.';
+import StuntSheet from '@/models/StuntSheet';
+import { GetterTree } from 'vuex';
 
-export default {
+const getters: GetterTree<CalChartState, CalChartState> = {
   // Show
-  getShowTitle: (state: CalChartState): string => state.show.title,
+  getShowTitle: (state): string => state.show.title,
 
   // Show -> Field
-  getFrontHashOffsetY: (state: CalChartState): number =>
+  getFrontHashOffsetY: (state): number =>
     state.show.field.frontHashOffsetY,
-  getBackHashOffsetY: (state: CalChartState): number =>
+  getBackHashOffsetY: (state): number =>
     state.show.field.backHashOffsetY,
-  getMiddleOfField: (state: CalChartState): number =>
+  getMiddleOfField: (state): number =>
     state.show.field.middleOfField,
+
+  // Show -> StuntSheet
+  getSelectedStuntSheet: (state): StuntSheet =>
+    state.show.stuntSheets[state.selectedSS],
 };
+
+export default getters;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import getters from './getters';
 import Show from '@/models/Show';
 import Serializable from '@/models/util/Serializable';
 import BaseTool from '@/tools/BaseTool';
+import StuntSheetDot from '@/models/StuntSheetDot';
 
 Vue.use(Vuex);
 
@@ -17,6 +18,7 @@ Vue.use(Vuex);
  * @property grapherSvgPanZoom - Initialized upon mounting Grapher
  * @property invertedCTMMatrix - Used to calculate clientX/Y to SVG X/Y
  * @property toolSelected      - See BaseTool
+ * @property grapherToolDots   - Helper dots to help visualize tools
  */
 export class CalChartState extends Serializable<CalChartState> {
   show: Show = new Show();
@@ -32,6 +34,8 @@ export class CalChartState extends Serializable<CalChartState> {
   invertedCTMMatrix?: DOMMatrix;
 
   toolSelected?: BaseTool;
+
+  grapherToolDots: StuntSheetDot[] = [];
 
   constructor(json: Partial<CalChartState> = {}) {
     super();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,21 +4,34 @@ import mutations from './mutations';
 import getters from './getters';
 import Show from '@/models/Show';
 import Serializable from '@/models/util/Serializable';
+import BaseTool from '@/tools/BaseTool';
 
 Vue.use(Vuex);
 
 /**
  * Defines the global state for the application
  *
- * @property show         - The currently selected show data
- * @property fourStepGrid - View setting to toggle the grapher grid
+ * @property show              - The currently selected show data
+ * @property selectedSS        - Index of stuntsheet currently in view
+ * @property fourStepGrid      - View setting to toggle the grapher grid
+ * @property grapherSvgPanZoom - Initialized upon mounting Grapher
+ * @property invertedCTMMatrix - Used to calculate clientX/Y to SVG X/Y
+ * @property toolSelected      - See BaseTool
  */
 export class CalChartState extends Serializable<CalChartState> {
   show: Show = new Show();
 
+  selectedSS: number = 0;
+
   fourStepGrid: boolean = true;
   yardlines: boolean = true;
   yardlineNumbers: boolean = true;
+
+  grapherSvgPanZoom?: SvgPanZoom.Instance;
+
+  invertedCTMMatrix?: DOMMatrix;
+
+  toolSelected?: BaseTool;
 
   constructor(json: Partial<CalChartState> = {}) {
     super();

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -50,4 +50,4 @@ export const generateStore
   getters,
 });
 
-export default generateStore();
+export const GlobalStore = generateStore();

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -57,6 +57,10 @@ const mutations: MutationTree<CalChartState> = {
   },
   setToolSelected(state, toolSelected: BaseTool): void {
     state.toolSelected = toolSelected;
+    state.grapherToolDots = [];
+  },
+  setGrapherToolDots(state, grapherToolDots: StuntSheetDot[]): void {
+    state.grapherToolDots = grapherToolDots;
   },
 };
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,40 +1,63 @@
 import { CalChartState } from '.';
 import Show from '@/models/Show';
+import getters from './getters';
+import BaseTool from '@/tools/BaseTool';
+import StuntSheetDot from '@/models/StuntSheetDot';
+import { MutationTree } from 'vuex';
 
-/**
- * To access the class methods of any property in state, initialize it again.
- * See Serializable.
- */
-
-export default {
+const mutations: MutationTree<CalChartState> = {
   // Show
-  setShow(state: CalChartState, show: Show): void {
+  setShow(state, show: Show): void {
     state.show = show;
   },
-
-  setShowTitle(state: CalChartState, title: string): void {
+  setShowTitle(state, title: string): void {
     state.show.title = title;
   },
 
   // Show -> Field
-  setFrontHashOffsetY(state: CalChartState, offsetY: number): void {
+  setFrontHashOffsetY(state, offsetY: number): void {
     state.show.field.frontHashOffsetY = offsetY;
   },
-  setBackHashOffsetY(state: CalChartState, offsetY: number): void {
+  setBackHashOffsetY(state, offsetY: number): void {
     state.show.field.backHashOffsetY = offsetY;
   },
-  setMiddleOfField(state: CalChartState, middle: number): void {
+  setMiddleOfField(state, middle: number): void {
     state.show.field.middleOfField = middle;
   },
 
+  // Show -> StuntSheet
+  removeDot(state, dotIndex: number): void {
+    const getSelectedStuntSheet: Function = getters.getSelectedStuntSheet;
+    const currentSS = getSelectedStuntSheet(state);
+    currentSS.removeDot(dotIndex);
+  },
+  addDot(state, dot: StuntSheetDot): void {
+    const getSelectedStuntSheet: Function = getters.getSelectedStuntSheet;
+    const currentSS = getSelectedStuntSheet(state);
+    currentSS.addDot(dot);
+  },
+
   // View Settings
-  setFourStepGrid(state: CalChartState, enabled: boolean): void {
+  setFourStepGrid(state, enabled: boolean): void {
     state.fourStepGrid = enabled;
   },
-  setYardlines(state: CalChartState, enabled: boolean): void {
+  setYardlines(state, enabled: boolean): void {
     state.yardlines = enabled;
   },
-  setYardlineNumbers(state: CalChartState, enabled: boolean): void {
+  setYardlineNumbers(state, enabled: boolean): void {
     state.yardlineNumbers = enabled;
   },
+
+  // Tools
+  setGrapherSvgPanZoom(state, svgPanZoomInstance: SvgPanZoom.Instance): void {
+    state.grapherSvgPanZoom = svgPanZoomInstance;
+  },
+  setInvertedCTMMatrix(state, matrix: DOMMatrix): void {
+    state.invertedCTMMatrix = matrix;
+  },
+  setToolSelected(state, toolSelected: BaseTool): void {
+    state.toolSelected = toolSelected;
+  },
 };
+
+export default mutations;

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -49,7 +49,7 @@ export default abstract class BaseTool {
   onClick(event: MouseEvent, store: Store<CalChartState>): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onMouseover(event: MouseEvent, store: Store<CalChartState>): void {}
+  onMousemove(event: MouseEvent, store: Store<CalChartState>): void {}
 }
 
 export interface ToolConstructor {

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -1,0 +1,54 @@
+import { CalChartState } from '@/store';
+import { Store } from 'vuex';
+
+/* eslint-disable max-len */
+/**
+ * Defines the functionality of a tool to be used in the Bottom Menu.
+ * Methods are event handlers for the svg in Grapher.
+ *
+ * For the conversion of clientX/Y to svg x/y, see the following resources:
+ * - https://css-tricks.com/creating-a-panning-effect-for-svg/#conclusion
+ * - https://www.sitepoint.com/how-to-translate-from-dom-to-svg-coordinates-and-back-again/
+ */
+/* eslint-enable max-len */
+export default abstract class BaseTool {
+  /**
+   * Approximates coordinate on the two step grid
+   *
+   * @param coordinate - Either the x or y coordinate
+   */
+  static roundCoordinateToGrid(coordinate: number): number {
+    return Math.round(coordinate / 2) * 2;
+  }
+
+  /**
+   * Convert clientX/Y to the X/Y coordinates on the SVG rectangle.
+   **/
+  static convertClientCoordinates(
+    event: MouseEvent,
+    store: Store<CalChartState>
+  ): [number, number] {
+    const svg = document.getElementsByTagName('svg')[0];
+    const point = svg.createSVGPoint();
+    point.x = event.clientX;
+    point.y = event.clientY;
+
+    const invertedCTMMatrix = store.state.invertedCTMMatrix;
+    if (invertedCTMMatrix === undefined) {
+      throw 'No inverted ctm matrix';
+    }
+    const convertedPoint = point.matrixTransform(invertedCTMMatrix);
+
+    return [
+      BaseTool.roundCoordinateToGrid(convertedPoint.x),
+      BaseTool.roundCoordinateToGrid(convertedPoint.y),
+    ];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onClick(event: MouseEvent, store: Store<CalChartState>): void {}
+}
+
+export interface ToolConstructor {
+  new (store: Store<CalChartState>): BaseTool;
+}

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -24,7 +24,8 @@ export default abstract class BaseTool {
    * Convert clientX/Y to the X/Y coordinates on the SVG rectangle.
    **/
   static convertClientCoordinates(event: MouseEvent): [number, number] {
-    const svg = document.getElementsByTagName('svg')[0];
+    const svg = document
+      .getElementsByClassName('grapher--svg')[0] as SVGSVGElement;
     const point = svg.createSVGPoint();
     point.x = event.clientX;
     point.y = event.clientY;

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -47,6 +47,9 @@ export default abstract class BaseTool {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onClick(event: MouseEvent, store: Store<CalChartState>): void {}
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onMouseover(event: MouseEvent, store: Store<CalChartState>): void {}
 }
 
 export interface ToolConstructor {

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -1,5 +1,4 @@
-import { CalChartState } from '@/store';
-import { Store } from 'vuex';
+import { GlobalStore } from '@/store';
 
 /* eslint-disable max-len */
 /**
@@ -24,16 +23,13 @@ export default abstract class BaseTool {
   /**
    * Convert clientX/Y to the X/Y coordinates on the SVG rectangle.
    **/
-  static convertClientCoordinates(
-    event: MouseEvent,
-    store: Store<CalChartState>
-  ): [number, number] {
+  static convertClientCoordinates(event: MouseEvent): [number, number] {
     const svg = document.getElementsByTagName('svg')[0];
     const point = svg.createSVGPoint();
     point.x = event.clientX;
     point.y = event.clientY;
 
-    const invertedCTMMatrix = store.state.invertedCTMMatrix;
+    const invertedCTMMatrix = GlobalStore.state.invertedCTMMatrix;
     if (invertedCTMMatrix === undefined) {
       throw 'No inverted ctm matrix';
     }
@@ -46,12 +42,12 @@ export default abstract class BaseTool {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onClick(event: MouseEvent, store: Store<CalChartState>): void {}
+  onClick(event: MouseEvent): void {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onMousemove(event: MouseEvent, store: Store<CalChartState>): void {}
+  onMousemove(event: MouseEvent): void {}
 }
 
 export interface ToolConstructor {
-  new (store: Store<CalChartState>): BaseTool;
+  new (): BaseTool;
 }

--- a/src/tools/ToolPanZoom.ts
+++ b/src/tools/ToolPanZoom.ts
@@ -1,0 +1,10 @@
+import BaseTool, { ToolConstructor } from './BaseTool';
+
+/**
+ * Enables pan and zoom functionality in svgPanZoom.
+ */
+const ToolPanZoom: ToolConstructor = class ToolPanZoom extends BaseTool {
+
+};
+
+export default ToolPanZoom;

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -1,0 +1,26 @@
+import BaseTool, { ToolConstructor } from './BaseTool';
+import { Store } from 'vuex';
+import { CalChartState } from '@/store';
+import StuntSheetDot from '@/models/StuntSheetDot';
+import StuntSheet from '@/models/StuntSheet';
+
+/**
+ * Add or remove a single dot on click.
+ */
+const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
+  onClick(event: MouseEvent, store: Store<CalChartState>): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event, store);
+    const stuntSheet: StuntSheet = store.getters.getSelectedStuntSheet;
+    const existingDotIndex = stuntSheet.stuntSheetDots
+      .findIndex((dot: StuntSheetDot): boolean => {
+        return x === dot.x && y === dot.y;
+      });
+    if (existingDotIndex !== -1) {
+      store.commit('removeDot', existingDotIndex);
+    } else {
+      store.commit('addDot', new StuntSheetDot({ x, y }));
+    }
+  }
+};
+
+export default ToolSingleDot;

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -21,6 +21,11 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
       store.commit('addDot', new StuntSheetDot({ x, y }));
     }
   }
+
+  onMouseover(event: MouseEvent, store: Store<CalChartState>): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event, store);
+    store.commit('setGrapherToolDots', [new StuntSheetDot({ x, y })]);
+  }
 };
 
 export default ToolSingleDot;

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -22,7 +22,7 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
     }
   }
 
-  onMouseover(event: MouseEvent, store: Store<CalChartState>): void {
+  onMousemove(event: MouseEvent, store: Store<CalChartState>): void {
     const [x, y] = BaseTool.convertClientCoordinates(event, store);
     store.commit('setGrapherToolDots', [new StuntSheetDot({ x, y })]);
   }

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -1,6 +1,5 @@
 import BaseTool, { ToolConstructor } from './BaseTool';
-import { Store } from 'vuex';
-import { CalChartState } from '@/store';
+import { GlobalStore } from '@/store';
 import StuntSheetDot from '@/models/StuntSheetDot';
 import StuntSheet from '@/models/StuntSheet';
 
@@ -8,23 +7,23 @@ import StuntSheet from '@/models/StuntSheet';
  * Add or remove a single dot on click.
  */
 const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
-  onClick(event: MouseEvent, store: Store<CalChartState>): void {
-    const [x, y] = BaseTool.convertClientCoordinates(event, store);
-    const stuntSheet: StuntSheet = store.getters.getSelectedStuntSheet;
+  onClick(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event);
+    const stuntSheet: StuntSheet = GlobalStore.getters.getSelectedStuntSheet;
     const existingDotIndex = stuntSheet.stuntSheetDots
       .findIndex((dot: StuntSheetDot): boolean => {
         return x === dot.x && y === dot.y;
       });
     if (existingDotIndex !== -1) {
-      store.commit('removeDot', existingDotIndex);
+      GlobalStore.commit('removeDot', existingDotIndex);
     } else {
-      store.commit('addDot', new StuntSheetDot({ x, y }));
+      GlobalStore.commit('addDot', new StuntSheetDot({ x, y }));
     }
   }
 
-  onMousemove(event: MouseEvent, store: Store<CalChartState>): void {
-    const [x, y] = BaseTool.convertClientCoordinates(event, store);
-    store.commit('setGrapherToolDots', [new StuntSheetDot({ x, y })]);
+  onMousemove(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event);
+    GlobalStore.commit('setGrapherToolDots', [new StuntSheetDot({ x, y })]);
   }
 };
 

--- a/tests/e2e/specs/App.spec.js
+++ b/tests/e2e/specs/App.spec.js
@@ -12,12 +12,4 @@ describe('App.vue', () => {
     cy.get('#app')
       .find('.menu-bottom');
   });
-
-  it('window.app exists for e2e tests', () => {
-    cy.visit('/');
-
-    cy.window()
-      .its('app.$store')
-      .should('not.to.be.undefined');
-  });
 });

--- a/tests/e2e/specs/App.spec.js
+++ b/tests/e2e/specs/App.spec.js
@@ -12,4 +12,12 @@ describe('App.vue', () => {
     cy.get('#app')
       .find('.menu-bottom');
   });
+
+  it('window.app exists for e2e tests', () => {
+    cy.visit('/');
+
+    cy.window()
+      .its('app.$store')
+      .should('not.to.be.undefined');
+  });
 });

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -1,0 +1,50 @@
+describe('components/menu-bottom/MenuBottom', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('all buttons are rendered and pan/zoom is selected', () => {
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .should('have.length', 2);
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
+      .should('have.length', 1)
+      .find('.mdi-hand-right')
+      .should('exist');
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-light')
+      .should('have.length', 1);
+  });
+
+  it('clicking on add/remove single dot disables pan/zoom', () => {
+    cy.get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
+      .click();
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
+      .should('have.length', 1)
+      .find('.mdi-plus-minus')
+      .should('exist');
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-light')
+      .should('have.length', 1);
+
+    cy.get('#svg-pan-zoom-controls')
+      .should('not.be.visible');
+  });
+
+  it('clicking from and to pan/zoom enables pan/zoom', () => {
+    cy.get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
+      .click();
+
+    cy.get('[data-test="menu-bottom--tool-button"] .mdi-hand-right')
+      .click();
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
+      .should('have.length', 1)
+      .find('.mdi-hand-right')
+      .should('exist');
+
+    cy.get('#svg-pan-zoom-controls')
+      .should('be.visible');
+  });
+});

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -59,6 +59,21 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.get('#svg-pan-zoom-controls')
       .should('be.visible');
 
+    // Try panning (taken from ToolPanZoom.spec.js)
+    cy.get('[data-test="grapher--field-rect"]')
+      .then((field) => {
+        const oldX = field.get(0).getBoundingClientRect().x;
+        cy.mousedownGrapher(24, 2);
+        cy.mousemoveGrapher(8, 2);
+        cy.mouseupGrapher(8, 2);
+
+        cy.get('[data-test="grapher--field-rect"]')
+          .then((field) => {
+            cy.wrap(field.get(0).getBoundingClientRect().x);
+          })
+          .should('lessThan', oldX);
+      });
+
     // Upon keyup, the selected tool returns to add/remove single dot
     cy.document()
       .trigger('keyup', { key: 'Control' });

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -47,4 +47,42 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.get('#svg-pan-zoom-controls')
       .should('be.visible');
   });
+
+  it('control key enables pan/zoom', () => {
+    // Starting tool is add/remove single dot
+    cy.get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
+      .click();
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
+      .should('have.length', 1)
+      .find('.mdi-plus-minus')
+      .should('exist');
+
+    cy.get('#svg-pan-zoom-controls')
+      .should('not.be.visible');
+
+    // Upon keydown, the selected tool is pan/zoom
+    cy.document()
+      .trigger('keydown', { key: 'Control' });
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
+      .should('have.length', 1)
+      .find('.mdi-hand-right')
+      .should('exist');
+
+    cy.get('#svg-pan-zoom-controls')
+      .should('be.visible');
+
+    // Upon keyup, the selected tool returns to add/remove single dot
+    cy.document()
+      .trigger('keyup', { key: 'Control' });
+
+    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
+      .should('have.length', 1)
+      .find('.mdi-plus-minus')
+      .should('exist');
+
+    cy.get('#svg-pan-zoom-controls')
+      .should('not.be.visible');
+  });
 });

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -4,25 +4,23 @@ describe('components/menu-bottom/MenuBottom', () => {
   });
 
   it('all buttons are rendered and pan/zoom is selected', () => {
-    cy.get('[data-test="menu-bottom--tool-button"]')
+    cy.get('[data-test="menu-bottom--tooltip"]')
       .should('have.length', 2);
 
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(0)
+    cy.get('[data-test="menu-bottom-tool--pan-zoom"]')
       .should('have.class', 'is-primary');
 
-    cy.get('[data-test="menu-bottom--tool-button"].is-light')
+    cy.get('[data-test="menu-bottom--tooltip"] .is-light')
       .should('have.length', 1);
   });
 
   it('clicking on add/remove single dot disables pan/zoom', () => {
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(1)
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
       .should('not.have.class', 'is-primary')
       .click()
       .should('have.class', 'is-primary');
 
-    cy.get('[data-test="menu-bottom--tool-button"].is-light')
+    cy.get('[data-test="menu-bottom--tooltip"] .is-light')
       .should('have.length', 1);
 
     cy.get('#svg-pan-zoom-controls')
@@ -30,12 +28,10 @@ describe('components/menu-bottom/MenuBottom', () => {
   });
 
   it('clicking from and to pan/zoom enables pan/zoom', () => {
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(1)
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
       .click();
 
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(0)
+    cy.get('[data-test="menu-bottom-tool--pan-zoom"]')
       .should('not.have.class', 'is-primary')
       .click()
       .should('have.class', 'is-primary');
@@ -46,8 +42,7 @@ describe('components/menu-bottom/MenuBottom', () => {
 
   it('control key enables pan/zoom', () => {
     // Starting tool is add/remove single dot
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(1)
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
       .click()
       .should('have.class', 'is-primary');
 
@@ -58,8 +53,7 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.document()
       .trigger('keydown', { key: 'Control' });
 
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(0)
+    cy.get('[data-test="menu-bottom-tool--pan-zoom"]')
       .should('have.class', 'is-primary');
 
     cy.get('#svg-pan-zoom-controls')
@@ -69,8 +63,7 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.document()
       .trigger('keyup', { key: 'Control' });
 
-    cy.get('[data-test="menu-bottom--tool-button"]')
-      .eq(1)
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
       .should('have.class', 'is-primary');
 
     cy.get('#svg-pan-zoom-controls')

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -7,23 +7,20 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.get('[data-test="menu-bottom--tool-button"]')
       .should('have.length', 2);
 
-    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
-      .should('have.length', 1)
-      .find('.mdi-hand-right')
-      .should('exist');
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(0)
+      .should('have.class', 'is-primary');
 
     cy.get('[data-test="menu-bottom--tool-button"].is-light')
       .should('have.length', 1);
   });
 
   it('clicking on add/remove single dot disables pan/zoom', () => {
-    cy.get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
-      .click();
-
-    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
-      .should('have.length', 1)
-      .find('.mdi-plus-minus')
-      .should('exist');
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(1)
+      .should('not.have.class', 'is-primary')
+      .click()
+      .should('have.class', 'is-primary');
 
     cy.get('[data-test="menu-bottom--tool-button"].is-light')
       .should('have.length', 1);
@@ -33,16 +30,15 @@ describe('components/menu-bottom/MenuBottom', () => {
   });
 
   it('clicking from and to pan/zoom enables pan/zoom', () => {
-    cy.get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(1)
       .click();
 
-    cy.get('[data-test="menu-bottom--tool-button"] .mdi-hand-right')
-      .click();
-
-    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
-      .should('have.length', 1)
-      .find('.mdi-hand-right')
-      .should('exist');
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(0)
+      .should('not.have.class', 'is-primary')
+      .click()
+      .should('have.class', 'is-primary');
 
     cy.get('#svg-pan-zoom-controls')
       .should('be.visible');
@@ -50,13 +46,10 @@ describe('components/menu-bottom/MenuBottom', () => {
 
   it('control key enables pan/zoom', () => {
     // Starting tool is add/remove single dot
-    cy.get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
-      .click();
-
-    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
-      .should('have.length', 1)
-      .find('.mdi-plus-minus')
-      .should('exist');
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(1)
+      .click()
+      .should('have.class', 'is-primary');
 
     cy.get('#svg-pan-zoom-controls')
       .should('not.be.visible');
@@ -65,10 +58,9 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.document()
       .trigger('keydown', { key: 'Control' });
 
-    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
-      .should('have.length', 1)
-      .find('.mdi-hand-right')
-      .should('exist');
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(0)
+      .should('have.class', 'is-primary');
 
     cy.get('#svg-pan-zoom-controls')
       .should('be.visible');
@@ -77,10 +69,9 @@ describe('components/menu-bottom/MenuBottom', () => {
     cy.document()
       .trigger('keyup', { key: 'Control' });
 
-    cy.get('[data-test="menu-bottom--tool-button"].is-primary')
-      .should('have.length', 1)
-      .find('.mdi-plus-minus')
-      .should('exist');
+    cy.get('[data-test="menu-bottom--tool-button"]')
+      .eq(1)
+      .should('have.class', 'is-primary');
 
     cy.get('#svg-pan-zoom-controls')
       .should('not.be.visible');

--- a/tests/e2e/specs/tools/ToolPanZoom.spec.js
+++ b/tests/e2e/specs/tools/ToolPanZoom.spec.js
@@ -1,8 +1,40 @@
 describe('tools/ToolPanZoom', () => {
   beforeEach(() => {
     cy.visit('/')
-      .get('[data-test="menu-bottom--tool-button"] .mdi-hand-right')
+      .get('[data-test="menu-bottom-tool--pan-zoom"]')
       .click();
   });
 
+  it('zoom in using the control icons', () => {
+    cy.get('[data-test="grapher--field-rect"]')
+      .then((field) => {
+        const oldWidth = field.get(0).getBoundingClientRect().width;
+
+        cy.get('#svg-pan-zoom-zoom-in')
+          .click()
+          .click();
+
+        cy.get('[data-test="grapher--field-rect"]')
+          .then((field) => {
+            cy.wrap(field.get(0).getBoundingClientRect().width);
+          })
+          .should('greaterThan', oldWidth);
+      });
+  });
+
+  it('shift grapher to the left by panning', () => {
+    cy.get('[data-test="grapher--field-rect"]')
+      .then((field) => {
+        const oldX = field.get(0).getBoundingClientRect().x;
+        cy.mousedownGrapher(24, 2);
+        cy.mousemoveGrapher(8, 2);
+        cy.mouseupGrapher(8, 2);
+
+        cy.get('[data-test="grapher--field-rect"]')
+          .then((field) => {
+            cy.wrap(field.get(0).getBoundingClientRect().x);
+          })
+          .should('lessThan', oldX);
+      });
+  });
 });

--- a/tests/e2e/specs/tools/ToolPanZoom.spec.js
+++ b/tests/e2e/specs/tools/ToolPanZoom.spec.js
@@ -1,0 +1,8 @@
+describe('tools/ToolPanZoom', () => {
+  beforeEach(() => {
+    cy.visit('/')
+      .get('[data-test="menu-bottom--tool-button"] .mdi-hand-right')
+      .click();
+  });
+
+});

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -1,7 +1,7 @@
 describe('tools/ToolSingleDot', () => {
   beforeEach(() => {
     cy.visit('/')
-      .get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
+      .get('[data-test="menu-bottom-tool--add-rm"]')
       .click();
   });
 
@@ -20,6 +20,29 @@ describe('tools/ToolSingleDot', () => {
 
     cy.get('[data-test="grapher--dot"]')
       .should('not.exist');
+  });
+
+  it('After panning and zooming, adding a dot is still accurate', () => {
+    cy.get('[data-test="menu-bottom-tool--pan-zoom')
+      .click();
+
+    cy.get('#svg-pan-zoom-zoom-out')
+      .click()
+      .click();
+
+    cy.mousedownGrapher(8, 2);
+    cy.mousemoveGrapher(24, 2);
+    cy.mouseupGrapher(24, 2);
+
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+      .click();
+
+    cy.clickGrapher(12, 8);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should('have.length', 1)
+      .should('have.attr', 'cx', '12')
+      .should('have.attr', 'cy', '8');
   });
 
   it('clicking multiple dots', () => {

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -5,4 +5,48 @@ describe('tools/ToolSingleDot', () => {
       .click();
   });
 
+  it('clicking adds, then removes a dot', () => {
+    cy.get('[data-test="grapher--dot"]')
+      .should('not.exist');
+
+    cy.clickGrapher(12, 8);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should('have.length', 1)
+      .should('have.attr', 'cx', '12')
+      .should('have.attr', 'cy', '8');
+
+    cy.clickGrapher(12, 8);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should('not.exist');
+  });
+
+  it('clicking multiple dots', () => {
+    cy.get('[data-test="grapher--dot"]')
+      .should('not.exist');
+
+    cy.clickGrapher(2, 0);
+    cy.clickGrapher(2, 2);
+    cy.clickGrapher(2, 4);
+    cy.clickGrapher(2, 6);
+    cy.clickGrapher(2, 8);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should('have.length', 5)
+      .each((dot, index) => {
+        expect(dot).to.have.attr('cx', '2');
+        expect(dot).to.have.attr('cy', (index * 2).toString());
+      });
+
+    cy.clickGrapher(2, 0);
+    cy.clickGrapher(2, 8);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should('have.length', 3)
+      .each((dot, index) => {
+        expect(dot).to.have.attr('cx', '2');
+        expect(dot).to.have.attr('cy', ((index + 1) * 2).toString());
+      });
+  });
 });

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -1,0 +1,8 @@
+describe('tools/ToolSingleDot', () => {
+  beforeEach(() => {
+    cy.visit('/')
+      .get('[data-test="menu-bottom--tool-button"] .mdi-plus-minus')
+      .click();
+  });
+
+});

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -49,4 +49,23 @@ describe('tools/ToolSingleDot', () => {
         expect(dot).to.have.attr('cy', ((index + 1) * 2).toString());
       });
   });
+
+  it('mousemove sets tool dots', () => {
+    cy.get('[data-test="grapher--tool-dot"]')
+      .should('not.exist');
+
+    cy.mousemoveGrapher(4, 6);
+
+    cy.get('[data-test="grapher--tool-dot"]')
+      .should('have.length', 1)
+      .should('have.attr', 'cx', '4')
+      .should('have.attr', 'cy', '6');
+
+    cy.mousemoveGrapher(6, 8);
+
+    cy.get('[data-test="grapher--tool-dot"]')
+      .should('have.length', 1)
+      .should('have.attr', 'cx', '6')
+      .should('have.attr', 'cy', '8');
+  });
 });

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -58,8 +58,9 @@ describe('tools/ToolSingleDot', () => {
     cy.get('[data-test="grapher--dot"]')
       .should('have.length', 5)
       .each((dot, index) => {
-        expect(dot).to.have.attr('cx', '2');
-        expect(dot).to.have.attr('cy', (index * 2).toString());
+        cy.wrap(dot)
+          .should('have.attr', 'cx', '2')
+          .should('have.attr', 'cy', `${index * 2}`);
       });
 
     cy.clickGrapher(2, 0);
@@ -68,8 +69,9 @@ describe('tools/ToolSingleDot', () => {
     cy.get('[data-test="grapher--dot"]')
       .should('have.length', 3)
       .each((dot, index) => {
-        expect(dot).to.have.attr('cx', '2');
-        expect(dot).to.have.attr('cy', ((index + 1) * 2).toString());
+        cy.wrap(dot)
+          .should('have.attr', 'cx', '2')
+          .should('have.attr', 'cy', `${(index + 1) * 2}`);
       });
   });
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -82,3 +82,25 @@ Cypress.Commands.add('clickGrapher', (x, y) => {
         });
     });
 });
+
+/**
+ * Converts the field X/Y into the mousemove X/Y coordinates
+ */
+Cypress.Commands.add('mousemoveGrapher', (x, y) => {
+  return cy.get('.grapher--wrapper')
+    .then((wrapper) => {
+      const matrix = wrapper[0].getCTM();
+
+      return cy.get('[data-test="grapher--svg"]')
+        .then((svg) => {
+          const point = svg[0].createSVGPoint();
+          point.x = x;
+          point.y = y;
+
+          const convertedPoint = point.matrixTransform(matrix);
+
+          cy.get('[data-test="grapher--svg"]')
+            .trigger('mousemove', convertedPoint.x, convertedPoint.y);
+        });
+    });
+});

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -62,45 +62,51 @@
 // }
 
 /**
- * Converts the field X/Y into the click X/Y coordinates
+ * Helper command for mouse events on the grapher
  */
-Cypress.Commands.add('clickGrapher', (x, y) => {
+const grapherMouseCommand = (eventName, x, y) => {
   return cy.get('.grapher--wrapper')
     .then((wrapper) => {
-      const matrix = wrapper[0].getCTM();
+      const matrix = wrapper.get(0).getCTM();
 
       return cy.get('[data-test="grapher--svg"]')
         .then((svg) => {
-          const point = svg[0].createSVGPoint();
+          const point = svg.get(0).createSVGPoint();
           point.x = x;
           point.y = y;
 
           const convertedPoint = point.matrixTransform(matrix);
 
           cy.get('[data-test="grapher--svg"]')
-            .click(convertedPoint.x, convertedPoint.y);
+            .trigger(eventName, convertedPoint.x, convertedPoint.y);
         });
     });
+};
+
+/**
+ * Converts the field X/Y into the click X/Y coordinates
+ */
+Cypress.Commands.add('clickGrapher', (x, y) => {
+  return grapherMouseCommand('click', x, y);
 });
 
 /**
  * Converts the field X/Y into the mousemove X/Y coordinates
  */
 Cypress.Commands.add('mousemoveGrapher', (x, y) => {
-  return cy.get('.grapher--wrapper')
-    .then((wrapper) => {
-      const matrix = wrapper[0].getCTM();
+  return grapherMouseCommand('mousemove', x, y);
+});
 
-      return cy.get('[data-test="grapher--svg"]')
-        .then((svg) => {
-          const point = svg[0].createSVGPoint();
-          point.x = x;
-          point.y = y;
+/**
+ * Converts the field X/Y into the mousedown X/Y coordinates
+ */
+Cypress.Commands.add('mousedownGrapher', (x, y) => {
+  return grapherMouseCommand('mousedown', x, y);
+});
 
-          const convertedPoint = point.matrixTransform(matrix);
-
-          cy.get('[data-test="grapher--svg"]')
-            .trigger('mousemove', convertedPoint.x, convertedPoint.y);
-        });
-    });
+/**
+ * Converts the field X/Y into the mousedown X/Y coordinates
+ */
+Cypress.Commands.add('mouseupGrapher', (x, y) => {
+  return grapherMouseCommand('mouseup', x, y);
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -60,3 +60,25 @@
 //     }
 //     return new Uint8Array(a);
 // }
+
+/**
+ * Converts the field X/Y into the click X/Y coordinates
+ */
+Cypress.Commands.add('clickGrapher', (x, y) => {
+  return cy.get('.grapher--wrapper')
+    .then((wrapper) => {
+      const matrix = wrapper[0].getCTM();
+
+      return cy.get('[data-test="grapher--svg"]')
+        .then((svg) => {
+          const point = svg[0].createSVGPoint();
+          point.x = x;
+          point.y = y;
+
+          const convertedPoint = point.matrixTransform(matrix);
+
+          cy.get('[data-test="grapher--svg"]')
+            .click(convertedPoint.x, convertedPoint.y);
+        });
+    });
+});

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -84,29 +84,21 @@ const grapherMouseCommand = (eventName, x, y) => {
 };
 
 /**
- * Converts the field X/Y into the click X/Y coordinates
+ * Generate the commands:
+ *  - clickGrapher
+ *  - mousemoveGrapher
+ *  - mousedownGrapher
+ *  - mouseupGrapher
  */
-Cypress.Commands.add('clickGrapher', (x, y) => {
-  return grapherMouseCommand('click', x, y);
-});
+const grapherCommands = [
+  'click',
+  'mousemove',
+  'mousedown',
+  'mouseup',
+];
 
-/**
- * Converts the field X/Y into the mousemove X/Y coordinates
- */
-Cypress.Commands.add('mousemoveGrapher', (x, y) => {
-  return grapherMouseCommand('mousemove', x, y);
-});
-
-/**
- * Converts the field X/Y into the mousedown X/Y coordinates
- */
-Cypress.Commands.add('mousedownGrapher', (x, y) => {
-  return grapherMouseCommand('mousedown', x, y);
-});
-
-/**
- * Converts the field X/Y into the mousedown X/Y coordinates
- */
-Cypress.Commands.add('mouseupGrapher', (x, y) => {
-  return grapherMouseCommand('mouseup', x, y);
+grapherCommands.forEach(command => {
+  Cypress.Commands.add(`${command}Grapher`, (x, y) => {
+    return grapherMouseCommand(command, x, y);
+  });
 });

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -8,16 +8,19 @@ import Field from '@/models/Field';
 import svgPanZoom from 'svg-pan-zoom';
 import StuntSheet from '@/models/StuntSheet';
 import StuntSheetDot from '@/models/StuntSheetDot';
+import BaseTool from '@/tools/BaseTool';
 
 jest.mock('svg-pan-zoom', () => {
   return {
     __esModule: true,
-    default: jest.fn().mockReturnValue({}),
+    default: jest.fn().mockReturnValue({ resize: jest.fn() }),
   };
 });
 
 describe('components/grapher/Grapher.vue', () => {
   let localVue: VueConstructor<Vue>;
+  let store: Store<CalChartState>;
+  let wrapper: Wrapper<Vue>;
   beforeAll(() => {
     localVue = createLocalVue();
     localVue.use(Vuex);
@@ -37,8 +40,6 @@ describe('components/grapher/Grapher.vue', () => {
   });
 
   describe('small field', () => {
-    let store: Store<CalChartState>;
-    let wrapper: Wrapper<Vue>;
     beforeAll(() => {
       const field: Field = new Field({
         frontHashOffsetY: 8,
@@ -118,8 +119,6 @@ describe('components/grapher/Grapher.vue', () => {
   });
 
   describe('default field (college field)', () => {
-    let store: Store<CalChartState>;
-    let wrapper: Wrapper<Vue>;
     beforeAll(() => {
       store = generateStore();
       wrapper = mount(Grapher, {
@@ -261,6 +260,41 @@ describe('components/grapher/Grapher.vue', () => {
         expect(wrapper.findAll('[data-test="grapher--tool-dot"]'))
           .toHaveLength(1);
       });
+    });
+  });
+
+  describe('event listners', () => {
+    let mockTool: BaseTool;
+
+    beforeEach(() => {
+      mockTool = {
+        onClick: jest.fn(),
+        onMousemove: jest.fn(),
+      };
+      store = generateStore({ toolSelected: mockTool });
+      wrapper = mount(Grapher, {
+        store,
+        localVue,
+      });
+    });
+
+    it('window.resize', () => {
+      window.dispatchEvent(new UIEvent('resize'));
+      const grapherSvgPanZoom
+        = store.state.grapherSvgPanZoom as SvgPanZoom.Instance;
+      expect(grapherSvgPanZoom.resize).toHaveBeenCalled();
+    });
+
+    it('click', () => {
+      expect(mockTool.onClick).not.toHaveBeenCalled();
+      wrapper.find('[data-test="grapher--svg"]').trigger('click');
+      expect(mockTool.onClick).toHaveBeenCalled();
+    });
+
+    it('mousemove', () => {
+      expect(mockTool.onMousemove).not.toHaveBeenCalled();
+      wrapper.find('[data-test="grapher--svg"]').trigger('mousemove');
+      expect(mockTool.onMousemove).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -190,76 +190,53 @@ describe('components/grapher/Grapher.vue', () => {
       expect(wrapper.findAll('[data-test="grapher--grid-vertical"]'))
         .toHaveLength(47);
     });
+  });
 
-    describe('stuntSheetDots', () => {
-      it('does not render any dots if no dots exist', () => {
-        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeFalsy();
+  describe('stuntSheetDots', () => {
+    const generateShowWithDots = (
+      numDots: number,
+      numToolDots: number
+    ): void => {
+      const stuntSheetDots = [];
+      for (let i = 0; i < numDots; i++) {
+        stuntSheetDots.push(new StuntSheetDot({
+          x: i * 2,
+          y: i * 2,
+        }));
+      }
+
+      const grapherToolDots = [];
+      for (let j = 0; j < numToolDots; j++) {
+        grapherToolDots.push(new StuntSheetDot({
+          x: j * 2 + 2,
+          y: j * 2 + 2,
+        }));
+      }
+
+      store = generateStore({
+        show: new Show({
+          stuntSheets: [new StuntSheet({ stuntSheetDots })],
+        }),
+        grapherToolDots,
       });
-
-      const generateShowWithDots
-      = (numDots: number, numToolDots: number): void => {
-        const stuntSheetDots = [];
-        for (let i = 0; i < numDots; i++) {
-          stuntSheetDots.push(new StuntSheetDot({
-            x: i * 2,
-            y: i * 2,
-          }));
-        }
-
-        const grapherToolDots = [];
-        for (let j = 0; j < numToolDots; j++) {
-          grapherToolDots.push(new StuntSheetDot({
-            x: j * 2 + 2,
-            y: j * 2 + 2,
-          }));
-        }
-
-        store = generateStore({
-          show: new Show({
-            stuntSheets: [new StuntSheet({ stuntSheetDots })],
-          }),
-          grapherToolDots,
-        });
-        wrapper = mount(Grapher, {
-          store,
-          localVue,
-        });
-      };
-
-      it('renders 1 dot', () => {
-        generateShowWithDots(1, 0);
-        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeTruthy();
-        expect(wrapper.findAll('[data-test="grapher--dot"]')).toHaveLength(1);
-        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
-          .toBeFalsy();
+      wrapper = mount(Grapher, {
+        store,
+        localVue,
       });
+    };
 
-      it('renders 2 dots', () => {
-        generateShowWithDots(2, 0);
-        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeTruthy();
-        expect(wrapper.findAll('[data-test="grapher--dot"]')).toHaveLength(2);
-        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
-          .toBeFalsy();
-      });
-
-      it('renders 1 tool dots', () => {
-        generateShowWithDots(0, 1);
-        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeFalsy();
-        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
-          .toBeTruthy();
-        expect(wrapper.findAll('[data-test="grapher--tool-dot"]'))
-          .toHaveLength(1);
-      });
-
-      it('renders 1 dot and 1 tool dots', () => {
-        generateShowWithDots(1, 1);
-        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeTruthy();
-        expect(wrapper.findAll('[data-test="grapher--dot"]')).toHaveLength(1);
-        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
-          .toBeTruthy();
-        expect(wrapper.findAll('[data-test="grapher--tool-dot"]'))
-          .toHaveLength(1);
-      });
+    it.each([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+    ])('renders %i dots and %i tool dots', (numDots, numToolDots) => {
+      generateShowWithDots(numDots, numToolDots);
+      expect(wrapper.findAll('[data-test="grapher--dot"]'))
+        .toHaveLength(numDots);
+      expect(wrapper.findAll('[data-test="grapher--tool-dot"]'))
+        .toHaveLength(numToolDots);
     });
   });
 

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -197,7 +197,8 @@ describe('components/grapher/Grapher.vue', () => {
         expect(wrapper.contains('[data-test="grapher--dot"]')).toBeFalsy();
       });
 
-      const generateShowWithDots = (numDots: number): void => {
+      const generateShowWithDots
+      = (numDots: number, numToolDots: number): void => {
         const stuntSheetDots = [];
         for (let i = 0; i < numDots; i++) {
           stuntSheetDots.push(new StuntSheetDot({
@@ -205,10 +206,20 @@ describe('components/grapher/Grapher.vue', () => {
             y: i * 2,
           }));
         }
+
+        const grapherToolDots = [];
+        for (let j = 0; j < numToolDots; j++) {
+          grapherToolDots.push(new StuntSheetDot({
+            x: j * 2 + 2,
+            y: j * 2 + 2,
+          }));
+        }
+
         store = generateStore({
           show: new Show({
             stuntSheets: [new StuntSheet({ stuntSheetDots })],
           }),
+          grapherToolDots,
         });
         wrapper = mount(Grapher, {
           store,
@@ -216,16 +227,39 @@ describe('components/grapher/Grapher.vue', () => {
         });
       };
 
-      it('renders 1 dot if exists', () => {
-        generateShowWithDots(1);
+      it('renders 1 dot', () => {
+        generateShowWithDots(1, 0);
         expect(wrapper.contains('[data-test="grapher--dot"]')).toBeTruthy();
         expect(wrapper.findAll('[data-test="grapher--dot"]')).toHaveLength(1);
+        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
+          .toBeFalsy();
       });
 
-      it('renders 2 dots if exists', () => {
-        generateShowWithDots(2);
+      it('renders 2 dots', () => {
+        generateShowWithDots(2, 0);
         expect(wrapper.contains('[data-test="grapher--dot"]')).toBeTruthy();
         expect(wrapper.findAll('[data-test="grapher--dot"]')).toHaveLength(2);
+        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
+          .toBeFalsy();
+      });
+
+      it('renders 1 tool dots', () => {
+        generateShowWithDots(0, 1);
+        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeFalsy();
+        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
+          .toBeTruthy();
+        expect(wrapper.findAll('[data-test="grapher--tool-dot"]'))
+          .toHaveLength(1);
+      });
+
+      it('renders 1 dot and 1 tool dots', () => {
+        generateShowWithDots(1, 1);
+        expect(wrapper.contains('[data-test="grapher--dot"]')).toBeTruthy();
+        expect(wrapper.findAll('[data-test="grapher--dot"]')).toHaveLength(1);
+        expect(wrapper.contains('[data-test="grapher--tool-dot"]'))
+          .toBeTruthy();
+        expect(wrapper.findAll('[data-test="grapher--tool-dot"]'))
+          .toHaveLength(1);
       });
     });
   });

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -83,9 +83,9 @@ describe('components/menu-bottom/MenuBottom', () => {
     });
 
     it('renders the correct amount of tools', () => {
-      expect(menu.contains('[data-test="menu-bottom--tool-button"]'))
+      expect(menu.contains('[data-test="menu-bottom--tooltip"]'))
         .toBeTruthy();
-      expect(menu.findAll('[data-test="menu-bottom--tool-button"]'))
+      expect(menu.findAll('[data-test="menu-bottom--tooltip"]'))
         .toHaveLength(2);
     });
 
@@ -96,18 +96,15 @@ describe('components/menu-bottom/MenuBottom', () => {
       }
       expect(ToolPanZoom).toHaveBeenCalled();
       expect(store.state.toolSelected.constructor === ToolPanZoom).toBeTruthy();
-      const firstToolBtn = menu
-        .findAll('[data-test="menu-bottom--tool-button"]')
-        .at(0);
-      expect(firstToolBtn.props('type')).toBe('is-primary');
+      const panZoomBtn = menu
+        .find('[data-test="menu-bottom-tool--pan-zoom"]');
+      expect(panZoomBtn.exists()).toBeTruthy();
+      expect(panZoomBtn.props('type')).toBe('is-primary');
     });
 
-    it('unselected tools have type is-light', () => {
-      const toolBtns = menu.findAll('[data-test="menu-bottom--tool-button"]');
-      const lightToolBtns = toolBtns.filter((btn: Wrapper<Vue>) => {
-        return btn.props('type') === 'is-light';
-      });
-      expect(lightToolBtns).toHaveLength(1);
+    it('add/remove single dot has type is-light when it is unselected', () => {
+      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      expect(addRmBtn.props('type')).toBe('is-light');
     });
 
     it('clicking add/remove single dot disables panning/zooming and '
@@ -120,10 +117,8 @@ describe('components/menu-bottom/MenuBottom', () => {
       expect(getScreenCTMMock).not.toHaveBeenCalled();
       expect(getElementsByClassNameMock).not.toHaveBeenCalled();
 
-      const secondToolBtn = menu
-        .findAll('[data-test="menu-bottom--tool-button"]')
-        .at(1);
-      secondToolBtn.trigger('click');
+      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      addRmBtn.trigger('click');
 
       expect(ToolSingleDot).toHaveBeenCalled();
       expect(store.state.toolSelected).not.toBeUndefined();
@@ -132,7 +127,7 @@ describe('components/menu-bottom/MenuBottom', () => {
       }
       expect(store.state.toolSelected.constructor === ToolSingleDot)
         .toBeTruthy();
-      expect(secondToolBtn.props('type')).toBe('is-primary');
+      expect(addRmBtn.props('type')).toBe('is-primary');
       expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
       expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
       expect(grapherSvgPanZoom.disableControlIcons).toHaveBeenCalled();
@@ -142,10 +137,9 @@ describe('components/menu-bottom/MenuBottom', () => {
     });
 
     it('pan and zoom is no longer selected', () => {
-      const firstToolBtn = menu
-        .findAll('[data-test="menu-bottom--tool-button"]')
-        .at(0);
-      expect(firstToolBtn.props('type')).toBe('is-light');
+      const panZoomBtn = menu
+        .find('[data-test="menu-bottom-tool--pan-zoom"]');
+      expect(panZoomBtn.props('type')).toBe('is-light');
     });
 
     it('clicking pan and zoom enables panning/zooming', () => {
@@ -153,10 +147,9 @@ describe('components/menu-bottom/MenuBottom', () => {
       expect(grapherSvgPanZoom.enableZoom).not.toHaveBeenCalled();
       expect(grapherSvgPanZoom.enableControlIcons).not.toHaveBeenCalled();
 
-      const firstToolBtn = menu
-        .findAll('[data-test="menu-bottom--tool-button"]')
-        .at(0);
-      firstToolBtn.trigger('click');
+      const panZoomBtn = menu
+        .find('[data-test="menu-bottom-tool--pan-zoom"]');
+      panZoomBtn.trigger('click');
 
       expect(store.state.toolSelected).not.toBeUndefined();
       if (store.state.toolSelected === undefined) {
@@ -164,7 +157,7 @@ describe('components/menu-bottom/MenuBottom', () => {
       }
       expect(store.state.toolSelected.constructor === ToolPanZoom)
         .toBeTruthy();
-      expect(firstToolBtn.props('type')).toBe('is-primary');
+      expect(panZoomBtn.props('type')).toBe('is-primary');
       expect(grapherSvgPanZoom.enablePan).toHaveBeenCalled();
       expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalled();
       expect(grapherSvgPanZoom.enableControlIcons).toHaveBeenCalled();

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -94,7 +94,7 @@ describe('components/menu-bottom/MenuBottom', () => {
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
       expect(ToolPanZoom).toHaveBeenCalled();
-      expect(toolSelected.constructor === ToolPanZoom).toBeTruthy();
+      expect(toolSelected.constructor).toBe(ToolPanZoom);
       const panZoomBtn = menu
         .find('[data-test="menu-bottom-tool--pan-zoom"]');
       expect(panZoomBtn.exists()).toBeTruthy();
@@ -122,7 +122,7 @@ describe('components/menu-bottom/MenuBottom', () => {
       expect(ToolSingleDot).toHaveBeenCalled();
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor === ToolSingleDot).toBeTruthy();
+      expect(toolSelected.constructor).toBe(ToolSingleDot);
       expect(addRmBtn.props('type')).toBe('is-primary');
       expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
       expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
@@ -149,8 +149,7 @@ describe('components/menu-bottom/MenuBottom', () => {
 
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor === ToolPanZoom)
-        .toBeTruthy();
+      expect(toolSelected.constructor).toBe(ToolPanZoom);
       expect(panZoomBtn.props('type')).toBe('is-primary');
       expect(grapherSvgPanZoom.enablePan).toHaveBeenCalled();
       expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalled();
@@ -226,26 +225,26 @@ describe('components/menu-bottom/MenuBottom', () => {
       expect(menu.vm.$data.temporaryTool).not.toBeNull();
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor === ToolSingleDot).toBeFalsy();
+      expect(toolSelected.constructor).not.toBe(ToolSingleDot);
 
       document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Control' }));
 
       expect(menu.vm.$data.temporaryTool).toBeNull();
       const nextToolSelected = store.state.toolSelected as BaseTool;
-      expect(nextToolSelected.constructor === ToolSingleDot).toBeTruthy();
+      expect(nextToolSelected.constructor).toBe(ToolSingleDot);
     });
 
     it('If meta key, enable pan/zoom and store old tool', async () => {
       expect(menu.vm.$data.temporaryTool).not.toBeNull();
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor === ToolSingleDot).toBeFalsy();
+      expect(toolSelected.constructor).not.toBe(ToolSingleDot);
 
       document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Meta' }));
 
       expect(menu.vm.$data.temporaryTool).toBeNull();
       const nextToolSelected = store.state.toolSelected as BaseTool;
-      expect(nextToolSelected.constructor === ToolSingleDot).toBeTruthy();
+      expect(nextToolSelected.constructor).toBe(ToolSingleDot);
     });
 
     it('If not ctrl key, do not do anything', () => {
@@ -254,7 +253,7 @@ describe('components/menu-bottom/MenuBottom', () => {
       expect(menu.vm.$data.temporaryTool).not.toBeNull();
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor === ToolSingleDot).toBeFalsy();
+      expect(toolSelected.constructor).not.toBe(ToolSingleDot);
     });
   });
 });

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -6,6 +6,7 @@ import Vuex, { Store } from 'vuex';
 import MenuBottom from '@/components/menu-bottom/MenuBottom.vue';
 import ToolSingleDot from '@/tools/ToolSingleDot';
 import ToolPanZoom from '@/tools/ToolPanZoom';
+import BaseTool from '@/tools/BaseTool';
 
 jest.mock('svg-pan-zoom', () => {
   return {
@@ -90,12 +91,10 @@ describe('components/menu-bottom/MenuBottom', () => {
     });
 
     it('on mount, selects the pan and zoom tool', () => {
-      expect(store.state.toolSelected).not.toBeUndefined();
-      if (store.state.toolSelected === undefined) {
-        throw 'toolSelected is undefined';
-      }
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
       expect(ToolPanZoom).toHaveBeenCalled();
-      expect(store.state.toolSelected.constructor === ToolPanZoom).toBeTruthy();
+      expect(toolSelected.constructor === ToolPanZoom).toBeTruthy();
       const panZoomBtn = menu
         .find('[data-test="menu-bottom-tool--pan-zoom"]');
       expect(panZoomBtn.exists()).toBeTruthy();
@@ -121,12 +120,9 @@ describe('components/menu-bottom/MenuBottom', () => {
       addRmBtn.trigger('click');
 
       expect(ToolSingleDot).toHaveBeenCalled();
-      expect(store.state.toolSelected).not.toBeUndefined();
-      if (store.state.toolSelected === undefined) {
-        throw 'toolSelected is undefined';
-      }
-      expect(store.state.toolSelected.constructor === ToolSingleDot)
-        .toBeTruthy();
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
+      expect(toolSelected.constructor === ToolSingleDot).toBeTruthy();
       expect(addRmBtn.props('type')).toBe('is-primary');
       expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
       expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
@@ -151,11 +147,9 @@ describe('components/menu-bottom/MenuBottom', () => {
         .find('[data-test="menu-bottom-tool--pan-zoom"]');
       panZoomBtn.trigger('click');
 
-      expect(store.state.toolSelected).not.toBeUndefined();
-      if (store.state.toolSelected === undefined) {
-        throw 'toolSelected is undefined';
-      }
-      expect(store.state.toolSelected.constructor === ToolPanZoom)
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
+      expect(toolSelected.constructor === ToolPanZoom)
         .toBeTruthy();
       expect(panZoomBtn.props('type')).toBe('is-primary');
       expect(grapherSvgPanZoom.enablePan).toHaveBeenCalled();
@@ -173,7 +167,7 @@ describe('components/menu-bottom/MenuBottom', () => {
       jest.clearAllMocks();
       ({ store, menu } = setupHelper());
 
-      store.commit('setToolSelected', new ToolSingleDot(store));
+      store.commit('setToolSelected', new ToolSingleDot());
 
       setToolMock = jest.fn();
       menu.setMethods({ setTool: setToolMock });
@@ -225,48 +219,42 @@ describe('components/menu-bottom/MenuBottom', () => {
       jest.clearAllMocks();
       ({ store, menu } = setupHelper());
 
-      menu.vm.$data.temporaryTool = new ToolSingleDot(store);
+      menu.vm.$data.temporaryTool = new ToolSingleDot();
     });
 
     it('If ctrl key, enable pan/zoom and store old tool', () => {
       expect(menu.vm.$data.temporaryTool).not.toBeNull();
-      if (store.state.toolSelected === undefined) {
-        throw 'toolSelected is undefined';
-      }
-      expect(store.state.toolSelected.constructor === ToolSingleDot)
-        .toBeFalsy();
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
+      expect(toolSelected.constructor === ToolSingleDot).toBeFalsy();
 
       document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Control' }));
 
       expect(menu.vm.$data.temporaryTool).toBeNull();
-      expect(store.state.toolSelected.constructor === ToolSingleDot)
-        .toBeTruthy();
+      const nextToolSelected = store.state.toolSelected as BaseTool;
+      expect(nextToolSelected.constructor === ToolSingleDot).toBeTruthy();
     });
 
-    it('If meta key, enable pan/zoom and store old tool', () => {
+    it('If meta key, enable pan/zoom and store old tool', async () => {
       expect(menu.vm.$data.temporaryTool).not.toBeNull();
-      if (store.state.toolSelected === undefined) {
-        throw 'toolSelected is undefined';
-      }
-      expect(store.state.toolSelected.constructor === ToolSingleDot)
-        .toBeFalsy();
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
+      expect(toolSelected.constructor === ToolSingleDot).toBeFalsy();
 
       document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Meta' }));
 
       expect(menu.vm.$data.temporaryTool).toBeNull();
-      expect(store.state.toolSelected.constructor === ToolSingleDot)
-        .toBeTruthy();
+      const nextToolSelected = store.state.toolSelected as BaseTool;
+      expect(nextToolSelected.constructor === ToolSingleDot).toBeTruthy();
     });
 
     it('If not ctrl key, do not do anything', () => {
       document.dispatchEvent(new KeyboardEvent('keyup', { key: 'KeyA' }));
 
       expect(menu.vm.$data.temporaryTool).not.toBeNull();
-      if (store.state.toolSelected === undefined) {
-        throw 'toolSelected is undefined';
-      }
-      expect(store.state.toolSelected.constructor === ToolSingleDot)
-        .toBeFalsy();
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
+      expect(toolSelected.constructor === ToolSingleDot).toBeFalsy();
     });
   });
 });

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -1,0 +1,151 @@
+import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
+import svgPanZoom from 'svg-pan-zoom';
+import Buefy from 'buefy';
+import { generateStore, CalChartState } from '@/store';
+import Vuex, { Store } from 'vuex';
+import MenuBottom from '@/components/menu-bottom/MenuBottom.vue';
+import ToolSingleDot from '@/tools/ToolSingleDot';
+import ToolPanZoom from '@/tools/ToolPanZoom';
+
+jest.mock('svg-pan-zoom', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({
+      disablePan: jest.fn(),
+      disableZoom: jest.fn(),
+      disableControlIcons: jest.fn(),
+      enablePan: jest.fn(),
+      enableZoom: jest.fn(),
+      enableControlIcons: jest.fn(),
+    })),
+  };
+});
+
+jest.mock('@/tools/ToolSingleDot');
+jest.mock('@/tools/ToolPanZoom');
+
+describe('components/menu-bottom/MenuBottom', () => {
+  describe('tool buttons', () => {
+    let inverseMock: jest.Mock;
+    let getScreenCTMMock: jest.Mock;
+    let getElementsByClassNameMock: jest.Mock;
+    let menu: Wrapper<Vue>;
+    let grapherSvgPanZoom: SvgPanZoom.Instance;
+    let store: Store<CalChartState>;
+    beforeAll(() => {
+      // Mock out inverse matrix calculations
+      inverseMock = jest.fn().mockReturnValue({});
+      getScreenCTMMock = jest.fn().mockReturnValue({
+        inverse: inverseMock,
+      });
+      getElementsByClassNameMock = jest.fn().mockReturnValue([{
+        getScreenCTM: getScreenCTMMock,
+      }]);
+      Object.defineProperty(document, 'getElementsByClassName', {
+        configurable: true,
+        value: getElementsByClassNameMock,
+      });
+
+      // Mock out store and mount
+      const localVue = createLocalVue();
+      localVue.use(Vuex);
+      localVue.use(Buefy);
+      grapherSvgPanZoom = svgPanZoom('');
+      store = generateStore({
+        grapherSvgPanZoom,
+      });
+      menu = mount(MenuBottom, {
+        store,
+        localVue,
+      });
+    });
+
+    it('renders the correct amount of tools', () => {
+      expect(menu.contains('[data-test="menu-bottom--tool-button"]'))
+        .toBeTruthy();
+      expect(menu.findAll('[data-test="menu-bottom--tool-button"]'))
+        .toHaveLength(2);
+    });
+
+    it('on mount, selects the pan and zoom tool', () => {
+      expect(store.state.toolSelected).not.toBeUndefined();
+      if (store.state.toolSelected === undefined) {
+        throw 'toolSelected is undefined';
+      }
+      expect(ToolPanZoom).toHaveBeenCalled();
+      expect(store.state.toolSelected.constructor === ToolPanZoom).toBeTruthy();
+      const firstToolBtn = menu
+        .findAll('[data-test="menu-bottom--tool-button"]')
+        .at(0);
+      expect(firstToolBtn.props('type')).toBe('is-primary');
+    });
+
+    it('unselected tools have type is-light', () => {
+      const toolBtns = menu.findAll('[data-test="menu-bottom--tool-button"]');
+      const lightToolBtns = toolBtns.filter((btn: Wrapper<Vue>) => {
+        return btn.props('type') === 'is-light';
+      });
+      expect(lightToolBtns).toHaveLength(1);
+    });
+
+    it('clicking add/remove single dot disables panning/zooming and '
+    + 'calculates inverse matrix', () => {
+      expect(ToolSingleDot).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disablePan).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableZoom).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableControlIcons).not.toHaveBeenCalled();
+      expect(inverseMock).not.toHaveBeenCalled();
+      expect(getScreenCTMMock).not.toHaveBeenCalled();
+      expect(getElementsByClassNameMock).not.toHaveBeenCalled();
+
+      const secondToolBtn = menu
+        .findAll('[data-test="menu-bottom--tool-button"]')
+        .at(1);
+      secondToolBtn.trigger('click');
+
+      expect(ToolSingleDot).toHaveBeenCalled();
+      expect(store.state.toolSelected).not.toBeUndefined();
+      if (store.state.toolSelected === undefined) {
+        throw 'toolSelected is undefined';
+      }
+      expect(store.state.toolSelected.constructor === ToolSingleDot)
+        .toBeTruthy();
+      expect(secondToolBtn.props('type')).toBe('is-primary');
+      expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableControlIcons).toHaveBeenCalled();
+      expect(inverseMock).toHaveBeenCalled();
+      expect(getScreenCTMMock).toHaveBeenCalled();
+      expect(getElementsByClassNameMock).toHaveBeenCalled();
+    });
+
+    it('pan and zoom is no longer selected', () => {
+      const firstToolBtn = menu
+        .findAll('[data-test="menu-bottom--tool-button"]')
+        .at(0);
+      expect(firstToolBtn.props('type')).toBe('is-light');
+    });
+
+    it('clicking pan and zoom enables panning/zooming', () => {
+      expect(grapherSvgPanZoom.enablePan).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.enableZoom).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.enableControlIcons).not.toHaveBeenCalled();
+
+      const firstToolBtn = menu
+        .findAll('[data-test="menu-bottom--tool-button"]')
+        .at(0);
+      firstToolBtn.trigger('click');
+
+      expect(store.state.toolSelected).not.toBeUndefined();
+      if (store.state.toolSelected === undefined) {
+        throw 'toolSelected is undefined';
+      }
+      expect(store.state.toolSelected.constructor === ToolPanZoom)
+        .toBeTruthy();
+      expect(firstToolBtn.props('type')).toBe('is-primary');
+      expect(grapherSvgPanZoom.enablePan).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.enableControlIcons).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/tools/BaseTool.spec.ts
+++ b/tests/unit/tools/BaseTool.spec.ts
@@ -1,0 +1,62 @@
+import BaseTool from '@/tools/BaseTool';
+import { generateStore, CalChartState } from '@/store';
+import { Store } from 'vuex';
+
+describe('tools/BaseTool', () => {
+  let matrixTransformMock: jest.Mock;
+  let createSVGPointMock: jest.Mock;
+  let getElementsByTagNameMock: jest.Mock;
+  let store: Store<CalChartState>;
+
+  beforeAll(() => {
+    // Mock out inverse matrix calculations
+    matrixTransformMock = jest.fn().mockReturnValue({
+      x: 1.5,
+      y: 0.5,
+    });
+    createSVGPointMock = jest.fn().mockReturnValue({
+      matrixTransform: matrixTransformMock,
+    });
+    getElementsByTagNameMock = jest.fn().mockReturnValue([{
+      createSVGPoint: createSVGPointMock,
+    }]);
+    Object.defineProperty(document, 'getElementsByTagName', {
+      configurable: true,
+      value: getElementsByTagNameMock,
+    });
+
+    // Mock out store
+    store = generateStore();
+    store.commit('setInvertedCTMMatrix', {});
+  });
+
+  it('convertClientCoordinates calls the correct functions', () => {
+    const [x, y] = BaseTool.convertClientCoordinates(
+      new MouseEvent('click', { clientX: 0, clientY: 0 }),
+      store,
+    );
+
+    expect(getElementsByTagNameMock).toHaveBeenCalled();
+    expect(createSVGPointMock).toHaveBeenCalled();
+    expect(matrixTransformMock).toHaveBeenCalled();
+    expect(matrixTransformMock)
+      .toHaveBeenCalledWith(store.state.invertedCTMMatrix);
+
+    expect(x).toBe(2);
+    expect(y).toBe(0);
+  });
+
+  describe('roundCoordinateToGrid', () => {
+    it('0.5 goes to 0', () => {
+      expect(BaseTool.roundCoordinateToGrid(0.5)).toBe(0);
+    });
+
+    it('1.1 rounds to 2', () => {
+      expect(BaseTool.roundCoordinateToGrid(1.1)).toBe(2);
+    });
+
+    it('3.0 rounds to 4', () => {
+      expect(BaseTool.roundCoordinateToGrid(3.0)).toBe(4);
+    });
+  });
+});

--- a/tests/unit/tools/BaseTool.spec.ts
+++ b/tests/unit/tools/BaseTool.spec.ts
@@ -1,12 +1,10 @@
 import BaseTool from '@/tools/BaseTool';
-import { generateStore, CalChartState } from '@/store';
-import { Store } from 'vuex';
+import { GlobalStore } from '@/store';
 
 describe('tools/BaseTool', () => {
   let matrixTransformMock: jest.Mock;
   let createSVGPointMock: jest.Mock;
   let getElementsByTagNameMock: jest.Mock;
-  let store: Store<CalChartState>;
 
   beforeAll(() => {
     // Mock out inverse matrix calculations
@@ -25,22 +23,20 @@ describe('tools/BaseTool', () => {
       value: getElementsByTagNameMock,
     });
 
-    // Mock out store
-    store = generateStore();
-    store.commit('setInvertedCTMMatrix', {});
+    GlobalStore.state.invertedCTMMatrix = new Object() as DOMMatrix;
   });
 
   it('convertClientCoordinates calls the correct functions', () => {
-    const [x, y] = BaseTool.convertClientCoordinates(
-      new MouseEvent('click', { clientX: 0, clientY: 0 }),
-      store,
-    );
+    const [x, y] = BaseTool.convertClientCoordinates(new MouseEvent(
+      'click',
+      { clientX: 0, clientY: 0 }
+    ));
 
     expect(getElementsByTagNameMock).toHaveBeenCalled();
     expect(createSVGPointMock).toHaveBeenCalled();
     expect(matrixTransformMock).toHaveBeenCalled();
     expect(matrixTransformMock)
-      .toHaveBeenCalledWith(store.state.invertedCTMMatrix);
+      .toHaveBeenCalledWith(GlobalStore.state.invertedCTMMatrix);
 
     expect(x).toBe(2);
     expect(y).toBe(0);

--- a/tests/unit/tools/BaseTool.spec.ts
+++ b/tests/unit/tools/BaseTool.spec.ts
@@ -4,7 +4,7 @@ import { GlobalStore } from '@/store';
 describe('tools/BaseTool', () => {
   let matrixTransformMock: jest.Mock;
   let createSVGPointMock: jest.Mock;
-  let getElementsByTagNameMock: jest.Mock;
+  let getElementsByClassNameMock: jest.Mock;
 
   beforeAll(() => {
     // Mock out inverse matrix calculations
@@ -15,12 +15,12 @@ describe('tools/BaseTool', () => {
     createSVGPointMock = jest.fn().mockReturnValue({
       matrixTransform: matrixTransformMock,
     });
-    getElementsByTagNameMock = jest.fn().mockReturnValue([{
+    getElementsByClassNameMock = jest.fn().mockReturnValue([{
       createSVGPoint: createSVGPointMock,
     }]);
-    Object.defineProperty(document, 'getElementsByTagName', {
+    Object.defineProperty(document, 'getElementsByClassName', {
       configurable: true,
-      value: getElementsByTagNameMock,
+      value: getElementsByClassNameMock,
     });
 
     GlobalStore.state.invertedCTMMatrix = new Object() as DOMMatrix;
@@ -32,7 +32,7 @@ describe('tools/BaseTool', () => {
       { clientX: 0, clientY: 0 }
     ));
 
-    expect(getElementsByTagNameMock).toHaveBeenCalled();
+    expect(getElementsByClassNameMock).toHaveBeenCalled();
     expect(createSVGPointMock).toHaveBeenCalled();
     expect(matrixTransformMock).toHaveBeenCalled();
     expect(matrixTransformMock)
@@ -43,16 +43,13 @@ describe('tools/BaseTool', () => {
   });
 
   describe('roundCoordinateToGrid', () => {
-    it('0.5 goes to 0', () => {
-      expect(BaseTool.roundCoordinateToGrid(0.5)).toBe(0);
-    });
-
-    it('1.1 rounds to 2', () => {
-      expect(BaseTool.roundCoordinateToGrid(1.1)).toBe(2);
-    });
-
-    it('3.0 rounds to 4', () => {
-      expect(BaseTool.roundCoordinateToGrid(3.0)).toBe(4);
+    it.each([
+      [0.5, 0],
+      [1.1, 2],
+      [3.0, 4],
+      [-1.5, -2],
+    ])('%f rounds to %i', (input, output) => {
+      expect(BaseTool.roundCoordinateToGrid(input)).toBe(output);
     });
   });
 });

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -1,18 +1,15 @@
 import ToolSingleDot from '@/tools/ToolSingleDot';
-import { generateStore, CalChartState } from '@/store';
-import { Store } from 'vuex';
+import { GlobalStore } from '@/store';
 import BaseTool from '@/tools/BaseTool';
 import StuntSheetDot from '@/models/StuntSheetDot';
 
 describe('tools/ToolSingleDot', () => {
-  let store: Store<CalChartState>;
   let tool: BaseTool;
 
   beforeEach(() => {
     BaseTool.convertClientCoordinates = jest.fn().mockReturnValue([0, 2]);
-    store = generateStore();
-    Object.defineProperty(store, 'commit', { value: jest.fn() });
-    tool = new ToolSingleDot(store);
+    Object.defineProperty(GlobalStore, 'commit', { value: jest.fn() });
+    tool = new ToolSingleDot();
   });
 
   afterEach(() => {
@@ -22,49 +19,49 @@ describe('tools/ToolSingleDot', () => {
   describe('onClick', () => {
     it('adds a new dot if none exists in the spot', () => {
       expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
-      expect(store.commit).not.toHaveBeenCalled();
+      expect(GlobalStore.commit).not.toHaveBeenCalled();
 
-      tool.onClick(new MouseEvent('click', { clientX: 0, clientY: 0 }), store);
+      tool.onClick(new MouseEvent('click', { clientX: 0, clientY: 0 }));
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
-      expect(store.commit).toHaveBeenCalledTimes(1);
-      expect(store.commit)
+      expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
+      expect(GlobalStore.commit)
         .toHaveBeenCalledWith('addDot', expect.any(StuntSheetDot));
     });
 
     it('removes a dot if it exists in the spot', () => {
-      const stuntSheet = store.state.show.stuntSheets[store.state.selectedSS];
+      const stuntSheet = GlobalStore.getters.getSelectedStuntSheet;
       stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 0, y: 2 }));
 
       expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
-      expect(store.commit).not.toHaveBeenCalled();
+      expect(GlobalStore.commit).not.toHaveBeenCalled();
 
-      tool.onClick(new MouseEvent('click', { clientX: 0, clientY: 2 }), store);
+      tool.onClick(new MouseEvent('click', { clientX: 0, clientY: 2 }));
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
-      expect(store.commit).toHaveBeenCalledTimes(1);
-      expect(store.commit).toHaveBeenCalledWith('removeDot', 0);
+      expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
+      expect(GlobalStore.commit).toHaveBeenCalledWith('removeDot', 0);
     });
   });
 
   describe('onMousemove', () => {
     it('sets grapher tool dot', () => {
       expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
-      expect(store.commit).not.toHaveBeenCalled();
+      expect(GlobalStore.commit).not.toHaveBeenCalled();
 
-      tool.onMousemove(
-        new MouseEvent('mousemove', { clientX: 0, clientY: 2 }),
-        store
-      );
+      tool.onMousemove(new MouseEvent(
+        'mousemove',
+        { clientX: 0, clientY: 2 }
+      ));
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
-      expect(store.commit).toHaveBeenCalledTimes(1);
-      expect(store.commit).toHaveBeenCalledWith(
+      expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
+      expect(GlobalStore.commit).toHaveBeenCalledWith(
         'setGrapherToolDots',
         expect.anything()
       );
       const grapherToolDots: StuntSheetDot[]
-        = (store.commit as jest.Mock).mock.calls[0][1];
+        = (GlobalStore.commit as jest.Mock).mock.calls[0][1];
       expect(grapherToolDots).toHaveLength(1);
       expect(grapherToolDots[0].x).toBe(0);
       expect(grapherToolDots[0].y).toBe(2);

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -46,4 +46,28 @@ describe('tools/ToolSingleDot', () => {
       expect(store.commit).toHaveBeenCalledWith('removeDot', 0);
     });
   });
+
+  describe('onMousemove', () => {
+    it('sets grapher tool dot', () => {
+      expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
+      expect(store.commit).not.toHaveBeenCalled();
+
+      tool.onMousemove(
+        new MouseEvent('mousemove', { clientX: 0, clientY: 2 }),
+        store
+      );
+
+      expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
+      expect(store.commit).toHaveBeenCalledTimes(1);
+      expect(store.commit).toHaveBeenCalledWith(
+        'setGrapherToolDots',
+        expect.anything()
+      );
+      const grapherToolDots: StuntSheetDot[]
+        = (store.commit as jest.Mock).mock.calls[0][1];
+      expect(grapherToolDots).toHaveLength(1);
+      expect(grapherToolDots[0].x).toBe(0);
+      expect(grapherToolDots[0].y).toBe(2);
+    });
+  });
 });

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -1,0 +1,49 @@
+import ToolSingleDot from '@/tools/ToolSingleDot';
+import { generateStore, CalChartState } from '@/store';
+import { Store } from 'vuex';
+import BaseTool from '@/tools/BaseTool';
+import StuntSheetDot from '@/models/StuntSheetDot';
+
+describe('tools/ToolSingleDot', () => {
+  let store: Store<CalChartState>;
+  let tool: BaseTool;
+
+  beforeEach(() => {
+    BaseTool.convertClientCoordinates = jest.fn().mockReturnValue([0, 2]);
+    store = generateStore();
+    Object.defineProperty(store, 'commit', { value: jest.fn() });
+    tool = new ToolSingleDot(store);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('onClick', () => {
+    it('adds a new dot if none exists in the spot', () => {
+      expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
+      expect(store.commit).not.toHaveBeenCalled();
+
+      tool.onClick(new MouseEvent('click', { clientX: 0, clientY: 0 }), store);
+
+      expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
+      expect(store.commit).toHaveBeenCalledTimes(1);
+      expect(store.commit)
+        .toHaveBeenCalledWith('addDot', expect.any(StuntSheetDot));
+    });
+
+    it('removes a dot if it exists in the spot', () => {
+      const stuntSheet = store.state.show.stuntSheets[store.state.selectedSS];
+      stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 0, y: 2 }));
+
+      expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
+      expect(store.commit).not.toHaveBeenCalled();
+
+      tool.onClick(new MouseEvent('click', { clientX: 0, clientY: 2 }), store);
+
+      expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
+      expect(store.commit).toHaveBeenCalledTimes(1);
+      expect(store.commit).toHaveBeenCalledWith('removeDot', 0);
+    });
+  });
+});

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  configureWebpack: {
+    devtool: 'source-map',
+  },
   lintOnSave: process.env.NODE_ENV !== 'production',
   publicPath: '',
   outputDir: 'calchart',


### PR DESCRIPTION
Addresses #27 

- Create two tools in the bottom menu
  - Pan/zoom
  - Add/remove single dot
- Created the template for tools with methods for click and mouseover.
- Clicking on a tool that is not pan/zoom disables panning/zooming
- Added very simple rendering of dots. Will create an issue to add the dot svg icons that Brandon made.
- Holding either the ctrl or meta key will enable pan/zoom.
- README: add suggestion for debugger
- Added type definition for store getters and mutations.
- Added short descriptions for each Vue component
- For components that use `v-for`, don't use `index` for the `key` unless the list doesn't change. 