### PR TITLE
MenuLeft: Select/add/remove/edit stuntsheets, control beat

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,10 @@
 <template>
   <div id="app" data-test="app">
     <MenuTop />
-    <div class="columns is-gapless app--bottom">
-      <MenuLeft />
-      <div class="column app--middle-col">
-        <Grapher />
-        <MenuBottom />
-      </div>
-      <MenuRight />
-    </div>
+    <MenuLeft />
+    <Grapher />
+    <MenuBottom />
+    <MenuRight />
   </div>
 </template>
 
@@ -51,17 +47,12 @@ body,
 
 #app {
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.app--bottom {
-  flex: 1 1;
-}
-
-.app--middle-col {
-  flex: 1 1;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 200px auto 200px;
+  grid-template-rows: $navbar-height auto 36px; // See Bulma for navbar-height
+  grid-template-areas:
+    "menu-top menu-top menu-top"
+    "menu-left grapher menu-right"
+    "menu-left menu-bottom menu-right";
 }
 </style>

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -244,7 +244,7 @@ export default Vue.extend({
 
 <style scoped lang="scss">
 .grapher {
-  flex: 1 1;
+  grid-area: grapher;
   background: $stone-pine;
   position: relative;
 }

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -148,4 +148,8 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.menu-bottom {
+  grid-area: menu-bottom;
+}
+</style>

--- a/src/components/menu-left/MenuLeft.vue
+++ b/src/components/menu-left/MenuLeft.vue
@@ -1,19 +1,155 @@
 <template>
-  <div class="column is-narrow menu-left">
-    <h3>Menu left</h3>
+  <div class="menu-left">
+    <b-field
+      :label="`Beat: ${beat} / ${selectedSSBeats}`"
+      data-test="menu-left--beat"
+    >
+      <b-slider
+        v-model="beat"
+        class="beat-slider"
+        data-test="menu-left--beat-slider"
+        :min="1"
+        :max="selectedSSBeats"
+        :tooltip="false"
+      />
+    </b-field>
+    <div class="buttons beat-buttons">
+      <b-button
+        type="is-primary"
+        icon-left="arrow-left-bold"
+        data-test="menu-left--decrement-beat"
+        @click="decrementBeat"
+      />
+      <b-button
+        type="is-primary"
+        icon-left="arrow-right-bold"
+        data-test="menu-left--increment-beat"
+        @click="incrementBeat"
+      />
+    </div>
+    <p class="label">Stuntsheets</p>
+    <b-menu>
+      <b-menu-list>
+        <b-menu-item
+          v-for="(stuntSheet, index) in stuntSheets"
+          :key="stuntSheet.title"
+          class="stuntsheet"
+          :active="selectedSS === index"
+          data-test="menu-left--ss"
+          @click="selectedSS = index"
+        >
+          <template slot="label">
+            {{ `${index + 1}) ${stuntSheet.title}` }}
+            <b-icon
+              class="stuntsheet-edit is-pulled-right"
+              icon="pencil"
+              size="is-small"
+              @click.native="stuntSheetModalActive = true"
+            />
+          </template>
+        </b-menu-item>
+      </b-menu-list>
+    </b-menu>
+    <b-button
+      type="is-text"
+      size="is-small"
+      expanded
+      data-test="menu-left--add-ss"
+      @click="addStuntSheet"
+    >
+      Add Stuntsheet
+    </b-button>
+    <b-modal
+      :active.sync="stuntSheetModalActive"
+      has-modal-card
+      trap-focus
+      data-test="menu-left--ss-modal"
+    >
+      <StuntSheetModal />
+    </b-modal>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
+import StuntSheet from "../../models/StuntSheet";
+import StuntSheetModal from "./StuntSheetModal.vue";
 
 export default Vue.extend({
   name: "MenuLeft",
+  components: {
+    StuntSheetModal,
+  },
+  data() {
+    return {
+      stuntSheetModalActive: false,
+    };
+  },
+  computed: {
+    beat: {
+      get(): number {
+        return this.$store.state.beat;
+      },
+      set(beat: number): void {
+        this.$store.commit("setBeat", beat);
+      },
+    },
+    stuntSheets(): StuntSheet[] {
+      return this.$store.state.show.stuntSheets;
+    },
+    selectedSS: {
+      get(): number {
+        return this.$store.state.selectedSS;
+      },
+      set(selectedSS: number): void {
+        this.$store.commit("setSelectedSS", selectedSS);
+        this.$store.commit("setBeat", 1);
+      },
+    },
+    selectedSSBeats(): number {
+      const selectedSS = this.$store.getters
+        .getSelectedStuntSheet as StuntSheet;
+      return selectedSS.beats;
+    },
+  },
+  methods: {
+    addStuntSheet(): void {
+      const stuntSheet = new StuntSheet();
+      this.$store.commit("addStuntSheet", stuntSheet);
+    },
+    incrementBeat(): void {
+      this.$store.commit("incrementBeat");
+    },
+    decrementBeat(): void {
+      this.$store.commit("decrementBeat");
+    },
+  },
 });
 </script>
 
 <style scoped lang="scss">
 .menu-left {
-  width: 150px;
+  grid-area: menu-left;
+  overflow-y: auto;
+  padding: $radius;
+
+  .beat-slider {
+    padding: 0 0.5rem;
+  }
+
+  .beat-buttons {
+    justify-content: space-between;
+  }
+}
+
+.stuntsheet {
+  .stuntsheet-edit {
+    display: none;
+  }
+
+  &:hover .stuntsheet-edit,
+  .is-active .stuntsheet-edit {
+    display: block;
+  }
 }
 </style>

--- a/src/components/menu-left/StuntSheetModal.vue
+++ b/src/components/menu-left/StuntSheetModal.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Edit Stuntsheet</p>
+    </header>
+
+    <section class="modal-card-body">
+      <b-field label="Stuntsheet Title">
+        <b-input v-model="title" data-test="ss-modal--title" />
+      </b-field>
+
+      <b-field label="Beats">
+        <b-numberinput
+          v-model="beats"
+          min="0"
+          max="256"
+          data-test="ss-modal--beats"
+        />
+      </b-field>
+    </section>
+
+    <footer class="modal-card-foot">
+      <b-button
+        type="is-primary"
+        data-test="ss-modal--close"
+        @click="$parent.close()"
+      >
+        Close
+      </b-button>
+      <b-button
+        v-if="canDeleteSS"
+        type="is-danger"
+        data-test="ss-modal--delete"
+        @click="deleteSS"
+      >
+        Delete
+      </b-button>
+    </footer>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+/**
+ * Show and modify values in the current Show model
+ */
+export default Vue.extend({
+  name: "StuntSheetModal",
+  computed: {
+    title: {
+      get(): string {
+        const stuntSheet = this.$store.getters.getSelectedStuntSheet;
+        return stuntSheet.title;
+      },
+      set(title: string): void {
+        this.$store.commit("setStuntSheetTitle", title);
+      },
+    },
+
+    beats: {
+      get(): number {
+        const stuntSheet = this.$store.getters.getSelectedStuntSheet;
+        return stuntSheet.beats;
+      },
+      set(beats: number): void {
+        this.$store.commit("setStuntSheetBeats", beats);
+      },
+    },
+
+    canDeleteSS(): boolean {
+      return this.$store.state.show.stuntSheets.length > 1;
+    },
+  },
+  methods: {
+    deleteSS(): void {
+      this.$store.commit("deleteStuntSheet");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this.$parent as any).close();
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/menu-right/MenuRight.vue
+++ b/src/components/menu-right/MenuRight.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column is-narrow menu-right">
+  <div class="menu-right">
     <h3>Menu right</h3>
   </div>
 </template>
@@ -14,6 +14,6 @@ export default Vue.extend({
 
 <style scoped lang="scss">
 .menu-right {
-  width: 250px;
+  grid-area: menu-right;
 }
 </style>

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -129,6 +129,6 @@ export default Vue.extend({
 
 <style scoped lang="scss">
 .menu-top {
-  flex: 0 0;
+  grid-area: menu-top;
 }
 </style>

--- a/src/models/util/ParseCalChart3Utils.ts
+++ b/src/models/util/ParseCalChart3Utils.ts
@@ -91,9 +91,9 @@ export function splitDataViewIntoChunks(
 }
 
 export function calChart3To4ConvertX(x: number): number {
-  return 160 + x / 8;
+  return 96 + x / 16;
 }
 
 export function calChart3To4ConvertY(y: number): number {
-  return 84 + y / 8;
+  return 42 + y / 16;
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,6 +14,7 @@ Vue.use(Vuex);
  *
  * @property show              - The currently selected show data
  * @property selectedSS        - Index of stuntsheet currently in view
+ * @property beat              - The point in time the show is in
  * @property fourStepGrid      - View setting to toggle the grapher grid
  * @property grapherSvgPanZoom - Initialized upon mounting Grapher
  * @property invertedCTMMatrix - Used to calculate clientX/Y to SVG X/Y
@@ -25,8 +26,12 @@ export class CalChartState extends Serializable<CalChartState> {
 
   selectedSS = 0;
 
+  beat = 1;
+
   fourStepGrid = true;
+
   yardlines = true;
+
   yardlineNumbers = true;
 
   grapherSvgPanZoom?: SvgPanZoom.Instance;

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -14,6 +14,16 @@ const mutations: MutationTree<CalChartState> = {
   setShowTitle(state, title: string): void {
     state.show.title = title;
   },
+  addStuntSheet(state, stuntSheet: StuntSheet): void {
+    state.show.stuntSheets.push(stuntSheet);
+    state.selectedSS = state.show.stuntSheets.length - 1;
+    state.beat = 1;
+  },
+  deleteStuntSheet(state): void {
+    state.show.stuntSheets.splice(state.selectedSS, 1);
+    state.selectedSS = Math.max(0, state.selectedSS - 1);
+    state.beat = 1;
+  },
 
   // Show -> Field
   setFrontHashOffsetY(state, offsetY: number): void {
@@ -40,6 +50,54 @@ const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.addDot(dot);
+  },
+  setStuntSheetTitle(state, title: string): void {
+    const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+      state: CalChartState
+    ) => StuntSheet;
+    const currentSS = getSelectedStuntSheet(state);
+    currentSS.title = title;
+  },
+  setStuntSheetBeats(state, beats: number): void {
+    const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+      state: CalChartState
+    ) => StuntSheet;
+    const currentSS = getSelectedStuntSheet(state);
+    currentSS.beats = beats;
+  },
+
+  // Show controls
+  setSelectedSS(state, selectedSS: number): void {
+    state.selectedSS = selectedSS;
+  },
+  setBeat(state, beat: number): void {
+    state.beat = beat;
+  },
+  incrementBeat(state): void {
+    const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+      state: CalChartState
+    ) => StuntSheet;
+    const currentSS: StuntSheet = getSelectedStuntSheet(state);
+    if (state.beat < currentSS.beats) {
+      state.beat += 1;
+    } else if (state.selectedSS + 1 < state.show.stuntSheets.length) {
+      // Go to next stuntsheet's first beat
+      state.selectedSS += 1;
+      state.beat = 1;
+    }
+  },
+  decrementBeat(state): void {
+    if (state.beat > 1) {
+      state.beat -= 1;
+    } else if (state.selectedSS > 0) {
+      // Go to previous stuntsheet's last beat
+      state.selectedSS -= 1;
+      const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+        state: CalChartState
+      ) => StuntSheet;
+      const currentSS: StuntSheet = getSelectedStuntSheet(state);
+      state.beat = currentSS.beats;
+    }
   },
 
   // View Settings

--- a/tests/e2e/specs/menu-left/MenuLeft.spec.js
+++ b/tests/e2e/specs/menu-left/MenuLeft.spec.js
@@ -1,0 +1,121 @@
+describe("components/menu-left/MenuLeft", () => {
+  it("Creating and editing two stuntsheets", () => {
+    cy.visit("/");
+
+    // Edit the first stuntsheet to have title "Sunset" and 2 beats
+    cy.get('[data-test="menu-left--ss-modal"]').should("not.be.visible");
+
+    cy.get('[data-test="menu-left--ss"]')
+      .eq(0)
+      .find(".stuntsheet-edit")
+      .should("be.visible")
+      .click();
+
+    cy.get('[data-test="menu-left--ss-modal"]').should("be.visible");
+
+    cy.get('[data-test="ss-modal--title"]')
+      .should("have.value", "")
+      .type("Sunset");
+
+    cy.get('[data-test="ss-modal--beats"]')
+      .should("have.value", "16")
+      .clear()
+      .type("2");
+
+    cy.get('[data-test="ss-modal--close"]').click();
+
+    // Check that the stuntsheet title and beats have been updated
+    cy.get('[data-test="menu-left--ss"]')
+      .should("have.length", 1)
+      .eq(0)
+      .should("have.class", "is-active")
+      .should("contain", "Sunset");
+
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "1 / 2");
+
+    // Add a stuntsheet dot (4, 4) to the first stuntsheet
+    cy.get('[data-test="grapher--dot"]').should("not.exist");
+
+    cy.get('[data-test="menu-bottom-tool--add-rm"]').click().clickGrapher(4, 4);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "4")
+      .should("have.attr", "cy", "4");
+
+    // Add new stuntsheet
+    cy.get('[data-test="menu-left--add-ss"]').click();
+
+    cy.get('[data-test="menu-left--ss"]')
+      .should("have.length", 2)
+      .eq(1)
+      .should("have.class", "is-active");
+
+    // Edit the second stuntsheet to have title "Script YOLO" and 4 beats
+    cy.get('[data-test="menu-left--ss"]')
+      .eq(1)
+      .find(".stuntsheet-edit")
+      .should("be.visible")
+      .click();
+
+    cy.get('[data-test="menu-left--ss-modal"]').should("be.visible");
+
+    cy.get('[data-test="ss-modal--title"]')
+      .should("have.value", "")
+      .type("Script YOLO");
+
+    cy.get('[data-test="ss-modal--beats"]')
+      .should("have.value", "16")
+      .clear()
+      .type("4");
+
+    cy.get('[data-test="ss-modal--close"]').click();
+
+    // Check that the stuntsheet title and beats have been updated
+    cy.get('[data-test="menu-left--ss"]')
+      .should("have.length", 2)
+      .eq(1)
+      .should("have.class", "is-active")
+      .should("contain", "Script YOLO");
+
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "1 / 4");
+
+    // Add a stuntsheet dot (8, 8) to the first stuntsheet
+    cy.get('[data-test="grapher--dot"]').should("not.exist");
+
+    cy.get('[data-test="menu-bottom-tool--add-rm"]').click().clickGrapher(8, 8);
+
+    cy.get('[data-test="grapher--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "8")
+      .should("have.attr", "cy", "8");
+
+    // Decrement the beat to go to the first stuntsheet at beat 2 / 2
+    cy.get('[data-test="menu-left--decrement-beat"]').click();
+
+    cy.get('[data-test="menu-left--ss"]')
+      .eq(0)
+      .should("have.class", "is-active");
+
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "2 / 2");
+
+    cy.get('[data-test="grapher--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "4")
+      .should("have.attr", "cy", "4");
+
+    // Increment the beat to go the second stuntsheet at beat 1 / 4
+    cy.get('[data-test="menu-left--increment-beat"]').click();
+
+    cy.get('[data-test="menu-left--ss"]')
+      .eq(1)
+      .should("have.class", "is-active");
+
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "1 / 4");
+
+    cy.get('[data-test="grapher--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "8")
+      .should("have.attr", "cy", "8");
+  });
+});

--- a/tests/e2e/specs/menu-left/StuntSheetModal.spec.js
+++ b/tests/e2e/specs/menu-left/StuntSheetModal.spec.js
@@ -1,0 +1,55 @@
+describe("components/menu-left/StuntSheetModal", () => {
+  beforeEach(() => {
+    cy.visit("/");
+
+    cy.get('[data-test="menu-left--ss"]').find(".stuntsheet-edit").click();
+
+    cy.get('[data-test="menu-left--ss-modal"]').should("be.visible");
+  });
+
+  it("Setting the title", () => {
+    cy.get('[data-test="ss-modal--title"]')
+      .should("have.value", "")
+      .type("Sunrise");
+
+    cy.get('[data-test="ss-modal--close"]').click();
+
+    cy.get('[data-test="menu-left--ss"]').should("include.text", "Sunrise");
+  });
+
+  it("Setting the beats", () => {
+    cy.get('[data-test="ss-modal--beats"]')
+      .should("have.value", "16")
+      .clear()
+      .type("2");
+
+    cy.get('[data-test="ss-modal--close"]').click();
+
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "1 / 2");
+  });
+
+  it("Can delete a stuntsheet if there is more than one", () => {
+    cy.get('[data-test="ss-modal--delete"]').should("not.exist");
+
+    cy.get('[data-test="ss-modal--title"]')
+      .should("have.value", "")
+      .type("Sunrise");
+
+    cy.get('[data-test="ss-modal--close"]').click();
+
+    cy.get('[data-test="menu-left--add-ss"]').click();
+
+    cy.get('[data-test="menu-left--ss"]')
+      .should("have.length", 2)
+      .first()
+      .should("include.text", "Sunrise")
+      .find(".stuntsheet-edit")
+      .click({ force: true }); // The icon is hidden so we must force
+
+    cy.get('[data-test="ss-modal--delete"]').click();
+
+    cy.get('[data-test="menu-left--ss"]')
+      .should("have.length", 1)
+      .should("not.include.text", "Sunrise");
+  });
+});

--- a/tests/unit/components/menu-left/MenuLeft.spec.ts
+++ b/tests/unit/components/menu-left/MenuLeft.spec.ts
@@ -1,0 +1,122 @@
+import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
+import Buefy from "buefy";
+import { generateStore, CalChartState } from "@/store";
+import Vuex, { Store } from "vuex";
+import MenuLeft from "@/components/menu-left/MenuLeft.vue";
+import Show from "@/models/Show";
+import StuntSheet from "@/models/StuntSheet";
+
+describe("components/menu-left/MenuLeft", () => {
+  let menu: Wrapper<Vue>;
+  let store: Store<CalChartState>;
+  let commitSpy: jest.SpyInstance;
+  const stuntSheets = [
+    new StuntSheet({ beats: 4, title: "a" }),
+    new StuntSheet({ beats: 8, title: "b" }),
+    new StuntSheet({ beats: 12, title: "c" }),
+  ];
+  const show = new Show({ stuntSheets });
+
+  beforeEach(() => {
+    // Mock out store and mount
+    const localVue = createLocalVue();
+    localVue.use(Vuex);
+    localVue.use(Buefy);
+    store = generateStore({ show });
+    commitSpy = jest.spyOn(store, "commit");
+    menu = mount(MenuLeft, {
+      store,
+      localVue,
+    });
+  });
+
+  describe("Beat controls", () => {
+    it.each([
+      [1, 0],
+      [2, 0],
+      [1, 1],
+      [4, 2],
+    ])(
+      "Beat control with beat %i and stuntsheet %i",
+      async (beat, selectedSS) => {
+        store.commit("setBeat", beat);
+        store.commit("setSelectedSS", selectedSS);
+        await menu.vm.$nextTick();
+
+        const beatControl = menu.find('[data-test="menu-left--beat"]');
+        expect(beatControl.exists()).toBeTruthy();
+        const selectedSSBeats = stuntSheets[selectedSS].beats;
+        expect(beatControl.text()).toContain(
+          `Beat: ${beat} / ${selectedSSBeats}`
+        );
+
+        const beatSlider = menu.find('[data-test="menu-left--beat-slider"]');
+        expect(beatSlider.exists()).toBeTruthy();
+        expect(beatSlider.props("max")).toBe(selectedSSBeats);
+        expect(beatSlider.props("value")).toBe(beat);
+      }
+    );
+
+    it.each([
+      ["decrementBeat", "menu-left--decrement-beat"],
+      ["incrementBeat", "menu-left--increment-beat"],
+    ])("Calls %s in store upon clicking button", (commitMsg, selector) => {
+      const button = menu.find(`[data-test="${selector}"]`);
+      expect(button.exists()).toBeTruthy();
+      expect(commitSpy).not.toHaveBeenCalledWith(commitMsg);
+      button.trigger("click");
+      expect(commitSpy).toHaveBeenCalledWith(commitMsg);
+    });
+  });
+
+  describe("Stuntsheet controls", () => {
+    it("Renders 3 stuntsheet menu items", () => {
+      expect(menu.findAll('[data-test="menu-left--ss"]')).toHaveLength(3);
+    });
+
+    it.each([0, 1, 2])("Correctly renders stuntsheet %i", async (index) => {
+      const stuntSheet = stuntSheets[index];
+      const menuItem = menu.findAll('[data-test="menu-left--ss"]').at(index);
+      expect(menuItem.text()).toContain(`${index + 1}) ${stuntSheet.title}`);
+      expect(menuItem.classes("is-active")).toBe(index === 0);
+
+      commitSpy.mockClear();
+      menuItem.trigger("click");
+      await menu.vm.$nextTick();
+
+      expect(commitSpy).toHaveBeenCalledWith("setSelectedSS", index);
+      expect(commitSpy).toHaveBeenCalledWith("setBeat", 1);
+      expect(menuItem.classes("is-active")).toBeTruthy();
+    });
+
+    it("Clicking the stuntsheet edit icon opens the modal", async () => {
+      expect(
+        menu.find('[data-test="menu-left--ss-modal"]').props("active")
+      ).toBe(false);
+      const editSS = menu.find('[data-test="menu-left--ss"] .stuntsheet-edit');
+      expect(editSS.exists()).toBeTruthy();
+
+      editSS.trigger("click");
+      await menu.vm.$nextTick();
+
+      expect(
+        menu.find('[data-test="menu-left--ss-modal"]').props("active")
+      ).toBe(true);
+    });
+
+    it("Calls addStuntSheet in store upon clicking button", async () => {
+      const addButton = menu.find('[data-test="menu-left--add-ss"]');
+      expect(addButton.exists()).toBeTruthy();
+
+      commitSpy.mockClear();
+      addButton.trigger("click");
+      await menu.vm.$nextTick();
+
+      expect(commitSpy).toHaveBeenLastCalledWith(
+        "addStuntSheet",
+        show.stuntSheets[3]
+      );
+      expect(menu.findAll('[data-test="menu-left--ss"]')).toHaveLength(4);
+    });
+  });
+});

--- a/tests/unit/components/menu-left/StuntSheetModal.spec.ts
+++ b/tests/unit/components/menu-left/StuntSheetModal.spec.ts
@@ -1,0 +1,78 @@
+import { Wrapper, createLocalVue, mount } from "@vue/test-utils";
+import Vue, { VueConstructor } from "vue";
+import Vuex, { Store } from "vuex";
+import Buefy from "buefy";
+import { CalChartState, generateStore } from "@/store";
+import StuntSheetModal from "@/components/menu-left/StuntSheetModal.vue";
+import StuntSheet from "@/models/StuntSheet";
+
+describe("components/menu-left/StuntSheetModal", () => {
+  let localVue: VueConstructor<Vue>;
+  let wrapper: Wrapper<Vue>;
+  let store: Store<CalChartState>;
+
+  beforeEach(() => {
+    localVue = createLocalVue();
+    localVue.use(Vuex);
+    localVue.use(Buefy);
+    store = generateStore();
+    wrapper = mount(StuntSheetModal, {
+      store,
+      localVue,
+    });
+  });
+
+  it("Stuntsheet title", async () => {
+    const title = wrapper.find('[data-test="ss-modal--title"]');
+    expect(title.exists()).toBeTruthy();
+    const stuntSheet: StuntSheet = store.getters.getSelectedStuntSheet;
+    expect((title.element as HTMLInputElement).value).toBe(stuntSheet.title);
+
+    title.setValue("Rainbow");
+    await wrapper.vm.$nextTick();
+
+    expect(stuntSheet.title).toBe("Rainbow");
+  });
+
+  it("Stuntsheet beats", async () => {
+    const beats = wrapper.find('[data-test="ss-modal--beats"]');
+    expect(beats.exists()).toBeTruthy();
+    const stuntSheet: StuntSheet = store.getters.getSelectedStuntSheet;
+    expect((beats.element as HTMLInputElement).value).toBe(
+      stuntSheet.beats.toString()
+    );
+
+    beats.setValue(2);
+    await wrapper.vm.$nextTick();
+
+    expect(stuntSheet.beats).toBe(2);
+  });
+
+  it("delete stuntsheet button does not show with 1 sheet", async () => {
+    store.state.show.stuntSheets = [new StuntSheet()];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-test="ss-modal--delete"]').exists()).toBe(false);
+  });
+
+  it("delete stuntsheet", async () => {
+    store.state.show.stuntSheets = [
+      new StuntSheet({ title: "a" }),
+      new StuntSheet({ title: "b" }),
+    ];
+    store.state.selectedSS = 0;
+    const parentCloseMock = jest.fn();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (wrapper.vm.$parent as any).close = parentCloseMock;
+    await wrapper.vm.$nextTick();
+
+    const deleteBtn = wrapper.find('[data-test="ss-modal--delete"]');
+    expect(deleteBtn.exists()).toBeTruthy();
+    expect(parentCloseMock).not.toHaveBeenCalled();
+    deleteBtn.trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(store.state.show.stuntSheets).toHaveLength(1);
+    expect(store.state.show.stuntSheets[0].title).toBe("b");
+    expect(parentCloseMock).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/models/util/LoadShow.spec.ts
+++ b/tests/unit/models/util/LoadShow.spec.ts
@@ -28,10 +28,10 @@ describe("models/util/LoadShow", () => {
       expect(show.stuntSheets[1].beats).toBe(4);
       expect(show.stuntSheets[0].stuntSheetDots.length).toBe(1);
       expect(show.stuntSheets[1].stuntSheetDots.length).toBe(1);
-      expect(show.stuntSheets[0].stuntSheetDots[0].x).toBe(0);
+      expect(show.stuntSheets[0].stuntSheetDots[0].x).toBe(16);
       expect(show.stuntSheets[0].stuntSheetDots[0].y).toBe(0);
-      expect(show.stuntSheets[1].stuntSheetDots[0].x).toBe(8);
-      expect(show.stuntSheets[1].stuntSheetDots[0].y).toBe(8);
+      expect(show.stuntSheets[1].stuntSheetDots[0].x).toBe(20);
+      expect(show.stuntSheets[1].stuntSheetDots[0].y).toBe(4);
     });
   });
 });

--- a/tests/unit/models/util/ParseCalChart34.spec.ts
+++ b/tests/unit/models/util/ParseCalChart34.spec.ts
@@ -22,10 +22,10 @@ describe("models/util/ParseCalChart34", () => {
       expect(show.stuntSheets[1].beats).toBe(4);
       expect(show.stuntSheets[0].stuntSheetDots.length).toBe(1);
       expect(show.stuntSheets[1].stuntSheetDots.length).toBe(1);
-      expect(show.stuntSheets[0].stuntSheetDots[0].x).toBe(0);
+      expect(show.stuntSheets[0].stuntSheetDots[0].x).toBe(16);
       expect(show.stuntSheets[0].stuntSheetDots[0].y).toBe(0);
-      expect(show.stuntSheets[1].stuntSheetDots[0].x).toBe(8);
-      expect(show.stuntSheets[1].stuntSheetDots[0].y).toBe(8);
+      expect(show.stuntSheets[1].stuntSheetDots[0].x).toBe(20);
+      expect(show.stuntSheets[1].stuntSheetDots[0].y).toBe(4);
     });
   });
 });

--- a/tests/unit/models/util/ParseCalChart3Utils.spec.ts
+++ b/tests/unit/models/util/ParseCalChart3Utils.spec.ts
@@ -219,13 +219,20 @@ describe("models/util/ParseCalChart3Utils", () => {
       }).toThrow("Offset is outside the bounds of the DataView");
     });
 
-    it("testing CalChart3 to 4 position convertions", () => {
-      expect(calChart3To4ConvertX(128)).toBe(176);
-      expect(calChart3To4ConvertX(-256)).toBe(128);
-      expect(calChart3To4ConvertX(0)).toBe(160);
-      expect(calChart3To4ConvertY(128)).toBe(100);
-      expect(calChart3To4ConvertY(-256)).toBe(52);
-      expect(calChart3To4ConvertY(0)).toBe(84);
+    it.each([
+      [128, 104],
+      [-256, 80],
+      [0, 96],
+    ])("calChart3To4ConvertX(%i) = %i", (input: number, output: number) => {
+      expect(calChart3To4ConvertX(input)).toBe(output);
+    });
+
+    it.each([
+      [128, 50],
+      [-256, 26],
+      [0, 42],
+    ])("calChart3To4ConvertY(%i) = %i", (input: number, output: number) => {
+      expect(calChart3To4ConvertY(input)).toBe(output);
     });
   });
 });

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -1,0 +1,72 @@
+import { CalChartState, generateStore } from "@/store";
+import { Store } from "vuex";
+import Show from "@/models/Show";
+import StuntSheet from "@/models/StuntSheet";
+
+describe("store/mutations", () => {
+  describe("incrementBeat", () => {
+    let store: Store<CalChartState>;
+    beforeAll(() => {
+      const stuntSheets = [
+        new StuntSheet({ beats: 2 }),
+        new StuntSheet({ beats: 2 }),
+      ];
+      store = generateStore({
+        show: new Show({ stuntSheets }),
+        selectedSS: 0,
+        beat: 2,
+      });
+    });
+
+    it("increments selectedSS at the end of stuntsheet", () => {
+      store.commit("incrementBeat");
+      expect(store.state.selectedSS).toBe(1);
+      expect(store.state.beat).toBe(1);
+    });
+
+    it("increments beat in the middle of a stuntsheet", () => {
+      store.commit("incrementBeat");
+      expect(store.state.selectedSS).toBe(1);
+      expect(store.state.beat).toBe(2);
+    });
+
+    it("does nothing at end of show", () => {
+      store.commit("incrementBeat");
+      expect(store.state.selectedSS).toBe(1);
+      expect(store.state.beat).toBe(2);
+    });
+  });
+
+  describe("decrementBeat", () => {
+    let store: Store<CalChartState>;
+    beforeAll(() => {
+      const stuntSheets = [
+        new StuntSheet({ beats: 2 }),
+        new StuntSheet({ beats: 2 }),
+      ];
+      store = generateStore({
+        show: new Show({ stuntSheets }),
+        selectedSS: 1,
+        beat: 1,
+      });
+    });
+
+    it("decrements selectedSS at the beginning of stuntsheet", () => {
+      store.commit("decrementBeat");
+      expect(store.state.selectedSS).toBe(0);
+      expect(store.state.beat).toBe(2);
+    });
+
+    it("decrements beat in the middle of a stuntsheet", () => {
+      store.commit("decrementBeat");
+      expect(store.state.selectedSS).toBe(0);
+      expect(store.state.beat).toBe(1);
+    });
+
+    it("does nothing at beginning of show", () => {
+      store.commit("decrementBeat");
+      expect(store.state.selectedSS).toBe(0);
+      expect(store.state.beat).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Updated https://github.com/calband/calchart-redesign/pull/68 to not use typescript in the E2E tests

- Change layout of whole app from flexbox to CSS grid
- MenuLeft
  - Select, add, remove, and edit stuntsheets
  - Control beat

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

![Screenshot from 2020-09-29 17-08-32](https://user-images.githubusercontent.com/13753033/94629023-79ee7800-0276-11eb-8e3c-1290b254f4de.png)
![Screenshot from 2020-09-29 17-08-46](https://user-images.githubusercontent.com/13753033/94629026-7a870e80-0276-11eb-93b3-7cf23b06beaf.png)
