### PR TITLE
Give unique ID to dot and ss. selectedDots -> selectedDotIds

### DIFF
--- a/src/components/grapher/GrapherDots.vue
+++ b/src/components/grapher/GrapherDots.vue
@@ -2,7 +2,7 @@
   <g class="grapher-dots--dots-container">
     <Dot
       v-for="(dot, index) in stuntSheetDots"
-      :key="`${dot.x}-${dot.y}-dots--dot`"
+      :key="`${dot.id}-dots--dot`"
       class="grapher-dots--dot"
       data-test="grapher-dots--dot"
       :transform="`translate(${dot.xAtBeat(beat - 1)}, ${dot.yAtBeat(
@@ -11,9 +11,9 @@
       :cx="dot.xAtBeat(beat - 1)"
       :cy="dot.yAtBeat(beat - 1)"
       :dotTypeIndex="dot.dotTypeIndex"
-      :label="dotLabels[index]"
+      :label="indexedDotLabels[index]"
       :labeled="showDotLabels"
-      :selected="selectedDots.includes(index)"
+      :selected="selectedDotIds.includes(dot.id)"
     />
   </g>
 </template>
@@ -39,10 +39,10 @@ export default Vue.extend({
     stuntSheetDots(): StuntSheetDot[] {
       return this.$store.getters.getSelectedStuntSheet.stuntSheetDots;
     },
-    selectedDots(): number[] {
-      return this.$store.state.selectedDots;
+    selectedDotIds(): number[] {
+      return this.$store.state.selectedDotIds;
     },
-    dotLabels(): string[] {
+    indexedDotLabels(): string[] {
       const dotLabels = this.$store.getters.getDotLabels;
       const dots: StuntSheetDot[] = this.$store.getters.getSelectedStuntSheet
         .stuntSheetDots;
@@ -53,7 +53,6 @@ export default Vue.extend({
           : index.toString();
       });
     },
-
     beat: {
       get(): number {
         return this.$store.state.beat;

--- a/src/components/grapher/GrapherTool.vue
+++ b/src/components/grapher/GrapherTool.vue
@@ -1,8 +1,8 @@
 <template>
   <g class="grapher-tool--tool-dots-container">
     <circle
-      v-for="dot in grapherToolDots"
-      :key="`${dot.x}-${dot.y}-tool--dot`"
+      v-for="(dot, index) in grapherToolDots"
+      :key="`${index}-tool--dot`"
       class="grapher-tool--dot"
       :cx="dot.x"
       :cy="dot.y"

--- a/src/components/menu-left/MenuLeft.vue
+++ b/src/components/menu-left/MenuLeft.vue
@@ -32,7 +32,7 @@
       <b-menu-list>
         <b-menu-item
           v-for="(stuntSheet, index) in stuntSheets"
-          :key="stuntSheet.title"
+          :key="stuntSheet.id"
           class="stuntsheet"
           :active="selectedSS === index"
           data-test="menu-left--ss"
@@ -114,8 +114,7 @@ export default Vue.extend({
   },
   methods: {
     addStuntSheet(): void {
-      const stuntSheet = new StuntSheet();
-      this.$store.commit("addStuntSheet", stuntSheet);
+      this.$store.commit("addStuntSheet");
     },
     incrementBeat(): void {
       this.$store.commit("incrementBeat");

--- a/src/models/Show.ts
+++ b/src/models/Show.ts
@@ -28,7 +28,7 @@ export default class Show extends Serializable<Show> {
 
   field: Field = new Field();
 
-  stuntSheets: StuntSheet[] = [new StuntSheet()];
+  stuntSheets: StuntSheet[] = [new StuntSheet({ title: "Stuntsheet 1" })];
 
   constructor(showJson: Partial<Show> = {}) {
     super();
@@ -50,7 +50,7 @@ export default class Show extends Serializable<Show> {
    * the flow based on it's continuities in stuntSheetDot.cachedFlow.
    */
   generateFlows(stuntSheetIndex: number): void {
-    if (stuntSheetIndex < 0 || stuntSheetIndex + 1 >= this.stuntSheets.length) {
+    if (stuntSheetIndex < 0 || stuntSheetIndex >= this.stuntSheets.length) {
       throw new Error(
         `stuntSheetIndex (${stuntSheetIndex}) is invalid with stuntsheet` +
           ` length ${this.stuntSheets.length}`
@@ -58,14 +58,16 @@ export default class Show extends Serializable<Show> {
     }
 
     const startSS: StuntSheet = this.stuntSheets[stuntSheetIndex];
-    const endSS: StuntSheet = this.stuntSheets[stuntSheetIndex + 1];
+    const endSS: StuntSheet | null =
+      stuntSheetIndex + 1 < this.stuntSheets.length
+        ? this.stuntSheets[stuntSheetIndex + 1]
+        : null;
 
-    startSS.stuntSheetDots.map((startDot: StuntSheetDot): void => {
+    startSS.stuntSheetDots.forEach((startDot: StuntSheetDot): void => {
       let endDot: StuntSheetDot | undefined;
-      if (startDot.dotLabelIndex !== null) {
+      if (endSS && startDot.nextDotId !== null) {
         endDot = endSS.stuntSheetDots.find(
-          (dot: StuntSheetDot): boolean =>
-            startDot.dotLabelIndex === dot.dotLabelIndex
+          (dot: StuntSheetDot): boolean => startDot.nextDotId === dot.id
         );
       }
 
@@ -78,5 +80,7 @@ export default class Show extends Serializable<Show> {
 
       startDot.cachedFlow = flow;
     });
+
+    startSS.nextSSId = endSS ? endSS.id : null;
   }
 }

--- a/src/models/StuntSheetDot.ts
+++ b/src/models/StuntSheetDot.ts
@@ -1,18 +1,29 @@
 import { FlowBeat } from "./util/types";
 import Serializable from "./util/Serializable";
 
+// Global ID counter for the next dot
+let NEXT_DOT_ID = 0;
+
 /**
  * Defines the position and direction of a marcher for a specific StuntSheet.
  *
+ * @property id            - Uniquely identifies a dot. Can be -1 if not
+ *                           relevant, e.g. for grapher tool dots. Used for
+ *                           connecting dots between stuntsheets, and labels.
  * @property x             - EW position of the first beat
  * @property y             - NS position of the first beat
- * @property dotLabelIndex - Which label to use in Show.dotLabels
+ * @property dotLabelIndex - Which label to use in Show.dotLabels. This is
+ *                           a cached value for stuntsheets after the first.
  * @property dotTypeIndex  - Which set of continuities to use in
  *                           StuntSheet.dotTypes
+ * @property nextDotId     - The dot in the next stuntsheet to generate
+ *                           a flow toward
  * @property cachedFlow    - Cached so that the flow does not need to be
  *                           recalculated again
  */
 export default class StuntSheetDot extends Serializable<StuntSheetDot> {
+  id = -1;
+
   x = 0;
 
   y = 0;
@@ -21,22 +32,31 @@ export default class StuntSheetDot extends Serializable<StuntSheetDot> {
 
   dotTypeIndex = 0;
 
+  nextDotId: number | null = null;
+
   cachedFlow: FlowBeat[] | null = null;
 
   constructor(dotJson: Partial<StuntSheetDot> = {}) {
     super();
+
+    if (dotJson.id === undefined) {
+      dotJson.id = NEXT_DOT_ID++;
+    } else if (dotJson.id >= NEXT_DOT_ID) {
+      NEXT_DOT_ID = dotJson.id + 1;
+    }
+
     this.fromJson(dotJson);
   }
 
   xAtBeat(beat: number): number {
-    return this.cachedFlow !== null && beat < this.cachedFlow.length
-      ? this.cachedFlow[beat].x
+    return this.cachedFlow && this.cachedFlow.length > 0
+      ? this.cachedFlow[Math.min(beat, this.cachedFlow.length - 1)].x
       : this.x;
   }
 
   yAtBeat(beat: number): number {
-    return this.cachedFlow !== null && beat < this.cachedFlow.length
-      ? this.cachedFlow[beat].y
+    return this.cachedFlow && this.cachedFlow.length > 0
+      ? this.cachedFlow[Math.min(beat, this.cachedFlow.length - 1)].y
       : this.y;
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,13 +40,14 @@ export class CalChartState extends Serializable<CalChartState> {
 
   invertedCTMMatrix?: DOMMatrix;
 
-  selectedDots: number[] = [];
+  selectedDotIds: number[] = [];
 
   toolSelected?: BaseTool;
 
   grapherToolDots: StuntSheetDot[] = [];
 
   showSelectionLasso = true;
+
   selectionLasso: [number, number][] = [];
 
   constructor(json: Partial<CalChartState> = {}) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -17,8 +17,12 @@ const mutations: MutationTree<CalChartState> = {
   setShowTitle(state, title: string): void {
     state.show.title = title;
   },
-  addStuntSheet(state, stuntSheet: StuntSheet): void {
-    state.show.stuntSheets.push(stuntSheet);
+  addStuntSheet(state): void {
+    state.show.stuntSheets.push(
+      new StuntSheet({
+        title: `Stuntsheet ${state.show.stuntSheets.length + 1}`,
+      })
+    );
     state.selectedSS = state.show.stuntSheets.length - 1;
     state.beat = 1;
   },
@@ -40,14 +44,14 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // Show -> StuntSheet
-  removeDot(state, dotIndex: number): void {
+  removeDot(state, dotId: number): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.removeDot(dotIndex);
+    currentSS.removeDot(dotId);
   },
-  addDot(state, dot: StuntSheetDot): void {
+  addDot(state, dot: Partial<StuntSheetDot>): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
@@ -56,13 +60,13 @@ const mutations: MutationTree<CalChartState> = {
   },
   moveDot(
     state,
-    { index, position }: { index: number; position: [number, number] }
+    { dotId, position }: { dotId: number; position: [number, number] }
   ): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.moveDot(index, position);
+    currentSS.moveDot(dotId, position);
   },
   setStuntSheetTitle(state, title: string): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
@@ -193,22 +197,22 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // selection
-  clearSelectedDots(state): void {
-    state.selectedDots = [];
+  clearSelectedDotIds(state): void {
+    state.selectedDotIds = [];
   },
-  addSelectedDots(state, dots: number[]): void {
-    dots.forEach((dot) => {
-      state.selectedDots.indexOf(dot) < 0 && state.selectedDots.push(dot);
+  addSelectedDotIds(state, dotIds: number[]): void {
+    dotIds.forEach((id) => {
+      !state.selectedDotIds.includes(id) && state.selectedDotIds.push(id);
     });
   },
-  toggleSelectedDots(state, dots: number[]): void {
+  toggleSelectedDotIds(state, dotIds: number[]): void {
     // first remove all the items passed in.
-    dots.forEach((v) => {
-      const index = state.selectedDots.indexOf(v);
+    dotIds.forEach((id) => {
+      const index = state.selectedDotIds.indexOf(id);
       if (index > -1) {
-        state.selectedDots.splice(index, 1);
+        state.selectedDotIds.splice(index, 1);
       } else {
-        state.selectedDots.push(v);
+        state.selectedDotIds.push(id);
       }
     });
   },

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -51,13 +51,13 @@ export default abstract class BaseTool {
   }
 
   /**
-   * returns index of dot at mouse event, or -1 if nothing found
+   * returns dot at mouse event, or undefined if nothing found
    **/
-  static findDotAtEvent(event: MouseEvent): number {
+  static findDotAtEvent(event: MouseEvent): StuntSheetDot | undefined {
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
     const stuntSheetDots: StuntSheetDot[] =
       GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
-    return stuntSheetDots.findIndex((dot: StuntSheetDot): boolean => {
+    return stuntSheetDots.find((dot: StuntSheetDot): boolean => {
       return x === dot.x && y === dot.y;
     });
   }

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -9,17 +9,19 @@ import StuntSheetDot from "@/models/StuntSheetDot";
 const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseMoveTool {
   onMouseDownInternal(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
-    const existingDotIndex = BaseTool.findDotAtEvent(event);
-    if (existingDotIndex !== -1) {
-      GlobalStore.commit("removeDot", existingDotIndex);
+    const existingDot = BaseTool.findDotAtEvent(event);
+    if (existingDot) {
+      GlobalStore.commit("removeDot", existingDot.id);
     } else {
-      GlobalStore.commit("addDot", new StuntSheetDot({ x, y }));
+      GlobalStore.commit("addDot", { x, y });
     }
   }
 
   onMouseMoveInternal(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
-    GlobalStore.commit("setGrapherToolDots", [new StuntSheetDot({ x, y })]);
+    GlobalStore.commit("setGrapherToolDots", [
+      new StuntSheetDot({ x, y, id: -1 }),
+    ]);
   }
 };
 

--- a/tests/e2e/specs/menu-left/MenuLeft.spec.js
+++ b/tests/e2e/specs/menu-left/MenuLeft.spec.js
@@ -14,7 +14,8 @@ describe("components/menu-left/MenuLeft", () => {
     cy.get('[data-test="menu-left--ss-modal"]').should("be.visible");
 
     cy.get('[data-test="ss-modal--title"]')
-      .should("have.value", "")
+      .should("have.value", "Stuntsheet 1")
+      .clear()
       .type("Sunset");
 
     cy.get('[data-test="ss-modal--beats"]')
@@ -64,7 +65,8 @@ describe("components/menu-left/MenuLeft", () => {
     cy.get('[data-test="menu-left--ss-modal"]').should("be.visible");
 
     cy.get('[data-test="ss-modal--title"]')
-      .should("have.value", "")
+      .should("have.value", "Stuntsheet 2")
+      .clear()
       .type("Script YOLO");
 
     cy.get('[data-test="ss-modal--beats"]')

--- a/tests/e2e/specs/menu-left/StuntSheetModal.spec.js
+++ b/tests/e2e/specs/menu-left/StuntSheetModal.spec.js
@@ -9,7 +9,8 @@ describe("components/menu-left/StuntSheetModal", () => {
 
   it("Setting the title", () => {
     cy.get('[data-test="ss-modal--title"]')
-      .should("have.value", "")
+      .should("have.value", "Stuntsheet 1")
+      .clear()
       .type("Sunrise");
 
     cy.get('[data-test="ss-modal--close"]').click();
@@ -32,7 +33,8 @@ describe("components/menu-left/StuntSheetModal", () => {
     cy.get('[data-test="ss-modal--delete"]').should("not.exist");
 
     cy.get('[data-test="ss-modal--title"]')
-      .should("have.value", "")
+      .should("have.value", "Stuntsheet 1")
+      .clear()
       .type("Sunrise");
 
     cy.get('[data-test="ss-modal--close"]').click();

--- a/tests/unit/components/menu-left/MenuLeft.spec.ts
+++ b/tests/unit/components/menu-left/MenuLeft.spec.ts
@@ -112,10 +112,7 @@ describe("components/menu-left/MenuLeft", () => {
       addButton.trigger("click");
       await menu.vm.$nextTick();
 
-      expect(commitSpy).toHaveBeenLastCalledWith(
-        "addStuntSheet",
-        show.stuntSheets[3]
-      );
+      expect(commitSpy).toHaveBeenLastCalledWith("addStuntSheet");
       expect(menu.findAll('[data-test="menu-left--ss"]')).toHaveLength(4);
     });
   });

--- a/tests/unit/tools/ToolBoxSelect.spec.ts
+++ b/tests/unit/tools/ToolBoxSelect.spec.ts
@@ -25,66 +25,66 @@ describe("tools/ToolBoxSelect", () => {
     stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 2, y: 4 }));
 
     it("Click where nothing is", () => {
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("Click on a dot", () => {
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
     });
 
     it("Click on a space loses selection", () => {
-      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 6, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[6, 2]]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("Click on a dot loses selection and adds another", () => {
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 4, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 4, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([0]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
@@ -93,12 +93,12 @@ describe("tools/ToolBoxSelect", () => {
         new MouseEvent("mousedown", { clientX: 4, clientY: 2, shiftKey: true })
       );
 
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 4, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
@@ -112,19 +112,19 @@ describe("tools/ToolBoxSelect", () => {
         })
       );
 
-      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([1]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("Selecting box will select all", () => {
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
 
       tool.onMouseMove(new MouseEvent("mousemove", { clientX: 6, clientY: 6 }));
@@ -138,44 +138,69 @@ describe("tools/ToolBoxSelect", () => {
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 6 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("shift and move will move the dots", () => {
       expect(GlobalStore.state.grapherToolDots).toEqual([]);
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
       tool.onMouseDown(
         new MouseEvent("mousedown", { clientX: 2, clientY: 2, shiftKey: true })
       );
 
-      expect(GlobalStore.state.grapherToolDots).toEqual([
-        { x: 2, y: 2, dotLabelIndex: null },
-        { x: 4, y: 2, dotLabelIndex: null },
-        { x: 2, y: 4, dotLabelIndex: null },
-      ]);
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      const grapherToolDotsBefore = GlobalStore.state.grapherToolDots;
+      expect(grapherToolDotsBefore).toHaveLength(3);
+      expect(grapherToolDotsBefore[0]).toMatchObject({
+        x: 2,
+        y: 2,
+        dotLabelIndex: null,
+      });
+      expect(grapherToolDotsBefore[1]).toMatchObject({
+        x: 4,
+        y: 2,
+        dotLabelIndex: null,
+      });
+      expect(grapherToolDotsBefore[2]).toMatchObject({
+        x: 2,
+        y: 4,
+        dotLabelIndex: null,
+      });
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseMove(new MouseEvent("mousemove", { clientX: 6, clientY: 6 }));
-      expect(GlobalStore.state.grapherToolDots).toEqual([
-        { x: 6, y: 6, dotLabelIndex: null },
-        { x: 8, y: 6, dotLabelIndex: null },
-        { x: 6, y: 8, dotLabelIndex: null },
-      ]);
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+
+      const grapherToolDotsAfter = GlobalStore.state.grapherToolDots;
+      expect(grapherToolDotsAfter).toHaveLength(3);
+      expect(grapherToolDotsAfter[0]).toMatchObject({
+        x: 6,
+        y: 6,
+        dotLabelIndex: null,
+      });
+      expect(grapherToolDotsAfter[1]).toMatchObject({
+        x: 8,
+        y: 6,
+        dotLabelIndex: null,
+      });
+      expect(grapherToolDotsAfter[2]).toMatchObject({
+        x: 6,
+        y: 8,
+        dotLabelIndex: null,
+      });
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 6 }));
 
       expect(GlobalStore.state.grapherToolDots).toEqual([]);
-      expect(GlobalStore.state.selectedDots).toEqual([0, 1, 2]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
       expect(stuntSheet.stuntSheetDots).toEqual([
-        new StuntSheetDot({ x: 6, y: 6, dotTypeIndex: 0 }),
-        new StuntSheetDot({ x: 8, y: 6, dotTypeIndex: 0 }),
-        new StuntSheetDot({ x: 6, y: 8, dotTypeIndex: 0 }),
+        new StuntSheetDot({ x: 6, y: 6, dotTypeIndex: 0, id: 0 }),
+        new StuntSheetDot({ x: 8, y: 6, dotTypeIndex: 0, id: 1 }),
+        new StuntSheetDot({ x: 6, y: 8, dotTypeIndex: 0, id: 2 }),
       ]);
     });
   });

--- a/tests/unit/tools/ToolLassoSelect.spec.ts
+++ b/tests/unit/tools/ToolLassoSelect.spec.ts
@@ -19,12 +19,12 @@ describe("tools/ToolBoxSelect", () => {
 
   describe("Selecting with a lasso", () => {
     it("Click where nothing is", () => {
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
 
       tool.onMouseMove(new MouseEvent("mousemove", { clientX: 3, clientY: 1 }));
@@ -36,7 +36,7 @@ describe("tools/ToolBoxSelect", () => {
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 3, clientY: 1 }));
 
-      expect(GlobalStore.state.selectedDots).toEqual([]);
+      expect(GlobalStore.state.selectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
   });

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -28,10 +28,7 @@ describe("tools/ToolSingleDot", () => {
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
-      expect(GlobalStore.commit).toHaveBeenCalledWith(
-        "addDot",
-        expect.any(StuntSheetDot)
-      );
+      expect(GlobalStore.commit).toHaveBeenCalledWith("addDot", { x: 0, y: 2 });
     });
 
     it("removes a dot if it exists in the spot", () => {


### PR DESCRIPTION
## Description

Fixes issue #103 and unblocks #102

- Give unique IDs to Dot and StuntSheet. This is the primary way to connect dots between stuntsheets. `dotLabelIndex` thus becomes a cached field (when a label is assigned to a dot, then we need to go through all connected dots and assign their `dotLabelIndex`.). This gives us benefits laid out in the issue, such as if a stuntsheet is re-ordered, we can show a UI warning that the continuities need to be re-made for the new SS.
- Rename store.selectedDots to store.selectedDotIds to be more clear
- Other minor refactors, such as default stuntsheet titles

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
