### PR TITLE
Selection and move

### DIFF
--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -3,8 +3,9 @@
     <svg
       class="grapher--svg"
       data-test="grapher--svg"
-      @click.prevent="onClick"
-      @mousemove="onMousemove"
+      @mousedown="onMouseDown"
+      @mouseup="onMouseUp"
+      @mousemove="onMouseMove"
     >
       <!-- Note:Inside svg, 1px = 1 eight-to-five step -->
       <g class="grapher--wrapper" data-test="grapher--wrapper">
@@ -53,13 +54,17 @@ export default Vue.extend({
     onResize(): void {
       this.$store.state.grapherSvgPanZoom.resize();
     },
-    onClick(event: MouseEvent): void {
+    onMouseDown(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
-      toolSelected.onClick(event);
+      toolSelected.onMouseDown(event);
     },
-    onMousemove(event: MouseEvent): void {
+    onMouseUp(event: MouseEvent): void {
       const toolSelected: BaseTool = this.$store.state.toolSelected;
-      toolSelected.onMousemove(event);
+      toolSelected.onMouseUp(event);
+    },
+    onMouseMove(event: MouseEvent): void {
+      const toolSelected: BaseTool = this.$store.state.toolSelected;
+      toolSelected.onMouseMove(event);
     },
   },
 });

--- a/src/components/grapher/GrapherDots.vue
+++ b/src/components/grapher/GrapherDots.vue
@@ -1,7 +1,7 @@
 <template>
   <g class="grapher-dots--dots-container">
     <circle
-      v-for="dot in stuntSheetDots"
+      v-for="dot in stuntSheetDotsUnselected"
       :key="`${dot.x}-${dot.y}-dots--dot`"
       class="grapher-dots--dot"
       :cx="dot.xAtBeat(beat - 1)"
@@ -9,16 +9,37 @@
       r="0.7"
       data-test="grapher-dots--dot"
     />
+    <circle
+      v-for="dot in stuntSheetDotsSelected"
+      :key="`${dot.x}-${dot.y}-dots--dot-selected`"
+      class="grapher-dots--dot-selected"
+      :cx="dot.xAtBeat(beat - 1)"
+      :cy="dot.yAtBeat(beat - 1)"
+      r="0.7"
+      data-test="grapher-dots--dot-selected"
+    />
     <g v-if="showDotLabels">
       <text
-        v-for="(dot, index) in stuntSheetDots"
-        :key="`${dot.x}-${dot.y}-dots--dottext`"
+        v-for="dot in dotLabelsUnselected"
+        :key="`${dot[0].x}-${dot[0].y}-dots--dottext`"
         class="grapher-dots--dottext"
-        :x="dot.xAtBeat(beat - 1)"
-        :y="dot.yAtBeat(beat - 1) - 1"
+        :x="dot[0].xAtBeat(beat - 1)"
+        :y="dot[0].yAtBeat(beat - 1) - 1"
         data-test="grapher-dots--dottext"
       >
-        {{ dotLabels[index] }}
+        {{ dot[1] }}
+      </text>
+    </g>
+    <g v-if="showDotLabels">
+      <text
+        v-for="dot in dotLabelsSelected"
+        :key="`${dot[0].x}-${dot[0].y}-dots--dottext-selected`"
+        class="grapher-dots--dottext-selected"
+        :x="dot[0].xAtBeat(beat - 1)"
+        :y="dot[0].yAtBeat(beat - 1) - 1"
+        data-test="grapher-dots--dottext-selected"
+      >
+        {{ dot[1] }}
       </text>
     </g>
   </g>
@@ -27,7 +48,6 @@
 <script lang="ts">
 import Vue from "vue";
 import StuntSheetDot from "@/models/StuntSheetDot";
-import StuntSheet from "@/models/StuntSheet";
 
 /**
  * Renders the dots of the current stunt sheet.
@@ -39,20 +59,50 @@ export default Vue.extend({
       return this.$store.state.showDotLabels;
     },
     stuntSheetDots(): StuntSheetDot[] {
-      const currentSS: StuntSheet = this.$store.getters.getSelectedStuntSheet;
-      return currentSS.stuntSheetDots;
+      return this.$store.getters.getSelectedStuntSheet.stuntSheetDots;
     },
-    dotLabels(): string[] {
+    stuntSheetDotsUnselected(): StuntSheetDot[] {
+      const selectedDots = this.$store.state.selectedDots;
+      return this.stuntSheetDots.filter((dot: StuntSheetDot, index: number) => {
+        return !selectedDots.includes(index);
+      });
+    },
+    stuntSheetDotsSelected(): StuntSheetDot[] {
+      const selectedDots = this.$store.state.selectedDots;
+      return this.stuntSheetDots.filter((dot: StuntSheetDot, index: number) => {
+        return selectedDots.includes(index);
+      });
+    },
+    dotLabels(): [StuntSheetDot, string][] {
       const dotLabels = this.$store.getters.getDotLabels;
       const dots: StuntSheetDot[] = this.$store.getters.getSelectedStuntSheet
         .stuntSheetDots;
       return dots.map((dot, index) => {
-        return dotLabels !== null &&
+        return [
+          dot,
+          dotLabels !== null &&
           dot.dotLabelIndex !== null &&
           dot.dotLabelIndex < dotLabels.length
-          ? dotLabels[dot.dotLabelIndex]
-          : index.toString();
+            ? dotLabels[dot.dotLabelIndex]
+            : index.toString(),
+        ];
       });
+    },
+    dotLabelsUnselected(): [StuntSheetDot, string][] {
+      const selectedDots = this.$store.state.selectedDots;
+      return this.dotLabels.filter(
+        (dotLabel: [StuntSheetDot, string], index: number) => {
+          return !selectedDots.includes(index);
+        }
+      );
+    },
+    dotLabelsSelected(): [StuntSheetDot, string][] {
+      const selectedDots = this.$store.state.selectedDots;
+      return this.dotLabels.filter(
+        (dotLabel: [StuntSheetDot, string], index: number) => {
+          return selectedDots.includes(index);
+        }
+      );
     },
     beat: {
       get(): number {
@@ -64,8 +114,26 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
+.grapher-dots--dot-selected {
+  fill: $yellow;
+}
+
 .grapher-dots--dottext {
   fill: $black;
+  font-size: 1px;
+  text-anchor: left;
+  user-select: none;
+}
+
+.grapher-dots--dottext-selected {
+  fill: $yellow;
+  font-size: 1px;
+  text-anchor: left;
+  user-select: none;
+}
+
+.grapher-dots--dottext-selected {
+  fill: $yellow;
   font-size: 2px;
   text-anchor: left;
   user-select: none;

--- a/src/components/grapher/GrapherTool.vue
+++ b/src/components/grapher/GrapherTool.vue
@@ -9,6 +9,25 @@
       r="0.7"
       data-test="grapher-tool--dot"
     />
+    <g v-if="showDotLabels">
+      <text
+        v-for="dot in grapherToolDotLabels"
+        :key="`${dot[0].x}-${dot[0].y}-tool--dottext`"
+        class="grapher-tool--dottext"
+        :x="dot[0].x"
+        :y="dot[0].y - 1"
+        data-test="grapher-tool--dottext"
+      >
+        {{ dot[1] }}
+      </text>
+    </g>
+    <polyline
+      v-if="showSelectionLasso"
+      class="grapher-tool--selection-lasso"
+      :points="selectionLasso"
+      fill="none"
+      data-test="grapher-tool--selection-lasso"
+    />
   </g>
 </template>
 
@@ -25,6 +44,34 @@ export default Vue.extend({
     grapherToolDots(): StuntSheetDot[] {
       return this.$store.state.grapherToolDots;
     },
+    showDotLabels(): boolean {
+      return this.$store.state.showDotLabels;
+    },
+    grapherToolDotLabels(): [StuntSheetDot, string][] {
+      const dotLabels = this.$store.getters.getDotLabels;
+      const dots: StuntSheetDot[] = this.grapherToolDots;
+      return dots.map((dot) => {
+        return [
+          dot,
+          dotLabels !== null &&
+          dot.dotLabelIndex !== null &&
+          dot.dotLabelIndex < dotLabels.length
+            ? dotLabels[dot.dotLabelIndex]
+            : "",
+        ];
+      });
+    },
+    showSelectionLasso(): boolean {
+      return this.$store.state.showSelectionLasso;
+    },
+    selectionLasso(): string {
+      // construct a string ready to be used by polyline.  See:
+      // https://developer.mozilla.org/en-US/docs/Web/SVG/Element/polyline
+      const lassoPointStrings: string[] = this.$store.state.selectionLasso.map(
+        (point: [number, number]) => point.join(",")
+      );
+      return lassoPointStrings.join(" ");
+    },
   },
 });
 </script>
@@ -33,7 +80,13 @@ export default Vue.extend({
 .grapher-tool--dot {
   opacity: 0.5;
 }
-.grapher-tool--box {
+.grapher-tool--dottext {
+  fill: $black;
+  font-size: 1px;
+  text-anchor: left;
+  user-select: none;
+}
+.grapher-tool--selection-lasso {
   stroke: $yellow;
   stroke-width: 0.5;
   opacity: 0.5;

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -24,7 +24,8 @@
  */
 import Vue from "vue";
 import BaseTool, { ToolConstructor } from "@/tools/BaseTool";
-import ToolPanZoom from "@/tools/ToolPanZoom";
+import ToolBoxSelect from "@/tools/ToolBoxSelect";
+import ToolLassoSelect from "@/tools/ToolLassoSelect";
 import ToolSingleDot from "@/tools/ToolSingleDot";
 
 interface ToolData {
@@ -39,14 +40,19 @@ export default Vue.extend({
   data: (): {
     toolDataList: ToolData[];
     toolSelectedIndex: number;
-    temporaryTool: BaseTool | null;
   } => ({
     toolDataList: [
       {
-        label: "Pan and Zoom (Hold Ctrl/Meta to turn on)",
+        label: "Drag Box to select, shift to add, shift+alt/option to toggle",
         icon: "hand-right",
-        tool: ToolPanZoom,
-        "data-test": "pan-zoom",
+        tool: ToolBoxSelect,
+        "data-test": "select-box-move",
+      },
+      {
+        label: "Lasso to select, shift to add, shift+alt/option to toggle",
+        icon: "pencil",
+        tool: ToolLassoSelect,
+        "data-test": "select-lasso-move",
       },
       {
         label: "Add and Remove Single Dot",
@@ -56,52 +62,9 @@ export default Vue.extend({
       },
     ],
     toolSelectedIndex: 0, // Assume that 0 is the pan/zoom tool
-    temporaryTool: null, // Used to hold last tool when ctrl/meta is held
   }),
-  watch: {
-    toolSelectedIndex(newIndex: number, oldIndex: number): void {
-      /**
-       * Calculate inverted CTM matrix that is used to convert ClientX/Y to
-       * X/Y of the SVG
-       */
-      const wrapper = document.getElementsByClassName(
-        "grapher--wrapper"
-      )[0] as SVGGElement;
-      const ctm = wrapper.getScreenCTM();
-      if (!ctm) {
-        throw new Error("Unable to retrieve wrapper CTM");
-      }
-      const invertedMatrix = ctm.inverse();
-      this.$store.commit("setInvertedCTMMatrix", invertedMatrix);
-
-      // Enable or disable pan/zoom depending on tool selected
-      // eslint-disable-next-line no-undef
-      const grapherSvgPanZoom: SvgPanZoom.Instance | undefined = this.$store
-        .state.grapherSvgPanZoom;
-      if (grapherSvgPanZoom === undefined) {
-        throw new Error("There is no grapher pan zoom instance");
-      }
-
-      if (newIndex === 0 && oldIndex !== 0) {
-        grapherSvgPanZoom.enablePan();
-        grapherSvgPanZoom.enableZoom();
-        grapherSvgPanZoom.enableControlIcons();
-      } else if (oldIndex === 0 && newIndex !== 0) {
-        grapherSvgPanZoom.disablePan();
-        grapherSvgPanZoom.disableZoom();
-        grapherSvgPanZoom.disableControlIcons();
-      }
-    },
-  },
   mounted() {
     this.setTool(this.$data.toolSelectedIndex);
-
-    document.addEventListener("keydown", this.onKeyDown);
-    document.addEventListener("keyup", this.onKeyUp);
-  },
-  beforeDestroy() {
-    document.removeEventListener("keydown", this.onKeyDown);
-    document.removeEventListener("keyup", this.onKeyUp);
   },
   methods: {
     setTool(toolIndex: number): void {
@@ -111,38 +74,6 @@ export default Vue.extend({
       ].tool;
       const tool: BaseTool = new ToolConstructor();
       this.$store.commit("setToolSelected", tool);
-    },
-    isCtrl(event: KeyboardEvent): boolean {
-      /**
-       * Capture both Ctrl and Meta key (Cmd on Mac or Windows logo key)
-       * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
-       * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
-       */
-      return (
-        event.key === "Control" ||
-        event.key === "Meta" ||
-        event.keyCode === 17 ||
-        event.keyCode === 91
-      );
-    },
-    onKeyDown(event: KeyboardEvent): void {
-      if (event.repeat || !this.isCtrl(event)) return;
-
-      this.$data.temporaryTool = this.$store.state.toolSelected;
-      this.setTool(0);
-    },
-    onKeyUp(event: KeyboardEvent): void {
-      if (!this.isCtrl(event) || this.$data.temporaryTool === null) return;
-
-      // We do not use this.setTool to avoid reinitializing the previous tool
-      const temporaryTool: BaseTool = this.$data.temporaryTool;
-      this.$store.commit("setToolSelected", temporaryTool);
-      this.$data.toolSelectedIndex = this.$data.toolDataList.findIndex(
-        (toolData: ToolData): boolean => {
-          return toolData.tool === temporaryTool.constructor;
-        }
-      );
-      this.$data.temporaryTool = null;
     },
   },
 });

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -51,4 +51,12 @@ export default class StuntSheet extends Serializable<StuntSheet> {
   removeDot(index: number): void {
     this.stuntSheetDots.splice(index, 1);
   }
+
+  moveDot(index: number, position: [number, number]): void {
+    if (index >= this.stuntSheetDots.length) {
+      return;
+    }
+    this.stuntSheetDots[index].x = position[0];
+    this.stuntSheetDots[index].y = position[1];
+  }
 }

--- a/src/models/util/Lasso.ts
+++ b/src/models/util/Lasso.ts
@@ -1,0 +1,56 @@
+/**
+ * Functions that determine if a point is within a lasso using the even-odd rule.  See: https://en.wikipedia.org/wiki/Even–odd_rule
+ */
+
+/**
+ * CrossesLine
+ * https://en.wikipedia.org/wiki/Even–odd_rule
+ */
+function CrossesLine(
+  start: [number, number],
+  end: [number, number],
+  p: [number, number]
+): boolean {
+  if (start[1] > end[1]) {
+    if (!(p[1] <= start[1] && p[1] > end[1])) {
+      return false;
+    }
+  } else {
+    if (!(p[1] <= end[1] && p[1] > start[1])) {
+      return false;
+    }
+  }
+  return (
+    p[0] >=
+    ((end[0] - start[0]) * (p[1] - start[1])) / (end[1] - start[1]) + start[0]
+  );
+}
+
+/**
+ * InsideLasso
+ *
+ * @param lasso Array of points representing a selection lasso.
+ * @param point Point to check.
+ * @returns Boolean to indicate if the point is inside the lasso.
+ */
+export const InsideLasso = (
+  lasso: [number, number][],
+  point: [number, number]
+): boolean => {
+  // Test if inside polygon using odd-even rule
+  let parity = false;
+  if (lasso.length < 2) {
+    return parity;
+  }
+  for (let i = 0; i < lasso.length - 1; i++) {
+    if (CrossesLine(lasso[i], lasso[i + 1], point)) {
+      parity = !parity;
+    }
+  }
+  // don't forget the first one:
+  if (CrossesLine(lasso[lasso.length - 1], lasso[0], point)) {
+    parity = !parity;
+  }
+
+  return parity;
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,9 +40,14 @@ export class CalChartState extends Serializable<CalChartState> {
 
   invertedCTMMatrix?: DOMMatrix;
 
+  selectedDots: number[] = [];
+
   toolSelected?: BaseTool;
 
   grapherToolDots: StuntSheetDot[] = [];
+
+  showSelectionLasso = true;
+  selectionLasso: [number, number][] = [];
 
   constructor(json: Partial<CalChartState> = {}) {
     super();

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -53,6 +53,16 @@ const mutations: MutationTree<CalChartState> = {
     const currentSS = getSelectedStuntSheet(state);
     currentSS.addDot(dot);
   },
+  moveDot(
+    state,
+    { index, position }: { index: number; position: [number, number] }
+  ): void {
+    const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+      state: CalChartState
+    ) => StuntSheet;
+    const currentSS = getSelectedStuntSheet(state);
+    currentSS.moveDot(index, position);
+  },
   setStuntSheetTitle(state, title: string): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
@@ -178,6 +188,30 @@ const mutations: MutationTree<CalChartState> = {
   },
   setGrapherToolDots(state, grapherToolDots: StuntSheetDot[]): void {
     state.grapherToolDots = grapherToolDots;
+  },
+
+  // selection
+  clearSelectedDots(state): void {
+    state.selectedDots = [];
+  },
+  addSelectedDots(state, dots: number[]): void {
+    dots.forEach((dot) => {
+      state.selectedDots.indexOf(dot) < 0 && state.selectedDots.push(dot);
+    });
+  },
+  toggleSelectedDots(state, dots: number[]): void {
+    // first remove all the items passed in.
+    dots.forEach((v) => {
+      const index = state.selectedDots.indexOf(v);
+      if (index > -1) {
+        state.selectedDots.splice(index, 1);
+      } else {
+        state.selectedDots.push(v);
+      }
+    });
+  },
+  setSelectionLasso(state, lasso: [number, number][]): void {
+    state.selectionLasso = lasso;
   },
 };
 

--- a/src/tools/BaseMoveTool.ts
+++ b/src/tools/BaseMoveTool.ts
@@ -1,0 +1,58 @@
+import { GlobalStore } from "@/store";
+import BaseTool from "./BaseTool";
+
+/**
+ * BaseMoveTool handles the basics of panning the field when meta/alt key is
+ * pressed.  Derived tools implement onMouseDown/Up/Move to do tool specific
+ * actions.
+ */
+export default abstract class BaseMoveTool {
+  static enablePan(enable: boolean): void {
+    const grapherSvgPanZoom: SvgPanZoom.Instance | undefined =
+      GlobalStore.state.grapherSvgPanZoom;
+    if (grapherSvgPanZoom === undefined) {
+      throw new Error("There is no grapher pan zoom instance");
+    }
+    if (enable) {
+      grapherSvgPanZoom.enablePan();
+    } else {
+      grapherSvgPanZoom.disablePan();
+    }
+  }
+
+  /**
+   * onMouseDown:  Enabling panning if meta/ctrl key is pressed, otherwise call
+   * out to the subclass to determine the action to take on mouse down.
+   */
+  onMouseDown(event: MouseEvent): void {
+    if (event.metaKey || event.ctrlKey) {
+      BaseMoveTool.enablePan(true);
+      return;
+    }
+    BaseMoveTool.enablePan(false);
+
+    BaseTool.updateInvertedCTMMatrix();
+    this.onMouseDownInternal(event);
+  }
+
+  onMouseUp(event: MouseEvent): void {
+    BaseTool.updateInvertedCTMMatrix();
+    this.onMouseUpInternal(event);
+  }
+
+  onMouseMove(event: MouseEvent): void {
+    BaseTool.updateInvertedCTMMatrix();
+    this.onMouseMoveInternal(event);
+  }
+
+  // override these functions in the extended classes
+  /* eslint-disable @typescript-eslint/no-unused-vars,
+    @typescript-eslint/no-empty-function */
+  onMouseDownInternal(event: MouseEvent): void {}
+
+  onMouseUpInternal(event: MouseEvent): void {}
+
+  onMouseMoveInternal(event: MouseEvent): void {}
+  /* eslint-enable @typescript-eslint/no-unused-vars,
+    @typescript-eslint/no-empty-function */
+}

--- a/src/tools/ToolBoxSelect.ts
+++ b/src/tools/ToolBoxSelect.ts
@@ -1,0 +1,24 @@
+import { ToolConstructor } from "./BaseTool";
+import { ToolSelectMove } from "./ToolSelectMove";
+import { GlobalStore } from "@/store";
+
+/**
+ * Enables Selection, Moving, and Panning via base class
+ * This Tool creates a rectangle as a lasso.
+ */
+const ToolBoxSelect: ToolConstructor = class ToolBoxSelect extends ToolSelectMove {
+  onNewMouseMoveSelection(point: [number, number]): void {
+    if (this.selectionLassoStart === null) {
+      return;
+    }
+    GlobalStore.commit("setSelectionLasso", [
+      [this.selectionLassoStart[0], this.selectionLassoStart[1]],
+      [point[0], this.selectionLassoStart[1]],
+      [point[0], point[1]],
+      [this.selectionLassoStart[0], point[1]],
+      [this.selectionLassoStart[0], this.selectionLassoStart[1]],
+    ]);
+  }
+};
+
+export default ToolBoxSelect;

--- a/src/tools/ToolLassoSelect.ts
+++ b/src/tools/ToolLassoSelect.ts
@@ -1,0 +1,20 @@
+import { ToolConstructor } from "./BaseTool";
+import { ToolSelectMove } from "./ToolSelectMove";
+import { GlobalStore } from "@/store";
+
+/**
+ * Enables Selection, Moving, and Panning via base class
+ * This Tool creates an arbitrary path as a lasso.
+ */
+const ToolLassoSelect: ToolConstructor = class ToolLassoSelect extends ToolSelectMove {
+  onNewMouseMoveSelection(point: [number, number]): void {
+    if (this.selectionLassoStart === null) {
+      return;
+    }
+    const arrayCopy = GlobalStore.state.selectionLasso;
+    arrayCopy.push(point);
+    GlobalStore.commit("setSelectionLasso", arrayCopy);
+  }
+};
+
+export default ToolLassoSelect;

--- a/src/tools/ToolPanZoom.ts
+++ b/src/tools/ToolPanZoom.ts
@@ -1,8 +1,0 @@
-import BaseTool, { ToolConstructor } from "./BaseTool";
-
-/**
- * Enables pan and zoom functionality in svgPanZoom.
- */
-const ToolPanZoom: ToolConstructor = class ToolPanZoom extends BaseTool {};
-
-export default ToolPanZoom;

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -1,0 +1,146 @@
+import BaseTool from "./BaseTool";
+import BaseMoveTool from "./BaseMoveTool";
+import { GlobalStore } from "@/store";
+import StuntSheetDot from "@/models/StuntSheetDot";
+import { InsideLasso } from "@/models/util/Lasso";
+
+/**
+ * Enables Selection and Moving.
+ * Selections are additive with the shift key, and toggle with the option/alt key.
+ * If a dot targeted on mouse down, that treats it as a selection, and transition to mouse move.
+ * If a dot is not targeted on mouse down, that starts a new selection.  Subclass this to create box or lasso selectors.
+ * If doing a mouse move, translate all the dots by the amount we've moved.
+ */
+export abstract class ToolSelectMove extends BaseMoveTool {
+  private moveToolStart: [number, number] | null = null;
+  protected selectionLassoStart: [number, number] | null = null;
+
+  onMouseDownInternal(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event);
+    const existingDotIndex = BaseTool.findDotAtEvent(event);
+
+    // reset what we are doing
+    this.moveToolStart = null;
+    this.selectionLassoStart = null;
+
+    if (existingDotIndex !== -1) {
+      // if we click on a selected dot, determine if we are toggling selection.
+      if (GlobalStore.state.selectedDots.includes(existingDotIndex)) {
+        if (event.altKey) {
+          GlobalStore.commit("toggleSelectedDots", [existingDotIndex]);
+        }
+      } else {
+        if (!event.shiftKey) {
+          GlobalStore.commit("clearSelectedDots");
+        }
+        if (event.altKey) {
+          GlobalStore.commit("toggleSelectedDots", [existingDotIndex]);
+        } else {
+          GlobalStore.commit("addSelectedDots", [existingDotIndex]);
+        }
+      }
+      this.moveToolStart = [x, y];
+      this.doGrapherToolMoveAction([x, y]);
+    } else {
+      // if we hvae not clicked on a dot, start a new selection.
+      if (!event.shiftKey) {
+        GlobalStore.commit("clearSelectedDots");
+      }
+      GlobalStore.commit("setSelectionLasso", [[x, y]]);
+      this.selectionLassoStart = [x, y];
+    }
+  }
+
+  onMouseUpInternal(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event);
+
+    if (this.moveToolStart !== null) {
+      // We are in a Move, so translate all the dots.
+      const [deltaX, deltaY] = [
+        x - this.moveToolStart[0],
+        y - this.moveToolStart[1],
+      ];
+      const currentSSDots: StuntSheetDot[] =
+        GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
+      GlobalStore.state.selectedDots.forEach((index: number) => {
+        const [roundedX, roundedY] = BaseTool.roundCoordinateToGrid([
+          currentSSDots[index].x + deltaX,
+          currentSSDots[index].y + deltaY,
+        ]);
+        GlobalStore.commit("moveDot", {
+          index: index,
+          position: [roundedX, roundedY],
+        });
+      });
+      // Set the ToolDots to be empty to indicate we're not moving anymore.
+      GlobalStore.commit("setGrapherToolDots", []);
+      // null out moveToolStart to incidcate we're not moving anymore.
+      this.moveToolStart = null;
+      return;
+    }
+    if (this.selectionLassoStart !== null) {
+      // Complete the selection by finding everything in the selection box.
+      const stuntSheetDots: StuntSheetDot[] =
+        GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
+      const newArray = stuntSheetDots.filter((dot) =>
+        InsideLasso(GlobalStore.state.selectionLasso, [dot.x, dot.y])
+      );
+      const newIndices = newArray.map((dot) =>
+        stuntSheetDots.findIndex((dot2): boolean => {
+          return dot.x === dot2.x && dot.y === dot2.y;
+        })
+      );
+      if (event.altKey) {
+        GlobalStore.commit("toggleSelectedDots", newIndices);
+      } else {
+        GlobalStore.commit("addSelectedDots", newIndices);
+      }
+      // we are done selecting, so clear out the box
+      GlobalStore.commit("setSelectionLasso", []);
+      this.selectionLassoStart = null;
+    }
+  }
+
+  onMouseMoveInternal(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinates(event);
+    if (this.moveToolStart !== null) {
+      this.doGrapherToolMoveAction([x, y]);
+      return;
+    }
+    if (this.selectionLassoStart !== null) {
+      this.onNewMouseMoveSelection([x, y]);
+    }
+  }
+
+  private doGrapherToolMoveAction(point: [number, number]): void {
+    // We are in a Move, so translate all the dots.
+    if (this.moveToolStart === null) {
+      return;
+    }
+    const [deltaX, deltaY] = [
+      point[0] - this.moveToolStart[0],
+      point[1] - this.moveToolStart[1],
+    ];
+    const currentSSDots: StuntSheetDot[] =
+      GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
+    GlobalStore.commit(
+      "setGrapherToolDots",
+      GlobalStore.state.selectedDots.map((index: number) => {
+        const [roundedX, roundedY] = BaseTool.roundCoordinateToGrid([
+          currentSSDots[index].x + deltaX,
+          currentSSDots[index].y + deltaY,
+        ]);
+        return currentSSDots !== null && index < currentSSDots.length
+          ? {
+              x: roundedX,
+              y: roundedY,
+              dotLabelIndex: currentSSDots[index].dotLabelIndex,
+            }
+          : {};
+      })
+    );
+  }
+
+  // override this function change the selection lasso.
+  abstract onNewMouseMoveSelection(point: [number, number]): void;
+}

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -1,20 +1,15 @@
+import BaseMoveTool from "./BaseMoveTool";
 import BaseTool, { ToolConstructor } from "./BaseTool";
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
-import StuntSheet from "@/models/StuntSheet";
 
 /**
  * Add or remove a single dot on click.
  */
-const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
-  onClick(event: MouseEvent): void {
-    const [x, y] = BaseTool.convertClientCoordinates(event);
-    const stuntSheet: StuntSheet = GlobalStore.getters.getSelectedStuntSheet;
-    const existingDotIndex = stuntSheet.stuntSheetDots.findIndex(
-      (dot: StuntSheetDot): boolean => {
-        return x === dot.x && y === dot.y;
-      }
-    );
+const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseMoveTool {
+  onMouseDownInternal(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
+    const existingDotIndex = BaseTool.findDotAtEvent(event);
     if (existingDotIndex !== -1) {
       GlobalStore.commit("removeDot", existingDotIndex);
     } else {
@@ -22,8 +17,8 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseTool {
     }
   }
 
-  onMousemove(event: MouseEvent): void {
-    const [x, y] = BaseTool.convertClientCoordinates(event);
+  onMouseMoveInternal(event: MouseEvent): void {
+    const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
     GlobalStore.commit("setGrapherToolDots", [new StuntSheetDot({ x, y })]);
   }
 };

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -3,21 +3,21 @@ describe("components/menu-bottom/MenuBottom", () => {
     cy.visit("/");
   });
 
-  it("all buttons are rendered and pan/zoom is selected", () => {
-    cy.get('[data-test="menu-bottom--tooltip"]').should("have.length", 2);
+  it("all buttons are rendered and box select is selected", () => {
+    cy.get('[data-test="menu-bottom--tooltip"]').should("have.length", 3);
 
-    cy.get('[data-test="menu-bottom-tool--pan-zoom"]').should(
+    cy.get('[data-test="menu-bottom-tool--select-box-move"]').should(
       "have.class",
       "is-primary"
     );
 
     cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
       "have.length",
-      1
+      2
     );
   });
 
-  it("clicking on add/remove single dot disables pan/zoom", () => {
+  it("clicking on add/remove single dot disables box", () => {
     cy.get('[data-test="menu-bottom-tool--add-rm"]')
       .should("not.have.class", "is-primary")
       .click()
@@ -25,17 +25,17 @@ describe("components/menu-bottom/MenuBottom", () => {
 
     cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
       "have.length",
-      1
+      2
     );
 
     // eslint-disable-next-line cypress/require-data-selectors
-    cy.get("#svg-pan-zoom-controls").should("not.be.visible");
+    cy.get("#svg-pan-zoom-controls").should("be.visible");
   });
 
   it("clicking from and to pan/zoom enables pan/zoom", () => {
     cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
 
-    cy.get('[data-test="menu-bottom-tool--pan-zoom"]')
+    cy.get('[data-test="menu-bottom-tool--select-box-move"]')
       .should("not.have.class", "is-primary")
       .click()
       .should("have.class", "is-primary");
@@ -51,25 +51,14 @@ describe("components/menu-bottom/MenuBottom", () => {
       .should("have.class", "is-primary");
 
     // eslint-disable-next-line cypress/require-data-selectors
-    cy.get("#svg-pan-zoom-controls").should("not.be.visible");
-
-    // Upon keydown, the selected tool is pan/zoom
-    cy.document().trigger("keydown", { key: "Control" });
-
-    cy.get('[data-test="menu-bottom-tool--pan-zoom"]').should(
-      "have.class",
-      "is-primary"
-    );
-
-    // eslint-disable-next-line cypress/require-data-selectors
     cy.get("#svg-pan-zoom-controls").should("be.visible");
 
     // Try panning (taken from ToolPanZoom.spec.js)
     cy.get('[data-test="grapher-field--rect"]').then((field) => {
       const oldX = field.get(0).getBoundingClientRect().x;
-      cy.mousedownGrapher(24, 2);
-      cy.mousemoveGrapher(8, 2);
-      cy.mouseupGrapher(8, 2);
+      cy.mousedownGrapher(24, 2, { metaKey: true });
+      cy.mousemoveGrapher(8, 2, { metaKey: true });
+      cy.mouseupGrapher(8, 2, { metaKey: true });
 
       cy.get('[data-test="grapher-field--rect"]')
         .then((field) => {
@@ -78,15 +67,12 @@ describe("components/menu-bottom/MenuBottom", () => {
         .should("lessThan", oldX);
     });
 
-    // Upon keyup, the selected tool returns to add/remove single dot
-    cy.document().trigger("keyup", { key: "Control" });
-
     cy.get('[data-test="menu-bottom-tool--add-rm"]').should(
       "have.class",
       "is-primary"
     );
 
     // eslint-disable-next-line cypress/require-data-selectors
-    cy.get("#svg-pan-zoom-controls").should("not.be.visible");
+    cy.get("#svg-pan-zoom-controls").should("be.visible");
   });
 });

--- a/tests/e2e/specs/menu-left/MenuLeft.spec.js
+++ b/tests/e2e/specs/menu-left/MenuLeft.spec.js
@@ -36,7 +36,10 @@ describe("components/menu-left/MenuLeft", () => {
     // Add a stuntsheet dot (4, 4) to the first stuntsheet
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click().clickGrapher(4, 4);
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+      .click()
+      .mousedownGrapher(4, 4)
+      .mouseupGrapher(4, 4);
 
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 1)
@@ -83,7 +86,10 @@ describe("components/menu-left/MenuLeft", () => {
     // Add a stuntsheet dot (8, 8) to the first stuntsheet
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click().clickGrapher(8, 8);
+    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+      .click()
+      .mousedownGrapher(8, 8)
+      .mouseupGrapher(8, 8);
 
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 1)

--- a/tests/e2e/specs/tools/ToolBoxSelect.spec.js
+++ b/tests/e2e/specs/tools/ToolBoxSelect.spec.js
@@ -1,6 +1,8 @@
-describe("tools/ToolPanZoom", () => {
+describe("tools/ToolBoxSelect", () => {
   beforeEach(() => {
-    cy.visit("/").get('[data-test="menu-bottom-tool--pan-zoom"]').click();
+    cy.visit("/")
+      .get('[data-test="menu-bottom-tool--select-box-move"]')
+      .click();
   });
 
   it("zoom in using the control icons", () => {
@@ -21,15 +23,25 @@ describe("tools/ToolPanZoom", () => {
   it("shift grapher to the left by panning", () => {
     cy.get('[data-test="grapher-field--rect"]').then((field) => {
       const oldX = field.get(0).getBoundingClientRect().x;
-      cy.mousedownGrapher(24, 2);
-      cy.mousemoveGrapher(8, 2);
-      cy.mouseupGrapher(8, 2);
+      cy.mousedownGrapher(24, 2, { metaKey: true });
+      cy.mousemoveGrapher(8, 2, { metaKey: true });
+      cy.mouseupGrapher(8, 2, { metaKey: true });
 
       cy.get('[data-test="grapher-field--rect"]')
         .then((field) => {
           cy.wrap(field.get(0).getBoundingClientRect().x);
         })
         .should("lessThan", oldX);
+    });
+  });
+  it("Create a selection box", () => {
+    cy.get('[data-test="grapher-field--rect"]').then(() => {
+      cy.mousedownGrapher(24, 2);
+      cy.mousemoveGrapher(8, 6);
+
+      cy.get('[data-test="grapher-tool--selection-lasso"]').then((polyline) => {
+        cy.wrap(polyline).should("have.attr", "points");
+      });
     });
   });
 });

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -6,7 +6,7 @@ describe("tools/ToolSingleDot", () => {
   it("clicking adds, then removes a dot", () => {
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.clickGrapher(12, 8);
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 1)
@@ -19,13 +19,13 @@ describe("tools/ToolSingleDot", () => {
       .should("have.attr", "y", "7");
     cy.get('[data-test="grapher-dots--dottext"]').contains("0");
 
-    cy.clickGrapher(12, 8);
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
   });
 
   it("After panning and zooming, adding a dot is still accurate", () => {
-    cy.get('[data-test="menu-bottom-tool--pan-zoom').click();
+    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
 
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get("#svg-pan-zoom-zoom-out").click().click();
@@ -36,7 +36,7 @@ describe("tools/ToolSingleDot", () => {
 
     cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
 
-    cy.clickGrapher(12, 8);
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 1)
@@ -51,11 +51,11 @@ describe("tools/ToolSingleDot", () => {
   it("clicking multiple dots", () => {
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.clickGrapher(2, 0);
-    cy.clickGrapher(2, 2);
-    cy.clickGrapher(2, 4);
-    cy.clickGrapher(2, 6);
-    cy.clickGrapher(2, 8);
+    cy.mousedownGrapher(2, 0).mouseupGrapher(2, 0);
+    cy.mousedownGrapher(2, 2).mouseupGrapher(2, 2);
+    cy.mousedownGrapher(2, 4).mouseupGrapher(2, 4);
+    cy.mousedownGrapher(2, 6).mouseupGrapher(2, 6);
+    cy.mousedownGrapher(2, 8).mouseupGrapher(2, 8);
 
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 5)
@@ -65,8 +65,8 @@ describe("tools/ToolSingleDot", () => {
           .should("have.attr", "cy", `${index * 2}`);
       });
 
-    cy.clickGrapher(2, 0);
-    cy.clickGrapher(2, 8);
+    cy.mousedownGrapher(2, 0).mouseupGrapher(2, 0);
+    cy.mousedownGrapher(2, 8).mouseupGrapher(2, 8);
 
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 3)

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -64,7 +64,7 @@
 /**
  * Helper command for mouse events on the grapher
  */
-const grapherMouseCommand = (eventName, x, y) => {
+const grapherMouseCommand = (eventName, x, y, options) => {
   return cy.get('[data-test="grapher--wrapper"]').then((wrapper) => {
     const matrix = wrapper.get(0).getCTM();
 
@@ -78,7 +78,8 @@ const grapherMouseCommand = (eventName, x, y) => {
       cy.get('[data-test="grapher--svg"]').trigger(
         eventName,
         convertedPoint.x,
-        convertedPoint.y
+        convertedPoint.y,
+        options
       );
     });
   });
@@ -91,10 +92,10 @@ const grapherMouseCommand = (eventName, x, y) => {
  *  - mousedownGrapher
  *  - mouseupGrapher
  */
-const grapherCommands = ["click", "mousemove", "mousedown", "mouseup"];
+const grapherCommands = ["mousemove", "mousedown", "mouseup"];
 
 grapherCommands.forEach((command) => {
-  Cypress.Commands.add(`${command}Grapher`, (x, y) => {
-    return grapherMouseCommand(command, x, y);
+  Cypress.Commands.add(`${command}Grapher`, (x, y, options) => {
+    return grapherMouseCommand(command, x, y, options);
   });
 });

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -100,8 +100,9 @@ describe("components/grapher/Grapher.vue", () => {
 
     beforeEach(() => {
       mockTool = {
-        onClick: jest.fn(),
-        onMousemove: jest.fn(),
+        onMouseDown: jest.fn(),
+        onMouseUp: jest.fn(),
+        onMouseMove: jest.fn(),
       };
       store = generateStore({ toolSelected: mockTool });
       wrapper = mount(Grapher, {
@@ -118,15 +119,15 @@ describe("components/grapher/Grapher.vue", () => {
     });
 
     it("click", () => {
-      expect(mockTool.onClick).not.toHaveBeenCalled();
-      wrapper.find('[data-test="grapher--svg"]').trigger("click");
-      expect(mockTool.onClick).toHaveBeenCalled();
+      expect(mockTool.onMouseDown).not.toHaveBeenCalled();
+      wrapper.find('[data-test="grapher--svg"]').trigger("mousedown");
+      expect(mockTool.onMouseDown).toHaveBeenCalled();
     });
 
     it("mousemove", () => {
-      expect(mockTool.onMousemove).not.toHaveBeenCalled();
+      expect(mockTool.onMouseMove).not.toHaveBeenCalled();
       wrapper.find('[data-test="grapher--svg"]').trigger("mousemove");
-      expect(mockTool.onMousemove).toHaveBeenCalled();
+      expect(mockTool.onMouseMove).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -1,64 +1,27 @@
 import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
-import svgPanZoom from "svg-pan-zoom";
 import Buefy from "buefy";
 import { generateStore, CalChartState } from "@/store";
 import Vuex, { Store } from "vuex";
 import MenuBottom from "@/components/menu-bottom/MenuBottom.vue";
 import ToolSingleDot from "@/tools/ToolSingleDot";
-import ToolPanZoom from "@/tools/ToolPanZoom";
+import ToolBoxSelect from "@/tools/ToolBoxSelect";
 import BaseTool from "@/tools/BaseTool";
 
-jest.mock("svg-pan-zoom", () => {
-  return {
-    __esModule: true,
-    default: jest.fn(() => ({
-      disablePan: jest.fn(),
-      disableZoom: jest.fn(),
-      disableControlIcons: jest.fn(),
-      enablePan: jest.fn(),
-      enableZoom: jest.fn(),
-      enableControlIcons: jest.fn(),
-    })),
-  };
-});
-
 jest.mock("@/tools/ToolSingleDot");
-jest.mock("@/tools/ToolPanZoom");
+jest.mock("@/tools/ToolBoxSelect");
 
 const setupHelper = () => {
-  // Mock inverse matrix calculations
-  const inverseMock = jest.fn().mockReturnValue({});
-  const getScreenCTMMock = jest.fn().mockReturnValue({
-    inverse: inverseMock,
-  });
-  const getElementsByClassNameMock = jest.fn().mockReturnValue([
-    {
-      getScreenCTM: getScreenCTMMock,
-    },
-  ]);
-  Object.defineProperty(document, "getElementsByClassName", {
-    configurable: true,
-    value: getElementsByClassNameMock,
-  });
-
   // Mock out store and mount
   const localVue = createLocalVue();
   localVue.use(Vuex);
   localVue.use(Buefy);
-  const grapherSvgPanZoom = svgPanZoom("");
-  const store = generateStore({
-    grapherSvgPanZoom,
-  });
+  const store = generateStore({});
   const menu = mount(MenuBottom, {
     store,
     localVue,
   });
 
   return {
-    inverseMock,
-    getScreenCTMMock,
-    getElementsByClassNameMock,
-    grapherSvgPanZoom,
     store,
     menu,
   };
@@ -66,37 +29,28 @@ const setupHelper = () => {
 
 describe("components/menu-bottom/MenuBottom", () => {
   describe("tool buttons", () => {
-    let inverseMock: jest.Mock;
-    let getScreenCTMMock: jest.Mock;
-    let getElementsByClassNameMock: jest.Mock;
-    let grapherSvgPanZoom: SvgPanZoom.Instance;
     let store: Store<CalChartState>;
     let menu: Wrapper<Vue>;
 
     beforeAll(() => {
       jest.clearAllMocks();
-      ({
-        inverseMock,
-        getScreenCTMMock,
-        getElementsByClassNameMock,
-        grapherSvgPanZoom,
-        store,
-        menu,
-      } = setupHelper());
+      ({ store, menu } = setupHelper());
     });
 
     it("renders the correct amount of tools", () => {
       expect(menu.findAll('[data-test="menu-bottom--tooltip"]')).toHaveLength(
-        2
+        3
       );
     });
 
     it("on mount, selects the pan and zoom tool", () => {
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(ToolPanZoom).toHaveBeenCalled();
-      expect(toolSelected.constructor).toBe(ToolPanZoom);
-      const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
+      expect(ToolBoxSelect).toHaveBeenCalled();
+      expect(toolSelected.constructor).toBe(ToolBoxSelect);
+      const panZoomBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-box-move"]'
+      );
       expect(panZoomBtn.exists()).toBeTruthy();
       expect(panZoomBtn.props("type")).toBe("is-primary");
     });
@@ -106,152 +60,38 @@ describe("components/menu-bottom/MenuBottom", () => {
       expect(addRmBtn.props("type")).toBe("is-light");
     });
 
-    it(
-      "clicking add/remove single dot disables panning/zooming and " +
-        "calculates inverse matrix",
-      async () => {
-        expect(ToolSingleDot).not.toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disablePan).not.toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableZoom).not.toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableControlIcons).not.toHaveBeenCalled();
-        expect(inverseMock).not.toHaveBeenCalled();
-        expect(getScreenCTMMock).not.toHaveBeenCalled();
-        expect(getElementsByClassNameMock).not.toHaveBeenCalled();
+    it("clicking add/remove single dot disables box select", async () => {
+      expect(ToolSingleDot).not.toHaveBeenCalled();
 
-        const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
-        addRmBtn.trigger("click");
-        await menu.vm.$nextTick();
+      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      addRmBtn.trigger("click");
+      await menu.vm.$nextTick();
 
-        expect(ToolSingleDot).toHaveBeenCalled();
-        const toolSelected = store.state.toolSelected as BaseTool;
-        expect(toolSelected).not.toBeUndefined();
-        expect(toolSelected.constructor).toBe(ToolSingleDot);
-        expect(addRmBtn.props("type")).toBe("is-primary");
-        expect(grapherSvgPanZoom.disablePan).toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableZoom).toHaveBeenCalled();
-        expect(grapherSvgPanZoom.disableControlIcons).toHaveBeenCalled();
-        expect(inverseMock).toHaveBeenCalled();
-        expect(getScreenCTMMock).toHaveBeenCalled();
-        expect(getElementsByClassNameMock).toHaveBeenCalled();
-      }
-    );
+      expect(ToolSingleDot).toHaveBeenCalled();
+      const toolSelected = store.state.toolSelected as BaseTool;
+      expect(toolSelected).not.toBeUndefined();
+      expect(toolSelected.constructor).toBe(ToolSingleDot);
+      expect(addRmBtn.props("type")).toBe("is-primary");
+    });
 
-    it("pan and zoom is no longer selected", () => {
-      const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
+    it("select box is no longer selected", () => {
+      const panZoomBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-box-move"]'
+      );
       expect(panZoomBtn.props("type")).toBe("is-light");
     });
 
-    it("clicking pan and zoom enables panning/zooming", async () => {
-      expect(grapherSvgPanZoom.enablePan).not.toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableZoom).not.toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableControlIcons).not.toHaveBeenCalled();
-
-      const panZoomBtn = menu.find('[data-test="menu-bottom-tool--pan-zoom"]');
+    it("clicking select box enables box", async () => {
+      const panZoomBtn = menu.find(
+        '[data-test="menu-bottom-tool--select-box-move"]'
+      );
       panZoomBtn.trigger("click");
       await menu.vm.$nextTick();
 
       const toolSelected = store.state.toolSelected as BaseTool;
       expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor).toBe(ToolPanZoom);
+      expect(toolSelected.constructor).toBe(ToolBoxSelect);
       expect(panZoomBtn.props("type")).toBe("is-primary");
-      expect(grapherSvgPanZoom.enablePan).toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableZoom).toHaveBeenCalled();
-      expect(grapherSvgPanZoom.enableControlIcons).toHaveBeenCalled();
-    });
-  });
-
-  describe("onKeyDown", () => {
-    let store: Store<CalChartState>;
-    let menu: Wrapper<Vue>;
-
-    beforeEach(() => {
-      ({ store, menu } = setupHelper());
-
-      store.commit("setToolSelected", new ToolSingleDot());
-    });
-
-    it("If ctrl key, enable pan/zoom and store old tool", () => {
-      expect(menu.vm.$data.temporaryTool).toBeNull();
-
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Control" }));
-
-      expect(menu.vm.$data.temporaryTool instanceof ToolSingleDot).toBe(true);
-      expect(store.state.toolSelected instanceof ToolPanZoom).toBe(true);
-    });
-
-    it("If meta key, enable pan/zoom and store old tool", () => {
-      expect(menu.vm.$data.temporaryTool).toBeNull();
-
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Meta" }));
-
-      expect(menu.vm.$data.temporaryTool instanceof ToolSingleDot).toBe(true);
-      expect(store.state.toolSelected instanceof ToolPanZoom).toBe(true);
-    });
-
-    it("If repeat event, do not do anything", () => {
-      document.dispatchEvent(
-        new KeyboardEvent("keydown", {
-          key: "Control",
-          repeat: true,
-        })
-      );
-
-      expect(menu.vm.$data.temporaryTool).toBeNull();
-      expect(store.state.toolSelected instanceof ToolSingleDot).toBe(true);
-    });
-
-    it("If not ctrl key, do not do anything", () => {
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "KeyA" }));
-
-      expect(menu.vm.$data.temporaryTool).toBeNull();
-      expect(store.state.toolSelected instanceof ToolSingleDot).toBe(true);
-    });
-  });
-
-  describe("onKeyUp", () => {
-    let store: Store<CalChartState>;
-    let menu: Wrapper<Vue>;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      ({ store, menu } = setupHelper());
-
-      menu.vm.$data.temporaryTool = new ToolSingleDot();
-    });
-
-    it("If ctrl key, enable pan/zoom and store old tool", () => {
-      expect(menu.vm.$data.temporaryTool).not.toBeNull();
-      const toolSelected = store.state.toolSelected as BaseTool;
-      expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor).not.toBe(ToolSingleDot);
-
-      document.dispatchEvent(new KeyboardEvent("keyup", { key: "Control" }));
-
-      expect(menu.vm.$data.temporaryTool).toBeNull();
-      const nextToolSelected = store.state.toolSelected as BaseTool;
-      expect(nextToolSelected.constructor).toBe(ToolSingleDot);
-    });
-
-    it("If meta key, enable pan/zoom and store old tool", async () => {
-      expect(menu.vm.$data.temporaryTool).not.toBeNull();
-      const toolSelected = store.state.toolSelected as BaseTool;
-      expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor).not.toBe(ToolSingleDot);
-
-      document.dispatchEvent(new KeyboardEvent("keyup", { key: "Meta" }));
-
-      expect(menu.vm.$data.temporaryTool).toBeNull();
-      const nextToolSelected = store.state.toolSelected as BaseTool;
-      expect(nextToolSelected.constructor).toBe(ToolSingleDot);
-    });
-
-    it("If not ctrl key, do not do anything", () => {
-      document.dispatchEvent(new KeyboardEvent("keyup", { key: "KeyA" }));
-
-      expect(menu.vm.$data.temporaryTool).not.toBeNull();
-      const toolSelected = store.state.toolSelected as BaseTool;
-      expect(toolSelected).not.toBeUndefined();
-      expect(toolSelected.constructor).not.toBe(ToolSingleDot);
     });
   });
 });

--- a/tests/unit/tools/BaseTool.spec.ts
+++ b/tests/unit/tools/BaseTool.spec.ts
@@ -29,7 +29,7 @@ describe("tools/BaseTool", () => {
   });
 
   it("convertClientCoordinates calls the correct functions", () => {
-    const [x, y] = BaseTool.convertClientCoordinates(
+    const [x, y] = BaseTool.convertClientCoordinatesRounded(
       new MouseEvent("click", { clientX: 0, clientY: 0 })
     );
 
@@ -51,7 +51,10 @@ describe("tools/BaseTool", () => {
       [3.0, 4],
       [-1.5, -2],
     ])("%f rounds to %i", (input, output) => {
-      expect(BaseTool.roundCoordinateToGrid(input)).toBe(output);
+      expect(BaseTool.roundCoordinateToGrid([input, input])).toStrictEqual([
+        output,
+        output,
+      ]);
     });
   });
 });

--- a/tests/unit/tools/ToolBoxSelect.spec.ts
+++ b/tests/unit/tools/ToolBoxSelect.spec.ts
@@ -1,0 +1,182 @@
+import ToolBoxSelect from "@/tools/ToolBoxSelect";
+import { GlobalStore } from "@/store";
+import BaseTool from "@/tools/BaseTool";
+import BaseMoveTool from "@/tools/BaseMoveTool";
+import StuntSheetDot from "@/models/StuntSheetDot";
+
+describe("tools/ToolBoxSelect", () => {
+  let tool: BaseTool;
+
+  beforeEach(() => {
+    BaseTool.convertClientCoordinates = jest.fn((x) => [x.clientX, x.clientY]);
+    BaseTool.updateInvertedCTMMatrix = jest.fn();
+    BaseMoveTool.enablePan = jest.fn();
+    tool = new ToolBoxSelect();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("Select a dot", () => {
+    const stuntSheet = GlobalStore.getters.getSelectedStuntSheet;
+    stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 2, y: 2 }));
+    stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 4, y: 2 }));
+    stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 2, y: 4 }));
+
+    it("Click where nothing is", () => {
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 0, clientY: 0 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+
+    it("Click on a dot", () => {
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 2, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
+    });
+
+    it("Click on a space loses selection", () => {
+      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 6, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([[6, 2]]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+
+    it("Click on a dot loses selection and adds another", () => {
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 4, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 4, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 2, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+
+    it("Click on a dot with shift adds it", () => {
+      tool.onMouseDown(
+        new MouseEvent("mousedown", { clientX: 4, clientY: 2, shiftKey: true })
+      );
+
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 4, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+
+    it("Click on a dot with shift+alt key toggles it", () => {
+      tool.onMouseDown(
+        new MouseEvent("mousedown", {
+          clientX: 2,
+          clientY: 2,
+          shiftKey: true,
+          altKey: true,
+        })
+      );
+
+      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+
+    it("Selecting box will select all", () => {
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
+
+      tool.onMouseMove(new MouseEvent("mousemove", { clientX: 6, clientY: 6 }));
+      expect(GlobalStore.state.selectionLasso).toEqual([
+        [0, 0],
+        [6, 0],
+        [6, 6],
+        [0, 6],
+        [0, 0],
+      ]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 6 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+
+    it("shift and move will move the dots", () => {
+      expect(GlobalStore.state.grapherToolDots).toEqual([]);
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+      tool.onMouseDown(
+        new MouseEvent("mousedown", { clientX: 2, clientY: 2, shiftKey: true })
+      );
+
+      expect(GlobalStore.state.grapherToolDots).toEqual([
+        { x: 2, y: 2, dotLabelIndex: null },
+        { x: 4, y: 2, dotLabelIndex: null },
+        { x: 2, y: 4, dotLabelIndex: null },
+      ]);
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseMove(new MouseEvent("mousemove", { clientX: 6, clientY: 6 }));
+      expect(GlobalStore.state.grapherToolDots).toEqual([
+        { x: 6, y: 6, dotLabelIndex: null },
+        { x: 8, y: 6, dotLabelIndex: null },
+        { x: 6, y: 8, dotLabelIndex: null },
+      ]);
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 6 }));
+
+      expect(GlobalStore.state.grapherToolDots).toEqual([]);
+      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+      expect(stuntSheet.stuntSheetDots).toEqual([
+        new StuntSheetDot({ x: 6, y: 6, dotTypeIndex: 0 }),
+        new StuntSheetDot({ x: 8, y: 6, dotTypeIndex: 0 }),
+        new StuntSheetDot({ x: 6, y: 8, dotTypeIndex: 0 }),
+      ]);
+    });
+  });
+});

--- a/tests/unit/tools/ToolLassoSelect.spec.ts
+++ b/tests/unit/tools/ToolLassoSelect.spec.ts
@@ -1,0 +1,43 @@
+import ToolLassoSelect from "@/tools/ToolLassoSelect";
+import { GlobalStore } from "@/store";
+import BaseTool from "@/tools/BaseTool";
+import BaseMoveTool from "@/tools/BaseMoveTool";
+
+describe("tools/ToolBoxSelect", () => {
+  let tool: BaseTool;
+
+  beforeEach(() => {
+    BaseTool.convertClientCoordinates = jest.fn((x) => [x.clientX, x.clientY]);
+    BaseTool.updateInvertedCTMMatrix = jest.fn();
+    BaseMoveTool.enablePan = jest.fn();
+    tool = new ToolLassoSelect();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("Selecting with a lasso", () => {
+    it("Click where nothing is", () => {
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+
+      tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
+
+      tool.onMouseMove(new MouseEvent("mousemove", { clientX: 3, clientY: 1 }));
+
+      expect(GlobalStore.state.selectionLasso).toEqual([
+        [0, 0],
+        [3, 1],
+      ]);
+
+      tool.onMouseUp(new MouseEvent("mouseup", { clientX: 3, clientY: 1 }));
+
+      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectionLasso).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -1,6 +1,7 @@
 import ToolSingleDot from "@/tools/ToolSingleDot";
 import { GlobalStore } from "@/store";
 import BaseTool from "@/tools/BaseTool";
+import BaseMoveTool from "@/tools/BaseMoveTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
 
 describe("tools/ToolSingleDot", () => {
@@ -8,6 +9,8 @@ describe("tools/ToolSingleDot", () => {
 
   beforeEach(() => {
     BaseTool.convertClientCoordinates = jest.fn().mockReturnValue([0, 2]);
+    BaseTool.updateInvertedCTMMatrix = jest.fn();
+    BaseMoveTool.enablePan = jest.fn();
     Object.defineProperty(GlobalStore, "commit", { value: jest.fn() });
     tool = new ToolSingleDot();
   });
@@ -16,12 +19,12 @@ describe("tools/ToolSingleDot", () => {
     jest.resetAllMocks();
   });
 
-  describe("onClick", () => {
+  describe("onMouseDown", () => {
     it("adds a new dot if none exists in the spot", () => {
       expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
       expect(GlobalStore.commit).not.toHaveBeenCalled();
 
-      tool.onClick(new MouseEvent("click", { clientX: 0, clientY: 0 }));
+      tool.onMouseDown(new MouseEvent("click", { clientX: 0, clientY: 0 }));
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
@@ -38,7 +41,7 @@ describe("tools/ToolSingleDot", () => {
       expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
       expect(GlobalStore.commit).not.toHaveBeenCalled();
 
-      tool.onClick(new MouseEvent("click", { clientX: 0, clientY: 2 }));
+      tool.onMouseDown(new MouseEvent("click", { clientX: 0, clientY: 2 }));
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
@@ -46,12 +49,12 @@ describe("tools/ToolSingleDot", () => {
     });
   });
 
-  describe("onMousemove", () => {
+  describe("onMouseMove", () => {
     it("sets grapher tool dot", () => {
       expect(BaseTool.convertClientCoordinates).not.toHaveBeenCalled();
       expect(GlobalStore.commit).not.toHaveBeenCalled();
 
-      tool.onMousemove(new MouseEvent("mousemove", { clientX: 0, clientY: 2 }));
+      tool.onMouseMove(new MouseEvent("mousemove", { clientX: 0, clientY: 2 }));
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Description

Fixes issue:
Select Dots tool #71

Redoing selection and move tools.

Creating two types of selection and move tools, the box selector, and the lasso selector.  Allowing all tools to do panning and zoom.

When users press meta/cmd key, it will always pan when they click, allowing all tools to move.

Select and move tools work by allowing you to select, add to selection with shift, and toggle selection with shift+alt.  When you have something selected, you press shift and click and move the dots.



## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
