### PR TITLE
Basic select next point tool and mode

### DIFF
--- a/src/components/menu-right/MenuRight.vue
+++ b/src/components/menu-right/MenuRight.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="menu-right">
+    <SetNextPoint />
     <p class="label">Dot Type Editor</p>
     <DotTypeEditor
       v-for="(dotType, index) in dotTypes"
@@ -20,6 +21,7 @@
 
 <script lang="ts">
 import DotTypeEditor from "./DotTypeEditor.vue";
+import SetNextPoint from "./SetNextPoint.vue";
 import BaseCont from "@/models/continuity/BaseCont";
 import Vue from "vue";
 import StuntSheet from "@/models/StuntSheet";
@@ -28,6 +30,7 @@ export default Vue.extend({
   name: "MenuRight",
   components: {
     DotTypeEditor,
+    SetNextPoint,
   },
   computed: {
     dotTypes(): BaseCont[][] {

--- a/src/components/menu-right/SetNextPoint.vue
+++ b/src/components/menu-right/SetNextPoint.vue
@@ -1,0 +1,54 @@
+<template>
+  <div>
+    <div class="mb-1 field">
+      <b-switch v-model="isSetNextPointMode" data-test="set-next-point--switch"
+        >Set Next Point Mode</b-switch
+      >
+    </div>
+    <div class="mb-4" v-if="isSetNextPointMode">
+      <b-message type="is-info" data-test="set-next-point--message">
+        <template v-if="isSetNextPointToolSelected">
+          <template v-if="currentSSDotIndex === null">
+            Select a dot from the <b>current</b> stunt sheet to start from.
+          </template>
+          <template v-else>
+            Select a dot from the <b>next</b> stunt sheet to end at.
+          </template>
+        </template>
+        <template v-else>
+          Select the <b>"Set Next Point"</b> tool in the bottom menu.
+        </template>
+      </b-message>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import BaseTool from "@/tools/BaseTool";
+import ToolSelectNextPoint from "@/tools/ToolSelectNextPoint";
+
+/**
+ * Component for guiding the user through the Set Next Point tool
+ */
+export default Vue.extend({
+  name: "SetNextPoint",
+  computed: {
+    isSetNextPointMode: {
+      get(): boolean {
+        return this.$store.state.isSetNextPointMode;
+      },
+      set(isSetNextPointMode: boolean): void {
+        this.$store.commit("setIsSetNextPointMode", isSetNextPointMode);
+      },
+    },
+    isSetNextPointToolSelected(): boolean {
+      return this.$store.state.toolSelected instanceof ToolSelectNextPoint;
+    },
+    currentSSDotIndex(): number | null {
+      const toolSelected: BaseTool = this.$store.state.toolSelected;
+      return toolSelected && toolSelected.currentSSDotIndex;
+    },
+  },
+});
+</script>

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -15,6 +15,10 @@ const getters: GetterTree<CalChartState, CalChartState> = {
   // Show -> StuntSheet
   getSelectedStuntSheet: (state): StuntSheet =>
     state.show.stuntSheets[state.selectedSS],
+  getNextStuntSheet: (state): StuntSheet | null =>
+    state.selectedSS + 1 < state.show.stuntSheets.length
+      ? state.show.stuntSheets[state.selectedSS + 1]
+      : null,
   getContinuity: (state) => (
     dotTypeIndex: number,
     continuityIndex: number

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -34,13 +34,15 @@ export class CalChartState extends Serializable<CalChartState> {
 
   yardlineNumbers = true;
 
-  grapherSvgPanZoom?: SvgPanZoom.Instance;
+  grapherSvgPanZoom: SvgPanZoom.Instance | null = null;
 
-  invertedCTMMatrix?: DOMMatrix;
+  invertedCTMMatrix: DOMMatrix | null = null;
 
-  toolSelected?: BaseTool;
+  toolSelected: BaseTool | null = null;
 
   grapherToolDots: StuntSheetDot[] = [];
+
+  isSetNextPointMode = false;
 
   constructor(json: Partial<CalChartState> = {}) {
     super();

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -10,6 +10,13 @@ import { GlobalStore } from "@/store";
  */
 export default abstract class BaseTool {
   /**
+   * Used in ToolSelectNextPoint. Put in BaseTool due to a circular dependency:
+   * ToolSingleDot -> BaseTool -> store/index -> store/mutations -> ToolSelectNextPoint -> BaseTool
+   * "TypeError: Class extends value undefined is not a constructor or null"
+   */
+  currentSSDotIndex: number | null = null;
+
+  /**
    * Approximates coordinate on the two step grid
    *
    * @param coordinate - Either the x or y coordinate
@@ -30,7 +37,7 @@ export default abstract class BaseTool {
     point.y = event.clientY;
 
     const invertedCTMMatrix = GlobalStore.state.invertedCTMMatrix;
-    if (invertedCTMMatrix === undefined) {
+    if (!invertedCTMMatrix) {
       throw new Error("No inverted ctm matrix");
     }
     const convertedPoint = point.matrixTransform(invertedCTMMatrix);
@@ -48,8 +55,4 @@ export default abstract class BaseTool {
   onMousemove(event: MouseEvent): void {}
   /* eslint-enable @typescript-eslint/no-unused-vars,
     @typescript-eslint/no-empty-function */
-}
-
-export interface ToolConstructor {
-  new (): BaseTool;
 }

--- a/src/tools/ToolPanZoom.ts
+++ b/src/tools/ToolPanZoom.ts
@@ -1,8 +1,6 @@
-import BaseTool, { ToolConstructor } from "./BaseTool";
+import BaseTool from "./BaseTool";
 
 /**
  * Enables pan and zoom functionality in svgPanZoom.
  */
-const ToolPanZoom: ToolConstructor = class ToolPanZoom extends BaseTool {};
-
-export default ToolPanZoom;
+export default class ToolPanZoom extends BaseTool {}

--- a/src/tools/ToolSelectNextPoint.ts
+++ b/src/tools/ToolSelectNextPoint.ts
@@ -1,0 +1,39 @@
+import BaseTool from "./BaseTool";
+import { GlobalStore } from "@/store";
+import StuntSheetDot from "@/models/StuntSheetDot";
+import StuntSheet from "@/models/StuntSheet";
+
+/**
+ * When in Set Next Point Mode, can set dots' dotLabelIndex and updates their flows
+ *
+ * @property currentSSDotIndex - The dot from the selected SS that has been clicked on
+ */
+export default class ToolSelectNextPoint extends BaseTool {
+  onClick(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event);
+
+    const stuntSheet: StuntSheet =
+      this.currentSSDotIndex === null
+        ? GlobalStore.getters.getSelectedStuntSheet
+        : GlobalStore.getters.getNextStuntSheet;
+    const existingDotIndex = stuntSheet.stuntSheetDots.findIndex(
+      (dot: StuntSheetDot): boolean => {
+        return x === dot.x && y === dot.y;
+      }
+    );
+
+    // Ignore if no dot found
+    if (existingDotIndex === -1) {
+      return;
+    }
+
+    if (this.currentSSDotIndex === null) {
+      GlobalStore.commit("updateToolSelectedNextPoint", existingDotIndex);
+    } else {
+      GlobalStore.commit("syncDotLabelIndices", {
+        currentSSDotIndex: this.currentSSDotIndex,
+        nextSSDotIndex: existingDotIndex,
+      });
+    }
+  }
+}

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -1,4 +1,4 @@
-import BaseTool, { ToolConstructor } from "./BaseTool";
+import BaseTool from "./BaseTool";
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
 import StuntSheet from "@/models/StuntSheet";
@@ -6,7 +6,7 @@ import StuntSheet from "@/models/StuntSheet";
 /**
  * Add or remove a single dot on click.
  */
-const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
+export default class ToolSingleDot extends BaseTool {
   onClick(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinates(event);
     const stuntSheet: StuntSheet = GlobalStore.getters.getSelectedStuntSheet;
@@ -26,6 +26,4 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
     const [x, y] = BaseTool.convertClientCoordinates(event);
     GlobalStore.commit("setGrapherToolDots", [new StuntSheetDot({ x, y })]);
   }
-};
-
-export default ToolSingleDot;
+}

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -4,7 +4,7 @@ describe("components/menu-bottom/MenuBottom", () => {
   });
 
   it("all buttons are rendered and pan/zoom is selected", () => {
-    cy.get('[data-test="menu-bottom--tooltip"]').should("have.length", 2);
+    cy.get('[data-test="menu-bottom--tooltip"]').should("have.length", 3);
 
     cy.get('[data-test="menu-bottom-tool--pan-zoom"]').should(
       "have.class",
@@ -13,7 +13,7 @@ describe("components/menu-bottom/MenuBottom", () => {
 
     cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
       "have.length",
-      1
+      2
     );
   });
 
@@ -25,7 +25,7 @@ describe("components/menu-bottom/MenuBottom", () => {
 
     cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
       "have.length",
-      1
+      2
     );
 
     // eslint-disable-next-line cypress/require-data-selectors

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -7,6 +7,7 @@ import MenuBottom from "@/components/menu-bottom/MenuBottom.vue";
 import ToolSingleDot from "@/tools/ToolSingleDot";
 import ToolPanZoom from "@/tools/ToolPanZoom";
 import BaseTool from "@/tools/BaseTool";
+import ToolSelectNextPoint from "@/tools/ToolSelectNextPoint";
 
 jest.mock("svg-pan-zoom", () => {
   return {
@@ -65,14 +66,14 @@ const setupHelper = () => {
 };
 
 describe("components/menu-bottom/MenuBottom", () => {
-  describe("tool buttons", () => {
-    let inverseMock: jest.Mock;
-    let getScreenCTMMock: jest.Mock;
-    let getElementsByClassNameMock: jest.Mock;
-    let grapherSvgPanZoom: SvgPanZoom.Instance;
-    let store: Store<CalChartState>;
-    let menu: Wrapper<Vue>;
+  let inverseMock: jest.Mock;
+  let getScreenCTMMock: jest.Mock;
+  let getElementsByClassNameMock: jest.Mock;
+  let grapherSvgPanZoom: SvgPanZoom.Instance;
+  let store: Store<CalChartState>;
+  let menu: Wrapper<Vue>;
 
+  describe("tool buttons", () => {
     beforeAll(() => {
       jest.clearAllMocks();
       ({
@@ -87,54 +88,54 @@ describe("components/menu-bottom/MenuBottom", () => {
 
     it("renders the correct amount of tools", () => {
       expect(menu.findAll('[data-test="menu-bottom--tooltip"]')).toHaveLength(
-        2
+        3
       );
     });
 
     it("on mount, selects the pan and zoom tool", () => {
-      const toolSelected = store.state.toolSelected as BaseTool;
-      expect(toolSelected).not.toBeUndefined();
-      expect(ToolPanZoom).toHaveBeenCalled();
-      expect(toolSelected.constructor).toBe(ToolPanZoom);
+      expect(store.state.toolSelected instanceof ToolPanZoom).toBe(true);
       const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
       expect(panZoomBtn.exists()).toBeTruthy();
       expect(panZoomBtn.props("type")).toBe("is-primary");
+      expect(panZoomBtn.attributes("disabled")).toBeFalsy();
     });
 
     it("add/remove single dot has type is-light when it is unselected", () => {
       const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
       expect(addRmBtn.props("type")).toBe("is-light");
+      expect(addRmBtn.attributes("disabled")).toBeFalsy();
     });
 
-    it(
-      "clicking add/remove single dot disables panning/zooming and " +
-        "calculates inverse matrix",
-      async () => {
-        expect(ToolSingleDot).not.toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disablePan).not.toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableZoom).not.toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableControlIcons).not.toHaveBeenCalled();
-        expect(inverseMock).not.toHaveBeenCalled();
-        expect(getScreenCTMMock).not.toHaveBeenCalled();
-        expect(getElementsByClassNameMock).not.toHaveBeenCalled();
+    it("set next point has type is-light and is disabled", () => {
+      const selectNextPointBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-next-point"]'
+      );
+      expect(selectNextPointBtn.props("type")).toBe("is-light");
+      expect(selectNextPointBtn.attributes("disabled")).toBeTruthy();
+    });
 
-        const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
-        addRmBtn.trigger("click");
-        await menu.vm.$nextTick();
+    it("clicking add/remove single dot disables panning/zooming and calculates inverse matrix", async () => {
+      expect(store.state.toolSelected instanceof ToolSingleDot).toBe(false);
+      expect(grapherSvgPanZoom.disablePan).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableZoom).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableControlIcons).not.toHaveBeenCalled();
+      expect(inverseMock).toHaveBeenCalledTimes(1);
+      expect(getScreenCTMMock).toHaveBeenCalledTimes(1);
+      expect(getElementsByClassNameMock).toHaveBeenCalledTimes(1);
 
-        expect(ToolSingleDot).toHaveBeenCalled();
-        const toolSelected = store.state.toolSelected as BaseTool;
-        expect(toolSelected).not.toBeUndefined();
-        expect(toolSelected.constructor).toBe(ToolSingleDot);
-        expect(addRmBtn.props("type")).toBe("is-primary");
-        expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableControlIcons).toHaveBeenCalled();
-        expect(inverseMock).toHaveBeenCalled();
-        expect(getScreenCTMMock).toHaveBeenCalled();
-        expect(getElementsByClassNameMock).toHaveBeenCalled();
-      }
-    );
+      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      addRmBtn.trigger("click");
+      await menu.vm.$nextTick();
+
+      expect(store.state.toolSelected instanceof ToolSingleDot).toBe(true);
+      expect(addRmBtn.props("type")).toBe("is-primary");
+      expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.disableControlIcons).toHaveBeenCalled();
+      expect(inverseMock).toHaveBeenCalledTimes(2);
+      expect(getScreenCTMMock).toHaveBeenCalledTimes(2);
+      expect(getElementsByClassNameMock).toHaveBeenCalledTimes(2);
+    });
 
     it("pan and zoom is no longer selected", () => {
       const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
@@ -142,28 +143,91 @@ describe("components/menu-bottom/MenuBottom", () => {
     });
 
     it("clicking pan and zoom enables panning/zooming", async () => {
-      expect(grapherSvgPanZoom.enablePan).not.toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableZoom).not.toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableControlIcons).not.toHaveBeenCalled();
+      expect(grapherSvgPanZoom.enablePan).toHaveBeenCalledTimes(1);
+      expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalledTimes(1);
+      expect(grapherSvgPanZoom.enableControlIcons).toHaveBeenCalledTimes(1);
 
       const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
       panZoomBtn.trigger("click");
       await menu.vm.$nextTick();
 
-      const toolSelected = store.state.toolSelected as BaseTool;
-      expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor).toBe(ToolPanZoom);
+      expect(store.state.toolSelected instanceof ToolPanZoom).toBe(true);
       expect(panZoomBtn.props("type")).toBe("is-primary");
-      expect(grapherSvgPanZoom.enablePan).toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableControlIcons).toHaveBeenCalled();
+      expect(grapherSvgPanZoom.enablePan).toHaveBeenCalledTimes(2);
+      expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalledTimes(2);
+      expect(grapherSvgPanZoom.enableControlIcons).toHaveBeenCalledTimes(2);
+    });
+
+    it("clicking set next point does nothing because it is disabled", async () => {
+      const selectNextPointBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-next-point"]'
+      );
+      selectNextPointBtn.trigger("click");
+      await menu.vm.$nextTick();
+
+      expect(store.state.toolSelected instanceof ToolPanZoom).toBe(true);
+    });
+  });
+
+  describe("tool buttons with isSetNextPointMode", () => {
+    beforeAll(() => {
+      jest.clearAllMocks();
+      ({
+        inverseMock,
+        getScreenCTMMock,
+        getElementsByClassNameMock,
+        grapherSvgPanZoom,
+        store,
+        menu,
+      } = setupHelper());
+      store.commit("setIsSetNextPointMode", true);
+    });
+
+    it("renders the correct amount of tools and no tool selected", () => {
+      expect(menu.findAll('[data-test="menu-bottom--tooltip"]')).toHaveLength(
+        3
+      );
+      expect(store.state.toolSelected).toBeNull();
+    });
+
+    it("pan and zoom tool has type is-light", () => {
+      const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
+      expect(panZoomBtn.exists()).toBeTruthy();
+      expect(panZoomBtn.props("type")).toBe("is-light");
+      expect(panZoomBtn.attributes("disabled")).toBeFalsy();
+    });
+
+    it("add/remove single dot has type is-light and is disabled", () => {
+      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      expect(addRmBtn.props("type")).toBe("is-light");
+      expect(addRmBtn.attributes("disabled")).toBeTruthy();
+    });
+
+    it("set next point has type is-light", () => {
+      const selectNextPointBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-next-point"]'
+      );
+      expect(selectNextPointBtn.props("type")).toBe("is-light");
+      expect(selectNextPointBtn.attributes("disabled")).toBeFalsy();
+    });
+
+    it("clicking the set next point tool switches the tool", async () => {
+      const selectNextPointBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-next-point"]'
+      );
+      selectNextPointBtn.trigger("click");
+      await menu.vm.$nextTick();
+
+      expect(store.state.toolSelected instanceof ToolSelectNextPoint).toBe(
+        true
+      );
+      expect(selectNextPointBtn.props("type")).toBe("is-primary");
+      const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
+      expect(panZoomBtn.props("type")).toBe("is-light");
     });
   });
 
   describe("onKeyDown", () => {
-    let store: Store<CalChartState>;
-    let menu: Wrapper<Vue>;
-
     beforeEach(() => {
       ({ store, menu } = setupHelper());
 
@@ -209,9 +273,6 @@ describe("components/menu-bottom/MenuBottom", () => {
   });
 
   describe("onKeyUp", () => {
-    let store: Store<CalChartState>;
-    let menu: Wrapper<Vue>;
-
     beforeEach(() => {
       jest.clearAllMocks();
       ({ store, menu } = setupHelper());

--- a/tests/unit/components/menu-right/MenuRight.spec.ts
+++ b/tests/unit/components/menu-right/MenuRight.spec.ts
@@ -3,6 +3,7 @@ import Buefy from "buefy";
 import { generateStore, CalChartState } from "@/store";
 import Vuex, { Store } from "vuex";
 import MenuRight from "@/components/menu-right/MenuRight.vue";
+import SetNextPoint from "@/components/menu-right/SetNextPoint.vue";
 import DotTypeEditor from "@/components/menu-right/DotTypeEditor.vue";
 import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
@@ -37,6 +38,11 @@ describe("components/menu-right/MenuRight", () => {
       store,
       localVue,
     });
+  });
+
+  it("renders SetNextPoint", () => {
+    const setNextPoint = menu.findComponent(SetNextPoint);
+    expect(setNextPoint.exists()).toBe(true);
   });
 
   it("renders all dot type editors", () => {

--- a/tests/unit/components/menu-right/SetNextPoint.spec.ts
+++ b/tests/unit/components/menu-right/SetNextPoint.spec.ts
@@ -1,0 +1,62 @@
+import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
+import Buefy from "buefy";
+import { generateStore, CalChartState } from "@/store";
+import Vuex, { Store } from "vuex";
+import SetNextPoint from "@/components/menu-right/SetNextPoint.vue";
+import ToolSelectNextPoint from "@/tools/ToolSelectNextPoint";
+
+describe("components/menu-right/SetNextPoint", () => {
+  let setNextPoint: Wrapper<Vue>;
+  let store: Store<CalChartState>;
+  let tool: ToolSelectNextPoint;
+
+  beforeAll(() => {
+    // Mock out store and mount
+    const localVue = createLocalVue();
+    localVue.use(Vuex);
+    localVue.use(Buefy);
+    store = generateStore();
+    setNextPoint = mount(SetNextPoint, {
+      store,
+      localVue,
+    });
+    tool = new ToolSelectNextPoint();
+  });
+
+  it("toggles on set next point mode on click", async () => {
+    expect(store.state.isSetNextPointMode).toBe(false);
+    expect(
+      setNextPoint.find('[data-test="set-next-point--message"]').exists()
+    ).toBe(false);
+    const switchBtn = setNextPoint.find('[data-test="set-next-point--switch"]');
+    expect(switchBtn.exists());
+    switchBtn.trigger("click");
+    await setNextPoint.vm.$nextTick();
+    expect(store.state.isSetNextPointMode).toBe(true);
+    const message = setNextPoint.find('[data-test="set-next-point--message"]');
+    expect(message.exists()).toBe(true);
+    expect(message.text()).toBe(
+      'Select the "Set Next Point" tool in the bottom menu.'
+    );
+  });
+
+  it("updates the message upon selecting the next point tool", async () => {
+    store.commit("setToolSelected", tool);
+    await setNextPoint.vm.$nextTick();
+    const message = setNextPoint.find('[data-test="set-next-point--message"]');
+    expect(message.exists()).toBe(true);
+    expect(message.text()).toBe(
+      "Select a dot from the current stunt sheet to start from."
+    );
+  });
+
+  it("updates the message upon selecting a dot", async () => {
+    store.commit("updateToolSelectedNextPoint", 0);
+    await setNextPoint.vm.$nextTick();
+    const message = setNextPoint.find('[data-test="set-next-point--message"]');
+    expect(message.exists()).toBe(true);
+    expect(message.text()).toBe(
+      "Select a dot from the next stunt sheet to end at."
+    );
+  });
+});

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -5,9 +5,51 @@ import StuntSheet from "@/models/StuntSheet";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import ContEven from "@/models/continuity/ContEven";
+import StuntSheetDot from "@/models/StuntSheetDot";
 
 describe("store/mutations", () => {
   let store: Store<CalChartState>;
+
+  describe("syncDotLabelIndices", () => {
+    // TODO: Update and add tests upon updating syncDotLabelIndices
+    beforeEach(() => {
+      store = generateStore({
+        show: new Show({
+          stuntSheets: [
+            new StuntSheet({
+              dotTypes: [[new ContETFDynamic(), new ContInPlace()]],
+              stuntSheetDots: [
+                new StuntSheetDot({ x: 0, y: 0 }),
+                new StuntSheetDot({ x: 2, y: 2 }),
+              ],
+            }),
+            new StuntSheet({
+              stuntSheetDots: [
+                new StuntSheetDot({ x: 0, y: 4 }),
+                new StuntSheetDot({ x: 2, y: 4 }),
+              ],
+            }),
+          ],
+        }),
+      });
+    });
+
+    it("updates current and next dot label indices", () => {
+      const dots = store.state.show.stuntSheets[0].stuntSheetDots;
+      expect(dots[0].dotLabelIndex).toBeNull();
+      expect(dots[1].dotLabelIndex).toBeNull();
+      store.commit("syncDotLabelIndices", {
+        currentSSDotIndex: 1,
+        nextSSDotIndex: 0,
+      });
+      const updatedDots = store.state.show.stuntSheets[0].stuntSheetDots;
+      expect(updatedDots[0].dotLabelIndex).toBeNull();
+      expect(updatedDots[1].dotLabelIndex).toBe(0);
+      const nextSSDots = store.state.show.stuntSheets[1].stuntSheetDots;
+      expect(nextSSDots[0].dotLabelIndex).toBe(0);
+      expect(nextSSDots[1].dotLabelIndex).toBeNull();
+    });
+  });
 
   describe("addDotType", () => {
     beforeEach(() => {

--- a/tests/unit/tools/ToolSelectNextPoint.spec.ts
+++ b/tests/unit/tools/ToolSelectNextPoint.spec.ts
@@ -1,0 +1,57 @@
+import ToolSelectNextPoint from "@/tools/ToolSelectNextPoint";
+import { GlobalStore } from "@/store";
+import BaseTool from "@/tools/BaseTool";
+import StuntSheet from "@/models/StuntSheet";
+import StuntSheetDot from "@/models/StuntSheetDot";
+import Show from "@/models/Show";
+
+describe("tools/ToolSelectNextPoint", () => {
+  describe("onClick", () => {
+    beforeAll(() => {
+      const currentSS = new StuntSheet({
+        stuntSheetDots: [
+          new StuntSheetDot({
+            x: 0,
+            y: 2,
+          }),
+        ],
+      });
+      const nextSS = new StuntSheet({
+        stuntSheetDots: [
+          new StuntSheetDot({
+            x: 4,
+            y: 4,
+          }),
+        ],
+      });
+      GlobalStore.commit(
+        "setShow",
+        new Show({
+          stuntSheets: [currentSS, nextSS],
+        })
+      );
+      GlobalStore.commit("setToolSelected", new ToolSelectNextPoint());
+    });
+
+    it("the first click selects the current stuntsheet's dot", () => {
+      BaseTool.convertClientCoordinates = jest.fn().mockReturnValue([0, 2]);
+      const tool = GlobalStore.state.toolSelected as ToolSelectNextPoint;
+      expect(tool.currentSSDotIndex).toBeNull();
+      tool.onClick(new MouseEvent("click"));
+      expect(tool.currentSSDotIndex).toBe(0);
+    });
+
+    it("the second click selects the next stuntsheet's dot", () => {
+      BaseTool.convertClientCoordinates = jest.fn().mockReturnValue([4, 4]);
+      const tool = GlobalStore.state.toolSelected as ToolSelectNextPoint;
+      const stuntSheets = GlobalStore.state.show.stuntSheets;
+      expect(stuntSheets[0].stuntSheetDots[0].dotLabelIndex).toBeNull();
+      expect(stuntSheets[1].stuntSheetDots[0].dotLabelIndex).toBeNull();
+      tool.onClick(new MouseEvent("click"));
+      expect(tool.currentSSDotIndex).toBeNull();
+      const updatedStuntSheets = GlobalStore.state.show.stuntSheets;
+      expect(updatedStuntSheets[0].stuntSheetDots[0].dotLabelIndex).toBe(0);
+      expect(updatedStuntSheets[1].stuntSheetDots[0].dotLabelIndex).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a mode called "Set Next Point". It shows "ghost dots" from the next stuntsheet and the flows that get to the next dot. The user can connect dots from the currently selected stuntsheet to the next stuntsheet.

A lot of this is a rough draft... I expect a lot of this to change in the coming months! But for an MVP I think this gets us to where we want to be.

TODO: I need to re-do how dots connect to each other. dotLabelIndex isn't effective.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

![Screenshot_2020-10-28 Calchart](https://user-images.githubusercontent.com/13753033/97529661-9d880980-196d-11eb-8dc2-f42286d53102.png)


