### PR TITLE
Undo/Redo system (WIP)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,8 @@
     <MenuTop />
     <MenuLeft />
     <Grapher />
-    <MenuBottom />
+    <MenuBottomTools />
+    <MenuBottomUndo />
     <MenuRight />
   </div>
 </template>
@@ -14,7 +15,8 @@ import MenuTop from "./components/menu-top/MenuTop.vue";
 import MenuLeft from "./components/menu-left/MenuLeft.vue";
 import Grapher from "./components/grapher/Grapher.vue";
 import MenuRight from "./components/menu-right/MenuRight.vue";
-import MenuBottom from "./components/menu-bottom/MenuBottom.vue";
+import MenuBottomTools from "./components/menu-bottom/MenuBottomTools.vue";
+import MenuBottomUndo from "./components/menu-bottom/MenuBottomUndo.vue";
 
 export default Vue.extend({
   name: "App",
@@ -23,7 +25,8 @@ export default Vue.extend({
     MenuLeft,
     Grapher,
     MenuRight,
-    MenuBottom,
+    MenuBottomTools,
+    MenuBottomUndo,
   },
 });
 </script>
@@ -48,11 +51,11 @@ body,
 #app {
   overflow: hidden;
   display: grid;
-  grid-template-columns: 200px auto 250px;
+  grid-template-columns: 200px auto auto 250px;
   grid-template-rows: $navbar-height auto 36px; // See Bulma for navbar-height
   grid-template-areas:
-    "menu-top menu-top menu-top"
-    "menu-left grapher menu-right"
-    "menu-left menu-bottom menu-right";
+    "menu-top menu-top menu-top menu-top"
+    "menu-left grapher grapher menu-right"
+    "menu-left menu-bottom-tools menu-bottom-undo menu-right";
 }
 </style>

--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -24,6 +24,7 @@ import GrapherDots from "./GrapherDots.vue";
 import GrapherTool from "./GrapherTool.vue";
 import svgPanZoom from "svg-pan-zoom";
 import BaseTool from "@/tools/BaseTool";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Holds the components for rendering the field, dots, tools, etc.
@@ -43,7 +44,7 @@ export default Vue.extend({
       controlIconsEnabled: true,
       dblClickZoomEnabled: false,
     });
-    this.$store.commit("setGrapherSvgPanZoom", svgPanZoomInstance);
+    this.$store.commit(Mutations.SET_GRAPHER_SVG_PAN_ZOOM, svgPanZoomInstance);
 
     window.addEventListener("resize", this.onResize);
   },

--- a/src/components/menu-bottom/MenuBottomTools.vue
+++ b/src/components/menu-bottom/MenuBottomTools.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="menu-bottom">
+  <div class="menu-bottom-tools">
     <div class="buttons">
       <b-tooltip
         v-for="(toolData, index) in toolDataList"
         :key="`${toolData.icon}-toolData`"
         :label="toolData.label"
-        data-test="menu-bottom--tooltip"
+        data-test="menu-bottom-tools--tooltip"
       >
         <b-button
           :type="toolSelectedIndex === index ? 'is-primary' : 'is-light'"
           :icon-left="toolData.icon"
-          :data-test="`menu-bottom-tool--${toolData['data-test']}`"
+          :data-test="`menu-bottom-tools-tool--${toolData['data-test']}`"
           @click="setTool(index)"
         />
       </b-tooltip>
@@ -27,6 +27,7 @@ import BaseTool, { ToolConstructor } from "@/tools/BaseTool";
 import ToolBoxSelect from "@/tools/ToolBoxSelect";
 import ToolLassoSelect from "@/tools/ToolLassoSelect";
 import ToolSingleDot from "@/tools/ToolSingleDot";
+import { Mutations } from "@/store/mutations";
 
 interface ToolData {
   label: string;
@@ -36,7 +37,7 @@ interface ToolData {
 }
 
 export default Vue.extend({
-  name: "MenuBottom",
+  name: "MenuBottomTools",
   data: (): {
     toolDataList: ToolData[];
     toolSelectedIndex: number;
@@ -73,9 +74,9 @@ export default Vue.extend({
         toolIndex
       ].tool;
       const tool: BaseTool = new ToolConstructor();
-      this.$store.commit("setToolSelected", tool);
+      this.$store.commit(Mutations.SET_TOOL_SELECTED, tool);
       if (!tool.supportsSelection) {
-        this.$store.commit("clearSelectedDotIds");
+        this.$store.commit(Mutations.CLEAR_SELECTED_DOTS);
       }
     },
   },
@@ -83,7 +84,7 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
-.menu-bottom {
-  grid-area: menu-bottom;
+.menu-bottom-tools {
+  grid-area: menu-bottom-tools;
 }
 </style>

--- a/src/components/menu-bottom/MenuBottomUndo.vue
+++ b/src/components/menu-bottom/MenuBottomUndo.vue
@@ -5,7 +5,7 @@
         <b-tooltip :label="undoName" data-test="menu-bottom-undo--tooltip-undo">
           <b-button
             icon-left="undo"
-            data-test="`menu-bottom-undo-tool--undo"
+            data-test="menu-bottom-undo-tool--undo"
             @click="undo"
           />
         </b-tooltip>
@@ -14,14 +14,14 @@
         <b-button
           disabled
           icon-left="undo"
-          data-test="`menu-bottom-undo-tool--undo"
+          data-test="menu-bottom-undo-tool--undo"
         />
       </p>
       <p class="control" v-if="canRedo">
         <b-tooltip :label="redoName" data-test="menu-bottom-undo--tooltip-redo">
           <b-button
             icon-left="redo"
-            data-test="`menu-bottom-undo-tool--redo"
+            data-test="menu-bottom-undo-tool--redo"
             @click="redo"
           />
         </b-tooltip>
@@ -30,7 +30,7 @@
         <b-button
           disabled
           icon-left="redo"
-          data-test="`menu-bottom-undo-tool--redo"
+          data-test="menu-bottom-undo-tool--redo"
         />
       </p>
     </div>

--- a/src/components/menu-bottom/MenuBottomUndo.vue
+++ b/src/components/menu-bottom/MenuBottomUndo.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="menu-bottom-undo">
+    <div class="buttons">
+      <p class="control" v-if="canUndo">
+        <b-tooltip :label="undoName" data-test="menu-bottom-undo--tooltip-undo">
+          <b-button
+            icon-left="undo"
+            data-test="`menu-bottom-undo-tool--undo"
+            @click="undo"
+          />
+        </b-tooltip>
+      </p>
+      <p class="control" v-else>
+        <b-button
+          disabled
+          icon-left="undo"
+          data-test="`menu-bottom-undo-tool--undo"
+        />
+      </p>
+      <p class="control" v-if="canRedo">
+        <b-tooltip :label="redoName" data-test="menu-bottom-undo--tooltip-redo">
+          <b-button
+            icon-left="redo"
+            data-test="`menu-bottom-undo-tool--redo"
+            @click="redo"
+          />
+        </b-tooltip>
+      </p>
+      <p class="control" v-else>
+        <b-button
+          disabled
+          icon-left="redo"
+          data-test="`menu-bottom-undo-tool--redo"
+        />
+      </p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+/**
+ * Handles setting and modifying the tools used in Grapher
+ */
+import { Mutations } from "@/store/mutations";
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "MenuBottomUndo",
+  computed: {
+    canUndo(): boolean {
+      return this.$store.getters.getCanUndo;
+    },
+    undoName(): string {
+      return "Undo " + this.$store.getters.getUndoName;
+    },
+    redoName(): string {
+      return "Redo " + this.$store.getters.getRedoName;
+    },
+    canRedo(): boolean {
+      return this.$store.getters.getCanRedo;
+    },
+  },
+  // },
+  methods: {
+    undo(): void {
+      this.$store.commit(Mutations.UNDO);
+    },
+    redo(): void {
+      this.$store.commit(Mutations.REDO);
+    },
+  },
+});
+</script>

--- a/src/components/menu-left/MenuLeft.vue
+++ b/src/components/menu-left/MenuLeft.vue
@@ -71,6 +71,7 @@
 </template>
 
 <script lang="ts">
+import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 import StuntSheet from "../../models/StuntSheet";
 import StuntSheetModal from "./StuntSheetModal.vue";
@@ -91,7 +92,7 @@ export default Vue.extend({
         return this.$store.state.beat;
       },
       set(beat: number): void {
-        this.$store.commit("setBeat", beat);
+        this.$store.commit(Mutations.SET_BEAT, beat);
       },
     },
     beatString(): string {
@@ -107,8 +108,8 @@ export default Vue.extend({
         return this.$store.state.selectedSS;
       },
       set(selectedSS: number): void {
-        this.$store.commit("setSelectedSS", selectedSS);
-        this.$store.commit("setBeat", 0);
+        this.$store.commit(Mutations.SET_SELECTED_SS, selectedSS);
+        this.$store.commit(Mutations.SET_BEAT, 0);
       },
     },
     selectedSSBeats(): number {
@@ -119,13 +120,13 @@ export default Vue.extend({
   },
   methods: {
     addStuntSheet(): void {
-      this.$store.commit("addStuntSheet");
+      this.$store.commit(Mutations.ADD_STUNT_SHEET);
     },
     incrementBeat(): void {
-      this.$store.commit("incrementBeat");
+      this.$store.commit(Mutations.INCREMENT_BEAT);
     },
     decrementBeat(): void {
-      this.$store.commit("decrementBeat");
+      this.$store.commit(Mutations.DECREMENT_BEAT);
     },
   },
 });

--- a/src/components/menu-left/StuntSheetModal.vue
+++ b/src/components/menu-left/StuntSheetModal.vue
@@ -40,6 +40,7 @@
 </template>
 
 <script lang="ts">
+import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 
 /**
@@ -54,7 +55,7 @@ export default Vue.extend({
         return stuntSheet.title;
       },
       set(title: string): void {
-        this.$store.commit("setStuntSheetTitle", title);
+        this.$store.commit(Mutations.SET_STUNT_SHEET_TITLE, title);
       },
     },
 
@@ -64,7 +65,7 @@ export default Vue.extend({
         return stuntSheet.beats;
       },
       set(beats: number): void {
-        this.$store.commit("setStuntSheetBeats", beats);
+        this.$store.commit(Mutations.SET_STUNT_SHEET_BEATS, beats);
       },
     },
 
@@ -74,7 +75,7 @@ export default Vue.extend({
   },
   methods: {
     deleteSS(): void {
-      this.$store.commit("deleteStuntSheet");
+      this.$store.commit(Mutations.DELETE_STUNT_SHEET);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this.$parent as any).close();
     },

--- a/src/components/menu-right/ContETFDynamicEditor.vue
+++ b/src/components/menu-right/ContETFDynamicEditor.vue
@@ -81,15 +81,10 @@ export default Vue.extend({
         return continuity.eightToFiveType;
       },
       set(etfType: ETF_DYNAMIC_TYPES): void {
-        const continuity: ContETFDynamic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.eightToFiveType = etfType;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_ETF_TYPE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          etfType: etfType,
         });
       },
     },
@@ -102,15 +97,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContETFDynamic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity: continuity,
+          marchType: marchType,
         });
       },
     },

--- a/src/components/menu-right/ContETFDynamicEditor.vue
+++ b/src/components/menu-right/ContETFDynamicEditor.vue
@@ -48,6 +48,7 @@ import ContETFDynamic, {
 } from "@/models/continuity/ContETFDynamic";
 import { MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an Eight to Five Static continuity
@@ -85,7 +86,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.eightToFiveType = etfType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -106,7 +107,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity: continuity,
@@ -121,7 +122,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/ContETFStaticEditor.vue
+++ b/src/components/menu-right/ContETFStaticEditor.vue
@@ -53,6 +53,7 @@ import Vue from "vue";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an ETF-Static continuity
@@ -100,7 +101,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -122,7 +123,7 @@ export default Vue.extend({
         );
         continuity.marchingDirection = direction;
         continuity.facingDirection = direction;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity: continuity,
@@ -143,7 +144,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.duration = duration;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -158,7 +159,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/ContETFStaticEditor.vue
+++ b/src/components/menu-right/ContETFStaticEditor.vue
@@ -131,7 +131,7 @@ export default Vue.extend({
         this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          duration: duration
+          duration: duration,
         });
       },
     },

--- a/src/components/menu-right/ContETFStaticEditor.vue
+++ b/src/components/menu-right/ContETFStaticEditor.vue
@@ -96,15 +96,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContETFStatic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          marchType: marchType,
         });
       },
     },
@@ -117,16 +112,10 @@ export default Vue.extend({
         return continuity.marchingDirection;
       },
       set(direction: number): void {
-        const continuity: ContETFStatic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchingDirection = direction;
-        continuity.facingDirection = direction;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity: continuity,
+          direction: direction,
         });
       },
     },
@@ -139,15 +128,10 @@ export default Vue.extend({
         return continuity.duration;
       },
       set(duration: number): void {
-        const continuity: ContETFStatic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.duration = duration;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          duration: duration
         });
       },
     },

--- a/src/components/menu-right/ContEvenEditor.vue
+++ b/src/components/menu-right/ContEvenEditor.vue
@@ -98,7 +98,7 @@ export default Vue.extend({
         this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          duration: duration
+          duration: duration,
         });
       },
     },

--- a/src/components/menu-right/ContEvenEditor.vue
+++ b/src/components/menu-right/ContEvenEditor.vue
@@ -79,15 +79,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContEven = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          marchType: marchType,
         });
       },
     },
@@ -100,15 +95,10 @@ export default Vue.extend({
         return continuity.duration;
       },
       set(duration: number): void {
-        const continuity: ContEven = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.duration = duration;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          duration: duration
         });
       },
     },

--- a/src/components/menu-right/ContEvenEditor.vue
+++ b/src/components/menu-right/ContEvenEditor.vue
@@ -39,6 +39,7 @@ import Vue from "vue";
 import ContEven from "@/models/continuity/ContEven";
 import { MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an In Place continuity
@@ -83,7 +84,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -104,7 +105,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.duration = duration;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -119,7 +120,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/ContInPlaceEditor.vue
+++ b/src/components/menu-right/ContInPlaceEditor.vue
@@ -137,7 +137,7 @@ export default Vue.extend({
         this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          duration: duration
+          duration: duration,
         });
       },
     },

--- a/src/components/menu-right/ContInPlaceEditor.vue
+++ b/src/components/menu-right/ContInPlaceEditor.vue
@@ -102,15 +102,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContInPlace = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          marchType: marchType,
         });
       },
     },
@@ -123,15 +118,10 @@ export default Vue.extend({
         return continuity.direction;
       },
       set(direction: number): void {
-        const continuity: ContInPlace = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.direction = direction;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity: continuity,
+          direction: direction,
         });
       },
     },
@@ -144,15 +134,10 @@ export default Vue.extend({
         return continuity.duration;
       },
       set(duration: number): void {
-        const continuity: ContInPlace = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.duration = duration;
-        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          duration: duration
         });
       },
     },

--- a/src/components/menu-right/ContInPlaceEditor.vue
+++ b/src/components/menu-right/ContInPlaceEditor.vue
@@ -53,6 +53,7 @@ import Vue from "vue";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an In Place continuity
@@ -106,7 +107,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -127,7 +128,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.direction = direction;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity: continuity,
@@ -148,7 +149,7 @@ export default Vue.extend({
           this.continuityIndex
         );
         continuity.duration = duration;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
           continuity,
@@ -163,7 +164,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import BaseCont from "@/models/continuity/BaseCont";
+import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 import ContInPlace from "@/models/continuity/ContInPlace";
@@ -80,25 +80,25 @@ export default Vue.extend({
     addContInPlace() {
       this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContInPlace(),
+        contID: CONT_IDS.IN_PLACE,
       });
     },
     addContETFDynamic() {
       this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContETFDynamic(),
+        contID: CONT_IDS.ETF_DYNAMIC,
       });
     },
     addContETFStatic() {
       this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContETFStatic(),
+        contID: CONT_IDS.ETF_STATIC,
       });
     },
     addContEven() {
       this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContEven(),
+        contID: CONT_IDS.EVEN,
       });
     },
   },

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -53,6 +53,7 @@ import ContEven from "@/models/continuity/ContEven";
 import StuntSheet from "@/models/StuntSheet";
 import Vue from "vue";
 import ContEditorHelper from "./ContEditorHelper.vue";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit all continuiuties for a dot type
@@ -77,25 +78,25 @@ export default Vue.extend({
   },
   methods: {
     addContInPlace() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuity: new ContInPlace(),
       });
     },
     addContETFDynamic() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuity: new ContETFDynamic(),
       });
     },
     addContETFStatic() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuity: new ContETFStatic(),
       });
     },
     addContEven() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuity: new ContEven(),
       });

--- a/src/components/menu-right/MenuRight.vue
+++ b/src/components/menu-right/MenuRight.vue
@@ -23,6 +23,7 @@ import DotTypeEditor from "./DotTypeEditor.vue";
 import BaseCont from "@/models/continuity/BaseCont";
 import Vue from "vue";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 export default Vue.extend({
   name: "MenuRight",
@@ -38,7 +39,7 @@ export default Vue.extend({
   },
   methods: {
     addDotType() {
-      this.$store.commit("addDotType");
+      this.$store.commit(Mutations.ADD_DOT_TYPE);
     },
   },
 });

--- a/src/components/menu-top/FileModal.vue
+++ b/src/components/menu-top/FileModal.vue
@@ -53,6 +53,7 @@
 
 <script lang="ts">
 import Vue from "vue";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Show and modify values in the current Show model
@@ -65,7 +66,7 @@ export default Vue.extend({
         return this.$store.getters.getShowTitle;
       },
       set(title: string): void {
-        this.$store.commit("setShowTitle", title);
+        this.$store.commit(Mutations.SET_SHOW_TITLE, title);
       },
     },
 
@@ -74,7 +75,7 @@ export default Vue.extend({
         return this.$store.getters.getFrontHashOffsetY;
       },
       set(offsetY: number): void {
-        this.$store.commit("setFrontHashOffsetY", offsetY);
+        this.$store.commit(Mutations.SET_FRONT_HASH_OFFSET_Y, offsetY);
       },
     },
 
@@ -83,7 +84,7 @@ export default Vue.extend({
         return this.$store.getters.getBackHashOffsetY;
       },
       set(offsetY: number): void {
-        this.$store.commit("setBackHashOffsetY", offsetY);
+        this.$store.commit(Mutations.SET_BACK_HASH_OFFSET_Y, offsetY);
       },
     },
 
@@ -92,7 +93,7 @@ export default Vue.extend({
         return this.$store.getters.getMiddleOfField;
       },
       set(middle: number): void {
-        this.$store.commit("setMiddleOfField", middle);
+        this.$store.commit(Mutations.SET_MIDDLE_OF_FIELD, middle);
       },
     },
   },

--- a/src/components/menu-top/LoadModal.vue
+++ b/src/components/menu-top/LoadModal.vue
@@ -50,16 +50,18 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { loadShowFromBuffer } from "@/models/util/LoadShow";
+import InitialLoadShowState from "@/models/InitialLoadShowState";
 import Show from "@/models/Show";
+import { Mutations } from "@/store/mutations";
 
 export default Vue.extend({
   name: "LoadModal",
   data: (): {
     file: Blob | null;
+    showLoadState: InitialLoadShowState | null;
     showPreview: Show | null;
     parseError: string;
-  } => ({ file: null, showPreview: null, parseError: "" }),
+  } => ({ file: null, showLoadState: null, showPreview: null, parseError: "" }),
   computed: {
     numMarchers(): number {
       return this.showPreview ? this.showPreview.dotLabels.length : 0;
@@ -79,7 +81,10 @@ export default Vue.extend({
       reader.onload = (): void => {
         if (reader.result && reader.result instanceof ArrayBuffer) {
           try {
-            this.showPreview = loadShowFromBuffer(reader.result);
+            this.showLoadState = new InitialLoadShowState({
+              showData: reader.result,
+            });
+            this.showPreview = this.showLoadState.getInitialState();
           } catch (e) {
             this.parseError = e;
           }
@@ -93,7 +98,7 @@ export default Vue.extend({
       if (!this.showPreview) {
         return;
       }
-      this.$store.commit("setShow", this.showPreview);
+      this.$store.commit(Mutations.SET_SHOW, this.showLoadState);
     },
   },
 });

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -27,6 +27,16 @@
           >
             Edit Show Details
           </b-navbar-item>
+
+          <hr class="navbar-divider" />
+
+          <b-navbar-item data-test="menu-top--undo" @click="undo">
+            Undo {{ undoName }}
+          </b-navbar-item>
+
+          <b-navbar-item data-test="menu-top--redo" @click="redo">
+            Redo {{ redoName }}
+          </b-navbar-item>
         </b-navbar-dropdown>
 
         <b-navbar-dropdown label="View" data-test="menu-top--view">
@@ -83,6 +93,7 @@
 </template>
 
 <script lang="ts">
+import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 import FileModal from "./FileModal.vue";
 import LoadModal from "./LoadModal.vue";
@@ -110,7 +121,7 @@ export default Vue.extend({
         return this.$store.state.fourStepGrid;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setFourStepGrid", enabled);
+        this.$store.commit(Mutations.SET_FOUR_STEP_GRID, enabled);
       },
     },
 
@@ -119,7 +130,7 @@ export default Vue.extend({
         return this.$store.state.yardlines;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setYardlines", enabled);
+        this.$store.commit(Mutations.SET_YARDLINES, enabled);
       },
     },
 
@@ -128,7 +139,7 @@ export default Vue.extend({
         return this.$store.state.yardlineNumbers;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setYardlineNumbers", enabled);
+        this.$store.commit(Mutations.SET_YARDLINE_NUMBERS, enabled);
       },
     },
 
@@ -137,8 +148,23 @@ export default Vue.extend({
         return this.$store.state.showDotLabels;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setShowDotLabels", enabled);
+        this.$store.commit(Mutations.SET_SHOW_DOT_LABELS, enabled);
       },
+    },
+
+    undoName(): string {
+      return this.$store.getters.getUndoName;
+    },
+    redoName(): string {
+      return this.$store.getters.getRedoName;
+    },
+  },
+  methods: {
+    undo(): void {
+      this.$store.commit(Mutations.UNDO);
+    },
+    redo(): void {
+      this.$store.commit(Mutations.REDO);
     },
   },
 });

--- a/src/models/InitialLoadShowState.ts
+++ b/src/models/InitialLoadShowState.ts
@@ -1,0 +1,30 @@
+import InitialShowState from "./InitialShowState";
+import { loadShowFromBuffer } from "@/models/util/LoadShow";
+import Show from "./Show";
+
+// Increment upon making show metadata changes that break previous versions.
+const METADATA_VERSION = 1;
+
+/**
+ */
+export default class InitialLoadShowState extends InitialShowState {
+  metadataVersion: number = METADATA_VERSION;
+
+  showData: ArrayBuffer | undefined;
+
+  constructor(json: Partial<InitialLoadShowState> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  /**
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store
+   * the flow based on it's continuities in stuntSheetDot.cachedFlow.
+   */
+  getInitialState(): Show {
+    if (this.showData) {
+      return loadShowFromBuffer(this.showData);
+    }
+    return new Show();
+  }
+}

--- a/src/models/InitialShowState.ts
+++ b/src/models/InitialShowState.ts
@@ -1,0 +1,31 @@
+import Serializable from "./util/Serializable";
+import Show from "./Show";
+
+// Increment upon making show metadata changes that break previous versions.
+const METADATA_VERSION = 1;
+
+/**
+ * Defines an object that creates the initial state of a show for Undo system.
+ * This way when we save and restore CalChart we have a way to always get back
+ * to the orignal starting point.
+ *
+ * Initializing a show state for a new show from scratch is the default.  This
+ * can be extended to load shows from other locations, like an array buffer
+ * representing a show from a previous version of CalChart.
+ */
+export default class InitialShowState extends Serializable<InitialShowState> {
+  metadataVersion: number = METADATA_VERSION;
+
+  constructor(json: Partial<InitialShowState> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  /**
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store
+   * the flow based on it's continuities in stuntSheetDot.cachedFlow.
+   */
+  getInitialState(): Show {
+    return new Show();
+  }
+}

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -73,22 +73,21 @@ export default class StuntSheet extends Serializable<StuntSheet> {
     this.fromJson(json);
   }
 
-  addDot(dot: Partial<StuntSheetDot> = {}): void {
-    this.stuntSheetDots.push(new StuntSheetDot(dot));
+  addDots(dots: Partial<StuntSheetDot>[] = []): void {
+    this.stuntSheetDots = this.stuntSheetDots.concat(dots.map(dot => new StuntSheetDot(dot)));
   }
 
-  removeDot(dotId: number): void {
-    const dotIndex = this.stuntSheetDots.findIndex((dot) => dot.id === dotId);
-    if (dotIndex !== -1) {
-      this.stuntSheetDots.splice(dotIndex, 1);
-    }
+  removeDots(indices: number[]): void {
+    this.stuntSheetDots = this.stuntSheetDots.filter(dot => !indices.includes(dot.id));
   }
 
-  moveDot(dotId: number, position: [number, number]): void {
-    const selectedDot = this.stuntSheetDots.find((dot) => dot.id === dotId);
-    if (selectedDot) {
-      selectedDot.x = position[0];
-      selectedDot.y = position[1];
+  moveDots(newPositions: [number, [number, number]][]): void {
+    for (const newPosition of newPositions) {
+      const selectedDot = this.stuntSheetDots.find((dot) => dot.id === newPosition[0]);
+      if (selectedDot) {
+        selectedDot.x = newPosition[1][0];
+        selectedDot.y = newPosition[1][1];
+      }
     }
   }
 }

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -74,16 +74,22 @@ export default class StuntSheet extends Serializable<StuntSheet> {
   }
 
   addDots(dots: Partial<StuntSheetDot>[] = []): void {
-    this.stuntSheetDots = this.stuntSheetDots.concat(dots.map(dot => new StuntSheetDot(dot)));
+    this.stuntSheetDots = this.stuntSheetDots.concat(
+      dots.map((dot) => new StuntSheetDot(dot))
+    );
   }
 
   removeDots(indices: number[]): void {
-    this.stuntSheetDots = this.stuntSheetDots.filter(dot => !indices.includes(dot.id));
+    this.stuntSheetDots = this.stuntSheetDots.filter(
+      (dot) => !indices.includes(dot.id)
+    );
   }
 
   moveDots(newPositions: [number, [number, number]][]): void {
     for (const newPosition of newPositions) {
-      const selectedDot = this.stuntSheetDots.find((dot) => dot.id === newPosition[0]);
+      const selectedDot = this.stuntSheetDots.find(
+        (dot) => dot.id === newPosition[0]
+      );
       if (selectedDot) {
         selectedDot.x = newPosition[1][0];
         selectedDot.y = newPosition[1][1];

--- a/src/models/UndoRedo.ts
+++ b/src/models/UndoRedo.ts
@@ -1,0 +1,74 @@
+import { Mutations, UNDOABLE_ACTIONS } from "@/store/mutations";
+import { CalChartState } from "@/store";
+import Serializable from "./util/Serializable";
+
+// Increment upon making show metadata changes that break previous versions.
+const METADATA_VERSION = 1;
+
+// The UndoRedo holds the initial state of the show and all new changes
+// built on it.  It provides the long history of the show as it was created.
+// https://vuejsdevelopers.com/2017/11/13/vue-js-vuex-undo-redo/
+export class UndoRedo extends Serializable<UndoRedo> {
+  metadataVersion: number = METADATA_VERSION;
+
+  done: any[] = [];
+  undone: any[] = [];
+  newMutation = true;
+
+  constructor(json: Partial<UndoRedo> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  canUndo(): boolean {
+    return this.done.length > 0;
+  }
+
+  undoString(): string {
+    return this.done.length ? this.done[this.done.length - 1].type : "";
+  }
+
+  canRedo(): boolean {
+    return this.undone.length > 0;
+  }
+
+  redoString(): string {
+    return this.undone.length ? this.undone[this.undone.length - 1].type : "";
+  }
+
+  createPlugin() {
+    return (store: any) => {
+      // called when the store is initialized
+      store.subscribe((mutation: any, state: CalChartState) => {
+        if (UNDOABLE_ACTIONS.includes(mutation.type)) {
+          this.done.push(mutation);
+          if (this.newMutation) {
+            this.undone = [];
+          }
+        }
+        if (mutation.type === Mutations.UNDO) {
+          const lastAction = this.done.pop();
+          if (!lastAction) {
+            return;
+          }
+          this.undone.push(lastAction);
+          this.newMutation = false;
+          store.commit(Mutations.INITIAL_SHOW_STATE);
+          this.done.forEach((mutant: any) => {
+            store.commit(`${mutant.type}`, mutant.payload);
+            this.done.pop();
+          });
+          this.newMutation = true;
+        }
+        if (mutation.type === Mutations.REDO) {
+          const commit = this.undone.pop();
+          if (commit) {
+            this.newMutation = false;
+            store.commit(`${commit.type}`, commit.payload);
+            this.newMutation = true;
+          }
+        }
+      });
+    };
+  }
+}

--- a/src/models/continuity/ContFactory.ts
+++ b/src/models/continuity/ContFactory.ts
@@ -17,9 +17,7 @@ import ContStepTwo from "./ContStepTwo";
  *                     undefined, the marcher will face the direction they are
  *                     marching.
  */
-export const ContFactory = (
-  whichCont: CONT_IDS
-): BaseCont => {
+export const ContFactory = (whichCont: CONT_IDS): BaseCont => {
   switch (whichCont) {
     case CONT_IDS.IN_PLACE:
       return new ContInPlace();
@@ -38,4 +36,4 @@ export const ContFactory = (
     case CONT_IDS.STEP_TWO:
       return new ContStepTwo();
   }
-}
+};

--- a/src/models/continuity/ContFactory.ts
+++ b/src/models/continuity/ContFactory.ts
@@ -1,0 +1,41 @@
+import ContEven from "./ContEven";
+import BaseCont, { CONT_IDS } from "./BaseCont";
+import ContCounterMarch from "./ContCounterMarch";
+import ContInPlace from "./ContInPlace";
+import ContETFStatic from "./ContETFStatic";
+import ContETFDynamic from "./ContETFDynamic";
+import ContFollowLeader from "./ContFollowLeader";
+import ContGateTurn from "./ContGateTurn";
+import ContStepTwo from "./ContStepTwo";
+
+/**
+ * Factory function for creating a new continuity
+ *
+ * @param offsetX    - How many steps to march. Positive is north, negative is
+ *                     south.
+ * @param direction? - To enforce a direction to face, set this parameter. If
+ *                     undefined, the marcher will face the direction they are
+ *                     marching.
+ */
+export const ContFactory = (
+  whichCont: CONT_IDS
+): BaseCont => {
+  switch (whichCont) {
+    case CONT_IDS.IN_PLACE:
+      return new ContInPlace();
+    case CONT_IDS.ETF_STATIC:
+      return new ContETFStatic();
+    case CONT_IDS.ETF_DYNAMIC:
+      return new ContETFDynamic();
+    case CONT_IDS.EVEN:
+      return new ContEven();
+    case CONT_IDS.FOLLOW_LEADER:
+      return new ContFollowLeader();
+    case CONT_IDS.COUNTER_MARCH:
+      return new ContCounterMarch();
+    case CONT_IDS.GATE_TURN:
+      return new ContGateTurn();
+    case CONT_IDS.STEP_TWO:
+      return new ContStepTwo();
+  }
+}

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -25,6 +25,12 @@ const getters: GetterTree<CalChartState, CalChartState> = {
     state.show.stuntSheets[state.selectedSS].dotTypes[dotTypeIndex][
       continuityIndex
     ],
+
+  // Undo
+  getCanUndo: (state): boolean => state.undoRedo.canUndo(),
+  getUndoName: (state): string => state.undoRedo.undoString(),
+  getCanRedo: (state): boolean => state.undoRedo.canRedo(),
+  getRedoName: (state): string => state.undoRedo.redoString(),
 };
 
 export default getters;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,13 @@
 import Vue from "vue";
 import Vuex, { Store } from "vuex";
-import mutations from "./mutations";
+import { mutations } from "./mutations";
 import getters from "./getters";
 import Show from "@/models/Show";
 import Serializable from "@/models/util/Serializable";
 import BaseTool from "@/tools/BaseTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { UndoRedo } from "@/models/UndoRedo";
+import InitialShowState from "@/models/InitialShowState";
 
 Vue.use(Vuex);
 
@@ -13,6 +15,8 @@ Vue.use(Vuex);
  * Defines the global state for the application
  *
  * @property show              - The currently selected show data
+ * @property initialShowState  - Beginning spot for undo system
+ * @property undoRedo          - The undoRedo state
  * @property selectedSS        - Index of stuntsheet currently in view
  * @property beat              - The point in time the show is in
  * @property fourStepGrid      - View setting to toggle the grapher grid
@@ -23,6 +27,10 @@ Vue.use(Vuex);
  */
 export class CalChartState extends Serializable<CalChartState> {
   show: Show = new Show();
+
+  initialShowState: InitialShowState = new InitialShowState();
+
+  undoRedo: UndoRedo = new UndoRedo();
 
   selectedSS = 0;
 
@@ -58,11 +66,14 @@ export class CalChartState extends Serializable<CalChartState> {
 
 export const generateStore = (
   json: Partial<CalChartState> = {}
-): Store<CalChartState> =>
-  new Vuex.Store({
-    state: new CalChartState(json),
+): Store<CalChartState> => {
+  const show = new CalChartState(json);
+  return new Vuex.Store({
+    state: show,
     mutations,
     getters,
+    plugins: [show.undoRedo.createPlugin()],
   });
+};
 
 export const GlobalStore = generateStore();

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,5 +1,5 @@
 import { CalChartState } from ".";
-import Show from "@/models/Show";
+import InitialShowState from "@/models/InitialShowState";
 import getters from "./getters";
 import BaseTool from "@/tools/BaseTool";
 import StuntSheet from "@/models/StuntSheet";
@@ -9,15 +9,81 @@ import BaseCont from "@/models/continuity/BaseCont";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import DotAppearance from "@/models/DotAppearance";
 
-const mutations: MutationTree<CalChartState> = {
-  // Show
-  setShow(state, show: Show): void {
-    state.show = show;
+export enum Mutations {
+  // Show mutations:
+  SET_SHOW = "Set new Show",
+  SET_SHOW_TITLE = "Set Show title",
+  ADD_STUNT_SHEET = "Add Stunt Sheet",
+  DELETE_STUNT_SHEET = "Delete Stunt Sheet",
+  // Field mutations:
+  SET_FRONT_HASH_OFFSET_Y = "Set front hash offset",
+  SET_BACK_HASH_OFFSET_Y = "Set back has offset",
+  SET_MIDDLE_OF_FIELD = "Set middle of field",
+  // Stuntsheet mutations:
+  ADD_DOTS = "Add Marcher",
+  REMOVE_DOTS = "Remove Marcher",
+  MOVE_DOTS = "Move Marcher",
+  SET_STUNT_SHEET_TITLE = "Set Stunt Sheet title",
+  SET_STUNT_SHEET_BEATS = "Set Stund Sheet beats",
+  ADD_DOT_TYPE = "Add Marcher type",
+  ADD_CONTINUITY = "Add Continuity",
+  // Continuity mutations:
+  UPDATE_DOT_TYPE_CONTINUITY = "Update Marcher Continuity",
+  DELETE_DOT_TYPE_CONTINUITY = "Remove Marcher Continuity",
+
+  // View mutations:
+  SET_SELECTED_SS = "setSelectedSS",
+  SET_BEAT = "setBeat",
+  INCREMENT_BEAT = "incrementBeat",
+  DECREMENT_BEAT = "decrementBeat",
+  // Field view mutations:
+  SET_FOUR_STEP_GRID = "setFourStepGrid",
+  SET_YARDLINES = "setYardlines",
+  SET_YARDLINE_NUMBERS = "setYardlineNumbers",
+  SET_SHOW_DOT_LABELS = "setShowDotLabels",
+  // Tools
+  SET_GRAPHER_SVG_PAN_ZOOM = "setGrapherSvgPanZoom",
+  SET_INVERTED_CTM_MATRIX = "setInvertedCTMMatrix",
+  SET_TOOL_SELECTED = "setToolSelected",
+  SET_GRAPHER_TOOL_DOTS = "setGrapherToolDots",
+  // selection
+  CLEAR_SELECTED_DOTS = "clearSelectedDots",
+  ADD_SELECTED_DOTS = "addSelectedDots",
+  TOGGLE_SELECTED_DOTS = "toggleSelectedDots",
+  SET_SELECTION_LASSO = "setSelectionLasso",
+
+  UNDO = "undo",
+  REDO = "redo",
+  INITIAL_SHOW_STATE = "resetShowState",
+}
+
+export const UNDOABLE_ACTIONS = [
+  Mutations.SET_SHOW_TITLE,
+  Mutations.ADD_STUNT_SHEET,
+  Mutations.DELETE_STUNT_SHEET,
+  Mutations.SET_FRONT_HASH_OFFSET_Y,
+  Mutations.SET_BACK_HASH_OFFSET_Y,
+  Mutations.SET_MIDDLE_OF_FIELD,
+  Mutations.ADD_DOTS,
+  Mutations.REMOVE_DOTS,
+  Mutations.MOVE_DOTS,
+  Mutations.SET_STUNT_SHEET_TITLE,
+  Mutations.SET_STUNT_SHEET_BEATS,
+  Mutations.ADD_DOT_TYPE,
+  Mutations.ADD_CONTINUITY,
+  Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+  Mutations.DELETE_DOT_TYPE_CONTINUITY,
+];
+
+export const mutations: MutationTree<CalChartState> = {
+  [Mutations.SET_SHOW](state, initialShowState: InitialShowState): void {
+    state.initialShowState = initialShowState;
+    state.show = state.initialShowState.getInitialState();
   },
-  setShowTitle(state, title: string): void {
+  [Mutations.SET_SHOW_TITLE](state, title: string): void {
     state.show.title = title;
   },
-  addStuntSheet(state): void {
+  [Mutations.ADD_STUNT_SHEET](state): void {
     state.show.stuntSheets.push(
       new StuntSheet({
         title: `Stuntsheet ${state.show.stuntSheets.length + 1}`,
@@ -26,63 +92,63 @@ const mutations: MutationTree<CalChartState> = {
     state.selectedSS = state.show.stuntSheets.length - 1;
     state.beat = 1;
   },
-  deleteStuntSheet(state): void {
+  [Mutations.DELETE_STUNT_SHEET](state): void {
     state.show.stuntSheets.splice(state.selectedSS, 1);
     state.selectedSS = Math.max(0, state.selectedSS - 1);
     state.beat = 1;
   },
 
   // Show -> Field
-  setFrontHashOffsetY(state, offsetY: number): void {
+  [Mutations.SET_FRONT_HASH_OFFSET_Y](state, offsetY: number): void {
     state.show.field.frontHashOffsetY = offsetY;
   },
-  setBackHashOffsetY(state, offsetY: number): void {
+  [Mutations.SET_BACK_HASH_OFFSET_Y](state, offsetY: number): void {
     state.show.field.backHashOffsetY = offsetY;
   },
-  setMiddleOfField(state, middle: number): void {
+  [Mutations.SET_MIDDLE_OF_FIELD](state, middle: number): void {
     state.show.field.middleOfField = middle;
   },
 
   // Show -> StuntSheet
-  removeDot(state, dotId: number): void {
+  [Mutations.REMOVE_DOTS](state, dotIndex: number[]): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.removeDot(dotId);
+    currentSS.removeDots(dotIndex);
   },
-  addDot(state, dot: Partial<StuntSheetDot>): void {
+  [Mutations.ADD_DOTS](state, jsons: Partial<StuntSheetDot>[]): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.addDot(dot);
+    currentSS.addDots(jsons.map((json) => new StuntSheetDot(json)));
   },
-  moveDot(
+  [Mutations.MOVE_DOTS](
     state,
-    { dotId, position }: { dotId: number; position: [number, number] }
+    newPositions: [number, [number, number]][]
   ): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.moveDot(dotId, position);
+    currentSS.moveDots(newPositions);
   },
-  setStuntSheetTitle(state, title: string): void {
+  [Mutations.SET_STUNT_SHEET_TITLE](state, title: string): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.title = title;
   },
-  setStuntSheetBeats(state, beats: number): void {
+  [Mutations.SET_STUNT_SHEET_BEATS](state, beats: number): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.beats = beats;
   },
-  addDotType(state): void {
+  [Mutations.ADD_DOT_TYPE](state): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
@@ -90,7 +156,7 @@ const mutations: MutationTree<CalChartState> = {
     currentSS.dotTypes.push([new ContInPlace()]);
     currentSS.dotAppearances.push(new DotAppearance());
   },
-  addContinuity(
+  [Mutations.ADD_CONTINUITY](
     state,
     { dotTypeIndex, continuity }: { dotTypeIndex: number; continuity: BaseCont }
   ): void {
@@ -103,7 +169,7 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // Show -> StuntSheet -> BaseCont
-  updateDotTypeContinuity(
+  [Mutations.UPDATE_DOT_TYPE_CONTINUITY](
     state,
     {
       dotTypeIndex,
@@ -118,7 +184,7 @@ const mutations: MutationTree<CalChartState> = {
     currentSS.dotTypes[dotTypeIndex][continuityIndex] = continuity;
     state.show.generateFlows(state.selectedSS);
   },
-  deleteDotTypeContinuity(
+  [Mutations.DELETE_DOT_TYPE_CONTINUITY](
     state,
     {
       dotTypeIndex,
@@ -134,13 +200,13 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // Show controls
-  setSelectedSS(state, selectedSS: number): void {
+  [Mutations.SET_SELECTED_SS](state, selectedSS: number): void {
     state.selectedSS = selectedSS;
   },
-  setBeat(state, beat: number): void {
+  [Mutations.SET_BEAT](state, beat: number): void {
     state.beat = beat;
   },
-  incrementBeat(state): void {
+  [Mutations.INCREMENT_BEAT](state): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
@@ -159,7 +225,7 @@ const mutations: MutationTree<CalChartState> = {
       state.beat += 1;
     }
   },
-  decrementBeat(state): void {
+  [Mutations.DECREMENT_BEAT](state): void {
     if (state.beat - 1 < 0) {
       if (state.selectedSS > 0) {
         // Go to previous stuntsheet's 2nd to last beat
@@ -179,44 +245,50 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // View Settings
-  setFourStepGrid(state, enabled: boolean): void {
+  [Mutations.SET_FOUR_STEP_GRID](state, enabled: boolean): void {
     state.fourStepGrid = enabled;
   },
-  setYardlines(state, enabled: boolean): void {
+  [Mutations.SET_YARDLINES](state, enabled: boolean): void {
     state.yardlines = enabled;
   },
-  setYardlineNumbers(state, enabled: boolean): void {
+  [Mutations.SET_YARDLINE_NUMBERS](state, enabled: boolean): void {
     state.yardlineNumbers = enabled;
   },
-  setShowDotLabels(state, enabled: boolean): void {
+  [Mutations.SET_SHOW_DOT_LABELS](state, enabled: boolean): void {
     state.showDotLabels = enabled;
   },
 
   // Tools
-  setGrapherSvgPanZoom(state, svgPanZoomInstance: SvgPanZoom.Instance): void {
+  [Mutations.SET_GRAPHER_SVG_PAN_ZOOM](
+    state,
+    svgPanZoomInstance: SvgPanZoom.Instance
+  ): void {
     state.grapherSvgPanZoom = svgPanZoomInstance;
   },
-  setInvertedCTMMatrix(state, matrix: DOMMatrix): void {
+  [Mutations.SET_INVERTED_CTM_MATRIX](state, matrix: DOMMatrix): void {
     state.invertedCTMMatrix = matrix;
   },
-  setToolSelected(state, toolSelected: BaseTool): void {
+  [Mutations.SET_TOOL_SELECTED](state, toolSelected: BaseTool): void {
     state.toolSelected = toolSelected;
     state.grapherToolDots = [];
   },
-  setGrapherToolDots(state, grapherToolDots: StuntSheetDot[]): void {
+  [Mutations.SET_GRAPHER_TOOL_DOTS](
+    state,
+    grapherToolDots: StuntSheetDot[]
+  ): void {
     state.grapherToolDots = grapherToolDots;
   },
 
   // selection
-  clearSelectedDotIds(state): void {
+  [Mutations.CLEAR_SELECTED_DOTS](state): void {
     state.selectedDotIds = [];
   },
-  addSelectedDotIds(state, dotIds: number[]): void {
+  [Mutations.ADD_SELECTED_DOTS](state, dotIds: number[]): void {
     dotIds.forEach((id) => {
       !state.selectedDotIds.includes(id) && state.selectedDotIds.push(id);
     });
   },
-  toggleSelectedDotIds(state, dotIds: number[]): void {
+  [Mutations.TOGGLE_SELECTED_DOTS](state, dotIds: number[]): void {
     // first remove all the items passed in.
     dotIds.forEach((id) => {
       const index = state.selectedDotIds.indexOf(id);
@@ -227,9 +299,18 @@ const mutations: MutationTree<CalChartState> = {
       }
     });
   },
-  setSelectionLasso(state, lasso: [number, number][]): void {
+  [Mutations.SET_SELECTION_LASSO](state, lasso: [number, number][]): void {
     state.selectionLasso = lasso;
   },
-};
 
-export default mutations;
+  // Undo system
+  [Mutations.UNDO](): void {
+    // intentionally empty as the Undo system is "sniffing" for this command.
+  },
+  [Mutations.REDO](): void {
+    // intentionally empty as the Undo system is "sniffing" for this command.
+  },
+  [Mutations.INITIAL_SHOW_STATE](state): void {
+    state.show = state.initialShowState.getInitialState();
+  },
+};

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -7,9 +7,11 @@ import StuntSheetDot from "@/models/StuntSheetDot";
 import { MutationTree } from "vuex";
 import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
 import ContInPlace from "@/models/continuity/ContInPlace";
-import ContETFDynamic, { ETF_DYNAMIC_TYPES } from "@/models/continuity/ContETFDynamic";
+import ContETFDynamic, {
+  ETF_DYNAMIC_TYPES,
+} from "@/models/continuity/ContETFDynamic";
 import DotAppearance from "@/models/DotAppearance";
-import { ContFactory } from "@/models/continuity/ContFactory"
+import { ContFactory } from "@/models/continuity/ContFactory";
 import { MARCH_TYPES } from "@/models/util/constants";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 
@@ -192,7 +194,10 @@ export const mutations: MutationTree<CalChartState> = {
     const getContinuity = getters.getContinuity as (
       state: CalChartState
     ) => (dotTypeIndex: number, continuityIndex: number) => BaseCont;
-    const continuity: BaseCont = getContinuity(state)(dotTypeIndex, continuityIndex)
+    const continuity: BaseCont = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
     continuity.marchType = marchType;
     updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
   },
@@ -207,7 +212,10 @@ export const mutations: MutationTree<CalChartState> = {
     const getContinuity = getters.getContinuity as (
       state: CalChartState
     ) => (dotTypeIndex: number, continuityIndex: number) => BaseCont;
-    const continuity: BaseCont = getContinuity(state)(dotTypeIndex, continuityIndex)
+    const continuity: BaseCont = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
     continuity.duration = duration;
     updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
   },
@@ -217,12 +225,19 @@ export const mutations: MutationTree<CalChartState> = {
       dotTypeIndex,
       continuityIndex,
       etfType,
-    }: { dotTypeIndex: number; continuityIndex: number; etfType: ETF_DYNAMIC_TYPES }
+    }: {
+      dotTypeIndex: number;
+      continuityIndex: number;
+      etfType: ETF_DYNAMIC_TYPES;
+    }
   ): void {
     const getContinuity = getters.getContinuity as (
       state: CalChartState
     ) => (dotTypeIndex: number, continuityIndex: number) => ContETFDynamic;
-    const continuity: ContETFDynamic = getContinuity(state)(dotTypeIndex, continuityIndex)
+    const continuity: ContETFDynamic = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
     continuity.eightToFiveType = etfType;
     updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
   },
@@ -237,7 +252,10 @@ export const mutations: MutationTree<CalChartState> = {
     const getContinuity = getters.getContinuity as (
       state: CalChartState
     ) => (dotTypeIndex: number, continuityIndex: number) => ContETFStatic;
-    const continuity: ContETFStatic = getContinuity(state)(dotTypeIndex, continuityIndex)
+    const continuity: ContETFStatic = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
     continuity.marchingDirection = direction;
     continuity.facingDirection = direction;
     updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
@@ -253,7 +271,10 @@ export const mutations: MutationTree<CalChartState> = {
     const getContinuity = getters.getContinuity as (
       state: CalChartState
     ) => (dotTypeIndex: number, continuityIndex: number) => ContInPlace;
-    const continuity: ContInPlace = getContinuity(state)(dotTypeIndex, continuityIndex)
+    const continuity: ContInPlace = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
     continuity.direction = direction;
     updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
   },
@@ -387,7 +408,6 @@ export const mutations: MutationTree<CalChartState> = {
     state.show = state.initialShowState.getInitialState();
   },
 };
-
 
 function updateContinuity(
   state: CalChartState,

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -1,5 +1,6 @@
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Defines the functionality of a tool to be used in the Bottom Menu.
@@ -77,7 +78,7 @@ export default abstract class BaseTool {
     if (!ctm) {
       throw new Error("Unable to retrieve wrapper CTM");
     }
-    GlobalStore.commit("setInvertedCTMMatrix", ctm.inverse());
+    GlobalStore.commit(Mutations.SET_INVERTED_CTM_MATRIX, ctm.inverse());
   }
 
   abstract onMouseDown(event: MouseEvent): void;

--- a/src/tools/ToolBoxSelect.ts
+++ b/src/tools/ToolBoxSelect.ts
@@ -1,6 +1,7 @@
 import { ToolConstructor } from "./BaseTool";
 import { ToolSelectMove } from "./ToolSelectMove";
 import { GlobalStore } from "@/store";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Enables Selection, Moving, and Panning via base class
@@ -11,7 +12,7 @@ const ToolBoxSelect: ToolConstructor = class ToolBoxSelect extends ToolSelectMov
     if (this.selectionLassoStart === null) {
       return;
     }
-    GlobalStore.commit("setSelectionLasso", [
+    GlobalStore.commit(Mutations.SET_SELECTION_LASSO, [
       [this.selectionLassoStart[0], this.selectionLassoStart[1]],
       [point[0], this.selectionLassoStart[1]],
       [point[0], point[1]],

--- a/src/tools/ToolLassoSelect.ts
+++ b/src/tools/ToolLassoSelect.ts
@@ -1,6 +1,7 @@
 import { ToolConstructor } from "./BaseTool";
 import { ToolSelectMove } from "./ToolSelectMove";
 import { GlobalStore } from "@/store";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Enables Selection, Moving, and Panning via base class
@@ -13,7 +14,7 @@ const ToolLassoSelect: ToolConstructor = class ToolLassoSelect extends ToolSelec
     }
     const arrayCopy = GlobalStore.state.selectionLasso;
     arrayCopy.push(point);
-    GlobalStore.commit("setSelectionLasso", arrayCopy);
+    GlobalStore.commit(Mutations.SET_TOOL_SELECTED, arrayCopy);
   }
 };
 

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -31,18 +31,14 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       // if we click on a selected dot, determine if we are toggling selection.
       if (GlobalStore.state.selectedDotIds.includes(existingDot.id)) {
         if (event.altKey) {
-          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [
-            existingDot.id,
-          ]);
+          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [existingDot.id]);
         }
       } else {
         if (!event.shiftKey) {
           GlobalStore.commit(Mutations.CLEAR_SELECTED_DOTS);
         }
         if (event.altKey) {
-          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [
-            existingDot.id,
-          ]);
+          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [existingDot.id]);
         } else {
           GlobalStore.commit(Mutations.ADD_SELECTED_DOTS, [existingDot.id]);
         }

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -3,6 +3,8 @@ import BaseMoveTool from "./BaseMoveTool";
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
 import { InsideLasso } from "@/models/util/Lasso";
+import { Mutations } from "@/store/mutations";
+import { filter } from "vue/types/umd";
 
 /**
  * Enables Selection and Moving.
@@ -29,16 +31,20 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       // if we click on a selected dot, determine if we are toggling selection.
       if (GlobalStore.state.selectedDotIds.includes(existingDot.id)) {
         if (event.altKey) {
-          GlobalStore.commit("toggleSelectedDotIds", [existingDot.id]);
+          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [
+            existingDot.id,
+          ]);
         }
       } else {
         if (!event.shiftKey) {
-          GlobalStore.commit("clearSelectedDotIds");
+          GlobalStore.commit(Mutations.CLEAR_SELECTED_DOTS);
         }
         if (event.altKey) {
-          GlobalStore.commit("toggleSelectedDotIds", [existingDot.id]);
+          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [
+            existingDot.id,
+          ]);
         } else {
-          GlobalStore.commit("addSelectedDotIds", [existingDot.id]);
+          GlobalStore.commit(Mutations.ADD_SELECTED_DOTS, [existingDot.id]);
         }
       }
       this.moveToolStart = [x, y];
@@ -46,9 +52,9 @@ export abstract class ToolSelectMove extends BaseMoveTool {
     } else {
       // if we hvae not clicked on a dot, start a new selection.
       if (!event.shiftKey) {
-        GlobalStore.commit("clearSelectedDotIds");
+        GlobalStore.commit(Mutations.CLEAR_SELECTED_DOTS);
       }
-      GlobalStore.commit("setSelectionLasso", [[x, y]]);
+      GlobalStore.commit(Mutations.SET_SELECTION_LASSO, [[x, y]]);
       this.selectionLassoStart = [x, y];
     }
   }
@@ -64,6 +70,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       ];
       const currentSSDots: StuntSheetDot[] =
         GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
+      const newPositions: [number, [number, number]][] = [];
       GlobalStore.state.selectedDotIds.forEach((id: number) => {
         const selectedDot = currentSSDots.find((dot) => dot.id === id);
         if (!selectedDot) {
@@ -73,13 +80,11 @@ export abstract class ToolSelectMove extends BaseMoveTool {
           selectedDot.x + deltaX,
           selectedDot.y + deltaY,
         ]);
-        GlobalStore.commit("moveDot", {
-          dotId: selectedDot.id,
-          position: [roundedX, roundedY],
-        });
+        newPositions.push([id, [roundedX, roundedY]]);
       });
+      GlobalStore.commit(Mutations.MOVE_DOTS, newPositions);
       // Set the ToolDots to be empty to indicate we're not moving anymore.
-      GlobalStore.commit("setGrapherToolDots", []);
+      GlobalStore.commit(Mutations.SET_GRAPHER_TOOL_DOTS, []);
       // null out moveToolStart to incidcate we're not moving anymore.
       this.moveToolStart = null;
       return;
@@ -93,12 +98,12 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       );
       const dotIdsInLasso = dotsInLasso.map((dot) => dot.id);
       if (event.altKey) {
-        GlobalStore.commit("toggleSelectedDotIds", dotIdsInLasso);
+        GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, dotIdsInLasso);
       } else {
-        GlobalStore.commit("addSelectedDotIds", dotIdsInLasso);
+        GlobalStore.commit(Mutations.ADD_SELECTED_DOTS, dotIdsInLasso);
       }
       // we are done selecting, so clear out the box
-      GlobalStore.commit("setSelectionLasso", []);
+      GlobalStore.commit(Mutations.SET_SELECTION_LASSO, []);
       this.selectionLassoStart = null;
     }
   }
@@ -143,7 +148,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
         })
       );
     });
-    GlobalStore.commit("setGrapherToolDots", grapherToolDots);
+    GlobalStore.commit(Mutations.SET_GRAPHER_TOOL_DOTS, grapherToolDots);
   }
 
   // override this function change the selection lasso.

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -2,6 +2,7 @@ import BaseMoveTool from "./BaseMoveTool";
 import BaseTool, { ToolConstructor } from "./BaseTool";
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Add or remove a single dot on click.
@@ -11,15 +12,15 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseMoveTool 
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
     const existingDot = BaseTool.findDotAtEvent(event);
     if (existingDot) {
-      GlobalStore.commit("removeDot", existingDot.id);
+      GlobalStore.commit(Mutations.REMOVE_DOTS, [ existingDot.id ]);
     } else {
-      GlobalStore.commit("addDot", { x, y });
+      GlobalStore.commit(Mutations.ADD_DOTS, [{ x, y }]);
     }
   }
 
   onMouseMoveInternal(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
-    GlobalStore.commit("setGrapherToolDots", [
+    GlobalStore.commit(Mutations.SET_GRAPHER_TOOL_DOTS, [
       new StuntSheetDot({ x, y, id: -1 }),
     ]);
   }

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -12,7 +12,7 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseMoveTool 
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
     const existingDot = BaseTool.findDotAtEvent(event);
     if (existingDot) {
-      GlobalStore.commit(Mutations.REMOVE_DOTS, [ existingDot.id ]);
+      GlobalStore.commit(Mutations.REMOVE_DOTS, [existingDot.id]);
     } else {
       GlobalStore.commit(Mutations.ADD_DOTS, [{ x, y }]);
     }

--- a/tests/e2e/specs/App.spec.js
+++ b/tests/e2e/specs/App.spec.js
@@ -10,6 +10,8 @@ describe("App.vue", () => {
 
     cy.get('[data-test="app"]').find(".menu-right");
 
-    cy.get('[data-test="app"]').find(".menu-bottom");
+    cy.get('[data-test="app"]').find(".menu-bottom-tools");
+
+    cy.get('[data-test="app"]').find(".menu-bottom-undo");
   });
 });

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -1,29 +1,29 @@
-describe("components/menu-bottom/MenuBottom", () => {
+describe("components/menu-bottom/MenuBottomTools", () => {
   beforeEach(() => {
     cy.visit("/");
   });
 
   it("all buttons are rendered and box select is selected", () => {
-    cy.get('[data-test="menu-bottom--tooltip"]').should("have.length", 3);
+    cy.get('[data-test="menu-bottom-tools--tooltip"]').should("have.length", 3);
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move"]').should(
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move"]').should(
       "have.class",
       "is-primary"
     );
 
-    cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
+    cy.get('[data-test="menu-bottom-tools--tooltip"] .is-light').should(
       "have.length",
       2
     );
   });
 
   it("clicking on add/remove single dot disables box", () => {
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .should("not.have.class", "is-primary")
       .click()
       .should("have.class", "is-primary");
 
-    cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
+    cy.get('[data-test="menu-bottom-tools--tooltip"] .is-light').should(
       "have.length",
       2
     );
@@ -33,9 +33,9 @@ describe("components/menu-bottom/MenuBottom", () => {
   });
 
   it("clicking from and to pan/zoom enables pan/zoom", () => {
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move"]')
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move"]')
       .should("not.have.class", "is-primary")
       .click()
       .should("have.class", "is-primary");
@@ -47,7 +47,7 @@ describe("components/menu-bottom/MenuBottom", () => {
   // #66 - Skipping due to flakey test
   it.skip("control key enables pan/zoom", () => {
     // Starting tool is add/remove single dot
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .click()
       .should("have.class", "is-primary");
 
@@ -68,7 +68,7 @@ describe("components/menu-bottom/MenuBottom", () => {
         .should("lessThan", oldX);
     });
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').should(
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').should(
       "have.class",
       "is-primary"
     );

--- a/tests/e2e/specs/menu-left/MenuLeft.spec.js
+++ b/tests/e2e/specs/menu-left/MenuLeft.spec.js
@@ -37,7 +37,7 @@ describe("components/menu-left/MenuLeft", () => {
     // Add a stuntsheet dot (4, 4) to the first stuntsheet
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .click()
       .mousedownGrapher(4, 4)
       .mouseupGrapher(4, 4);
@@ -87,7 +87,7 @@ describe("components/menu-left/MenuLeft", () => {
     // Add a stuntsheet dot (8, 8) to the first stuntsheet
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .click()
       .mousedownGrapher(8, 8)
       .mouseupGrapher(8, 8);

--- a/tests/e2e/specs/tools/ToolBoxSelect.spec.js
+++ b/tests/e2e/specs/tools/ToolBoxSelect.spec.js
@@ -1,7 +1,7 @@
 describe("tools/ToolBoxSelect", () => {
   beforeEach(() => {
     cy.visit("/")
-      .get('[data-test="menu-bottom-tool--select-box-move"]')
+      .get('[data-test="menu-bottom-tools-tool--select-box-move"]')
       .click();
   });
 

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -23,7 +23,7 @@ describe("tools/ToolSingleDot", () => {
   });
 
   it("After panning and zooming, adding a dot is still accurate", () => {
-    cy.get('[data-test="menu-bottom-tools-tools-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get("#svg-pan-zoom-zoom-out").click().click();
@@ -32,7 +32,7 @@ describe("tools/ToolSingleDot", () => {
     cy.mousemoveGrapher(24, 2);
     cy.mouseupGrapher(24, 2);
 
-    cy.get('[data-test="menu-bottom-tools-tools-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
@@ -108,7 +108,7 @@ describe("tools/ToolSingleDot", () => {
       0
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
@@ -118,7 +118,7 @@ describe("tools/ToolSingleDot", () => {
       1
     );
 
-    cy.get('[data-test="menu-bottom-tool--add-rm').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm').click();
 
     cy.mousedownGrapher(20, 16).mouseupGrapher(20, 16);
 
@@ -142,7 +142,7 @@ describe("tools/ToolSingleDot", () => {
       0
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
@@ -152,7 +152,7 @@ describe("tools/ToolSingleDot", () => {
       1
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-lasso-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-lasso-move').click();
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
     cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
@@ -160,7 +160,7 @@ describe("tools/ToolSingleDot", () => {
       1
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
     cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -1,6 +1,6 @@
 describe("tools/ToolSingleDot", () => {
   beforeEach(() => {
-    cy.visit("/").get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.visit("/").get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
   });
 
   it("clicking adds, then removes a dot", () => {
@@ -23,7 +23,7 @@ describe("tools/ToolSingleDot", () => {
   });
 
   it("After panning and zooming, adding a dot is still accurate", () => {
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tools-tool--select-box-move').click();
 
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get("#svg-pan-zoom-zoom-out").click().click();
@@ -32,7 +32,7 @@ describe("tools/ToolSingleDot", () => {
     cy.mousemoveGrapher(24, 2);
     cy.mouseupGrapher(24, 2);
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tools-tool--add-rm"]').click();
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 

--- a/tests/e2e/specs/undo/undoAdd.spec.js
+++ b/tests/e2e/specs/undo/undoAdd.spec.js
@@ -1,0 +1,69 @@
+describe("undo/add", () => {
+  beforeEach(() => {
+    cy.visit("/")
+      .get('[data-test="menu-bottom-tools-tool--select-box-move"]')
+      .click();
+  });
+  it("clicking add, undo, should have no dot, then redo has dot", () => {
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.disabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
+
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1);
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.enabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
+
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.disabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.enabled");
+  
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1);
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.enabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
+
+  });
+
+  it("clicking add, change cont, undo, undo, redo, redo should do cont", () => {
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1);
+
+    cy.get('[data-test="cont-in-place--march-type"]')
+      .should("have.length", 1)
+      .should("have.value", "HS");
+
+    cy.get('[data-test="cont-in-place--march-type"]').select("MM");
+    cy.get('[data-test="cont-in-place--march-type"]')
+      .should("have.length", 1)
+      .should("have.value", "MM");
+
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').click();
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
+
+    cy.get('[data-test="cont-in-place--march-type"]')
+      .should("have.length", 1)
+      .should("have.value", "MM");
+
+  });
+
+
+});

--- a/tests/e2e/specs/undo/undoAdd.spec.js
+++ b/tests/e2e/specs/undo/undoAdd.spec.js
@@ -14,8 +14,7 @@ describe("undo/add", () => {
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
-    cy.get('[data-test="grapher-dots--dot"]')
-      .should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
     cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.enabled");
     cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
 
@@ -24,14 +23,12 @@ describe("undo/add", () => {
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
     cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.disabled");
     cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.enabled");
-  
+
     cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
 
-    cy.get('[data-test="grapher-dots--dot"]')
-      .should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
     cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.enabled");
     cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
-
   });
 
   it("clicking add, change cont, undo, undo, redo, redo should do cont", () => {
@@ -39,8 +36,7 @@ describe("undo/add", () => {
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
-    cy.get('[data-test="grapher-dots--dot"]')
-      .should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
 
     cy.get('[data-test="cont-in-place--march-type"]')
       .should("have.length", 1)
@@ -62,8 +58,5 @@ describe("undo/add", () => {
     cy.get('[data-test="cont-in-place--march-type"]')
       .should("have.length", 1)
       .should("have.value", "MM");
-
   });
-
-
 });

--- a/tests/e2e/specs/undo/undoCont.spec.js
+++ b/tests/e2e/specs/undo/undoCont.spec.js
@@ -1,0 +1,93 @@
+describe("undo/continuity", () => {
+  it("clicking add, add, modify continuity, then undo/redo adds continuity", () => {
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "12")
+      .should("have.attr", "cy", "8");
+
+    cy.get('[data-test="grapher-dots--dottext"]')
+      .should("have.length", 1)
+      .should("have.attr", "x", "12")
+      .should("have.attr", "y", "7");
+    cy.get('[data-test="grapher-dots--dottext"]').contains("0");
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+  });
+
+  it("After panning and zooming, adding a dot is still accurate", () => {
+    cy.get('[data-test="menu-bottom-tools-tools-tool--select-box-move').click();
+
+    // eslint-disable-next-line cypress/require-data-selectors
+    cy.get("#svg-pan-zoom-zoom-out").click().click();
+
+    cy.mousedownGrapher(8, 2);
+    cy.mousemoveGrapher(24, 2);
+    cy.mouseupGrapher(24, 2);
+
+    cy.get('[data-test="menu-bottom-tools-tools-tool--add-rm"]').click();
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "12")
+      .should("have.attr", "cy", "8");
+    cy.get('[data-test="grapher-dots--dottext"]')
+      .should("have.length", 1)
+      .should("have.attr", "x", "12")
+      .should("have.attr", "y", "7");
+  });
+
+  it("clicking multiple dots", () => {
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.mousedownGrapher(2, 0).mouseupGrapher(2, 0);
+    cy.mousedownGrapher(2, 2).mouseupGrapher(2, 2);
+    cy.mousedownGrapher(2, 4).mouseupGrapher(2, 4);
+    cy.mousedownGrapher(2, 6).mouseupGrapher(2, 6);
+    cy.mousedownGrapher(2, 8).mouseupGrapher(2, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 5)
+      .each((dot, index) => {
+        cy.wrap(dot)
+          .should("have.attr", "cx", "2")
+          .should("have.attr", "cy", `${index * 2}`);
+      });
+
+    cy.mousedownGrapher(2, 0).mouseupGrapher(2, 0);
+    cy.mousedownGrapher(2, 8).mouseupGrapher(2, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 3)
+      .each((dot, index) => {
+        cy.wrap(dot)
+          .should("have.attr", "cx", "2")
+          .should("have.attr", "cy", `${(index + 1) * 2}`);
+      });
+  });
+
+  it("mousemove sets tool dots", () => {
+    cy.get('[data-test="grapher-tool--dot"]').should("not.exist");
+
+    cy.mousemoveGrapher(4, 6);
+
+    cy.get('[data-test="grapher-tool--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "4")
+      .should("have.attr", "cy", "6");
+
+    cy.mousemoveGrapher(6, 8);
+
+    cy.get('[data-test="grapher-tool--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "cx", "6")
+      .should("have.attr", "cy", "8");
+  });
+});

--- a/tests/e2e/specs/undo/undoCont.spec.js
+++ b/tests/e2e/specs/undo/undoCont.spec.js
@@ -21,7 +21,7 @@ describe("undo/continuity", () => {
   });
 
   it("After panning and zooming, adding a dot is still accurate", () => {
-    cy.get('[data-test="menu-bottom-tools-tools-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get("#svg-pan-zoom-zoom-out").click().click();
@@ -30,7 +30,7 @@ describe("undo/continuity", () => {
     cy.mousemoveGrapher(24, 2);
     cy.mouseupGrapher(24, 2);
 
-    cy.get('[data-test="menu-bottom-tools-tools-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -4,7 +4,8 @@ import MenuTop from "@/components/menu-top/MenuTop.vue";
 import MenuLeft from "@/components/menu-left/MenuLeft.vue";
 import Grapher from "@/components/grapher/Grapher.vue";
 import MenuRight from "@/components/menu-right/MenuRight.vue";
-import MenuBottom from "@/components/menu-bottom/MenuBottom.vue";
+import MenuBottomTools from "@/components/menu-bottom/MenuBottomTools.vue";
+import MenuBottomUndo from "@/components/menu-bottom/MenuBottomUndo.vue";
 
 describe("App.vue", () => {
   it("Renders the menus and grapher", () => {
@@ -13,6 +14,7 @@ describe("App.vue", () => {
     expect(app.findComponent(MenuLeft).exists()).toBeTruthy();
     expect(app.findComponent(Grapher).exists()).toBeTruthy();
     expect(app.findComponent(MenuRight).exists()).toBeTruthy();
-    expect(app.findComponent(MenuBottom).exists()).toBeTruthy();
+    expect(app.findComponent(MenuBottomTools).exists()).toBeTruthy();
+    expect(app.findComponent(MenuBottomUndo).exists()).toBeTruthy();
   });
 });

--- a/tests/unit/components/grapher/GrapherField.spec.ts
+++ b/tests/unit/components/grapher/GrapherField.spec.ts
@@ -5,6 +5,7 @@ import Grapher from "@/components/grapher/Grapher.vue";
 import { CalChartState, generateStore } from "@/store";
 import Show from "@/models/Show";
 import Field from "@/models/Field";
+import { Mutations } from "@/store/mutations";
 
 jest.mock("svg-pan-zoom", () => {
   return {
@@ -72,7 +73,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("does not render four step grid if fourStepGrid is false", async () => {
-      store.commit("setFourStepGrid", false);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -84,14 +85,14 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("replaces yardlines with gridlines if yardlines is false", async () => {
-      store.commit("setYardlines", false);
+      store.commit(Mutations.SET_YARDLINES, false);
       await wrapper.vm.$nextTick();
 
       expect(
         wrapper.find('[data-test="grapher-field--yard-line"]').exists()
       ).toBeFalsy();
 
-      store.commit("setFourStepGrid", true);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, true);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -100,7 +101,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("if yardlineNumbers is false, do not render", async () => {
-      store.commit("setYardlineNumbers", false);
+      store.commit(Mutations.SET_YARDLINE_NUMBERS, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -109,7 +110,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("if showDotLabels is false, do not render", async () => {
-      store.commit("setShowDotLabels", false);
+      store.commit(Mutations.SET_SHOW_DOT_LABELS, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -164,7 +165,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("does not render four step grid if fourStepGrid is false", async () => {
-      store.commit("setFourStepGrid", false);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -176,7 +177,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("does not render yardlines if yardlines is false", async () => {
-      store.commit("setYardlines", false);
+      store.commit(Mutations.SET_YARDLINES, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -185,14 +186,14 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("replaces yardlines with gridlines if yardlines is false", async () => {
-      store.commit("setYardlines", false);
+      store.commit(Mutations.SET_YARDLINES, false);
       await wrapper.vm.$nextTick();
 
       expect(
         wrapper.find('[data-test="grapher-field--yard-line"]').exists()
       ).toBeFalsy();
 
-      store.commit("setFourStepGrid", true);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, true);
       await wrapper.vm.$nextTick();
 
       expect(

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -2,7 +2,7 @@ import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
 import Buefy from "buefy";
 import { generateStore, CalChartState } from "@/store";
 import Vuex, { Store } from "vuex";
-import MenuBottom from "@/components/menu-bottom/MenuBottom.vue";
+import MenuBottomTools from "@/components/menu-bottom/MenuBottomTools.vue";
 import ToolSingleDot from "@/tools/ToolSingleDot";
 import ToolBoxSelect from "@/tools/ToolBoxSelect";
 import BaseTool from "@/tools/BaseTool";
@@ -16,7 +16,7 @@ const setupHelper = () => {
   localVue.use(Vuex);
   localVue.use(Buefy);
   const store = generateStore({});
-  const menu = mount(MenuBottom, {
+  const menu = mount(MenuBottomTools, {
     store,
     localVue,
   });
@@ -27,7 +27,7 @@ const setupHelper = () => {
   };
 };
 
-describe("components/menu-bottom/MenuBottom", () => {
+describe("components/menu-bottom-tools/MenuBottom", () => {
   describe("tool buttons", () => {
     let store: Store<CalChartState>;
     let menu: Wrapper<Vue>;
@@ -38,9 +38,9 @@ describe("components/menu-bottom/MenuBottom", () => {
     });
 
     it("renders the correct amount of tools", () => {
-      expect(menu.findAll('[data-test="menu-bottom--tooltip"]')).toHaveLength(
-        3
-      );
+      expect(
+        menu.findAll('[data-test="menu-bottom-tools--tooltip"]')
+      ).toHaveLength(3);
     });
 
     it("on mount, selects the pan and zoom tool", () => {
@@ -49,21 +49,25 @@ describe("components/menu-bottom/MenuBottom", () => {
       expect(ToolBoxSelect).toHaveBeenCalled();
       expect(toolSelected.constructor).toBe(ToolBoxSelect);
       const panZoomBtn = menu.find(
-        '[data-test="menu-bottom-tool--select-box-move"]'
+        '[data-test="menu-bottom-tools-tool--select-box-move"]'
       );
       expect(panZoomBtn.exists()).toBeTruthy();
       expect(panZoomBtn.props("type")).toBe("is-primary");
     });
 
     it("add/remove single dot has type is-light when it is unselected", () => {
-      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      const addRmBtn = menu.find(
+        '[data-test="menu-bottom-tools-tool--add-rm"]'
+      );
       expect(addRmBtn.props("type")).toBe("is-light");
     });
 
     it("clicking add/remove single dot disables box select", async () => {
       expect(ToolSingleDot).not.toHaveBeenCalled();
 
-      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      const addRmBtn = menu.find(
+        '[data-test="menu-bottom-tools-tool--add-rm"]'
+      );
       addRmBtn.trigger("click");
       await menu.vm.$nextTick();
 
@@ -76,14 +80,14 @@ describe("components/menu-bottom/MenuBottom", () => {
 
     it("select box is no longer selected", () => {
       const panZoomBtn = menu.find(
-        '[data-test="menu-bottom-tool--select-box-move"]'
+        '[data-test="menu-bottom-tools-tool--select-box-move"]'
       );
       expect(panZoomBtn.props("type")).toBe("is-light");
     });
 
     it("clicking select box enables box", async () => {
       const panZoomBtn = menu.find(
-        '[data-test="menu-bottom-tool--select-box-move"]'
+        '[data-test="menu-bottom-tools-tool--select-box-move"]'
       );
       panZoomBtn.trigger("click");
       await menu.vm.$nextTick();

--- a/tests/unit/components/menu-left/MenuLeft.spec.ts
+++ b/tests/unit/components/menu-left/MenuLeft.spec.ts
@@ -5,6 +5,7 @@ import Vuex, { Store } from "vuex";
 import MenuLeft from "@/components/menu-left/MenuLeft.vue";
 import Show from "@/models/Show";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-left/MenuLeft", () => {
   let menu: Wrapper<Vue>;
@@ -39,8 +40,8 @@ describe("components/menu-left/MenuLeft", () => {
     ])(
       "Beat control with beat %i and stuntsheet %i",
       async (beat, selectedSS) => {
-        store.commit("setBeat", beat);
-        store.commit("setSelectedSS", selectedSS);
+        store.commit(Mutations.SET_BEAT, beat);
+        store.commit(Mutations.SET_SELECTED_SS, selectedSS);
         await menu.vm.$nextTick();
 
         const beatControl = menu.find('[data-test="menu-left--beat"]');
@@ -58,8 +59,8 @@ describe("components/menu-left/MenuLeft", () => {
     );
 
     it.each([
-      ["decrementBeat", "menu-left--decrement-beat"],
-      ["incrementBeat", "menu-left--increment-beat"],
+      [Mutations.DECREMENT_BEAT, "menu-left--decrement-beat"],
+      [Mutations.INCREMENT_BEAT, "menu-left--increment-beat"],
     ])("Calls %s in store upon clicking button", (commitMsg, selector) => {
       const button = menu.find(`[data-test="${selector}"]`);
       expect(button.exists()).toBeTruthy();
@@ -84,8 +85,8 @@ describe("components/menu-left/MenuLeft", () => {
       menuItem.trigger("click");
       await menu.vm.$nextTick();
 
-      expect(commitSpy).toHaveBeenCalledWith("setSelectedSS", index);
-      expect(commitSpy).toHaveBeenCalledWith("setBeat", 0);
+      expect(commitSpy).toHaveBeenCalledWith(Mutations.SET_SELECTED_SS, index);
+      expect(commitSpy).toHaveBeenCalledWith(Mutations.SET_BEAT, 0);
       expect(menuItem.classes("is-active")).toBeTruthy();
     });
 
@@ -112,7 +113,7 @@ describe("components/menu-left/MenuLeft", () => {
       addButton.trigger("click");
       await menu.vm.$nextTick();
 
-      expect(commitSpy).toHaveBeenCalledWith("addStuntSheet");
+      expect(commitSpy).toHaveBeenCalledWith(Mutations.ADD_STUNT_SHEET);
       expect(menu.findAll('[data-test="menu-left--ss"]')).toHaveLength(4);
     });
   });

--- a/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
@@ -57,7 +57,7 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectETFType.setValue(ETF_DYNAMIC_TYPES.NSEW);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_ETF_TYPE,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.eightToFiveType).toBe(
@@ -75,7 +75,7 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(

--- a/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
@@ -10,6 +10,7 @@ import ContETFDynamic, {
   ETF_DYNAMIC_TYPES,
 } from "@/models/continuity/ContETFDynamic";
 import { MARCH_TYPES } from "@/models/util/constants";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContETFDynamicEditor", () => {
   let editor: Wrapper<Vue>;
@@ -56,7 +57,7 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectETFType.setValue(ETF_DYNAMIC_TYPES.NSEW);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.eightToFiveType).toBe(
@@ -74,7 +75,7 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
@@ -90,10 +91,13 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 0,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 0,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
@@ -60,9 +60,7 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
         Mutations.UPDATE_DOT_TYPE_ETF_TYPE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.eightToFiveType).toBe(
-        ETF_DYNAMIC_TYPES.NSEW
-      );
+      expect(commitSpy.mock.calls[0][1].etfType).toBe(ETF_DYNAMIC_TYPES.NSEW);
     });
 
     it("changing march type", () => {
@@ -78,7 +76,7 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
         Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(
         MARCH_TYPES.MINI_MILITARY
       );
     });

--- a/tests/unit/components/menu-right/ContEvenEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContEvenEditor.spec.ts
@@ -8,6 +8,7 @@ import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContEven from "@/models/continuity/ContEven";
 import { MARCH_TYPES } from "@/models/util/constants";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContEvenEditor", () => {
   let editor: Wrapper<Vue>;
@@ -51,7 +52,7 @@ describe("components/menu-right/ContEvenEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.HS);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
@@ -65,10 +66,13 @@ describe("components/menu-right/ContEvenEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 0,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 0,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContEvenEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContEvenEditor.spec.ts
@@ -55,9 +55,7 @@ describe("components/menu-right/ContEvenEditor", () => {
         Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
-        MARCH_TYPES.HS
-      );
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(MARCH_TYPES.HS);
     });
 
     it("can delete if more than one continuity exists for the dot type", async () => {

--- a/tests/unit/components/menu-right/ContEvenEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContEvenEditor.spec.ts
@@ -52,7 +52,7 @@ describe("components/menu-right/ContEvenEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.HS);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(

--- a/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
@@ -55,7 +55,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
@@ -73,7 +73,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       durationInput.setValue("10");
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_DURATION,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(10);
@@ -89,7 +89,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectDirection.setValue(`${DIRECTIONS.S}`);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchingDirection).toBe(

--- a/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
@@ -8,6 +8,7 @@ import Show from "@/models/Show";
 import ContETFStatic from "@/models/continuity/ContETFStatic.ts";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContETFStaticEditor", () => {
   let editor: Wrapper<Vue>;
@@ -54,7 +55,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
@@ -72,7 +73,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       durationInput.setValue("10");
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(10);
@@ -88,7 +89,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectDirection.setValue(`${DIRECTIONS.S}`);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchingDirection).toBe(
@@ -102,10 +103,13 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 1,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 1,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
@@ -58,7 +58,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
         Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(
         MARCH_TYPES.MINI_MILITARY
       );
     });
@@ -76,7 +76,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
         Mutations.UPDATE_DOT_TYPE_DURATION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(10);
+      expect(commitSpy.mock.calls[0][1].duration).toBe(10);
     });
 
     it("changing direction", () => {
@@ -92,9 +92,7 @@ describe("components/menu-right/ContETFStaticEditor", () => {
         Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchingDirection).toBe(
-        DIRECTIONS.S
-      );
+      expect(commitSpy.mock.calls[0][1].direction).toBe(DIRECTIONS.S);
     });
 
     it("can delete if more than one continuity exists for the dot type", async () => {

--- a/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
@@ -55,7 +55,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
@@ -73,7 +73,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       durationInput.setValue("8");
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_DURATION,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(8);
@@ -89,7 +89,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectDirection.setValue(`${DIRECTIONS.S}`);
       expect(commitSpy).toHaveBeenCalledWith(
-        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
+        Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.direction).toBe(

--- a/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
@@ -8,6 +8,7 @@ import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContInPlaceEditor", () => {
   let editor: Wrapper<Vue>;
@@ -54,7 +55,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
@@ -72,7 +73,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       durationInput.setValue("8");
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(8);
@@ -88,7 +89,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectDirection.setValue(`${DIRECTIONS.S}`);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_CONTINUITY,
         expect.anything()
       );
       expect(commitSpy.mock.calls[0][1].continuity.direction).toBe(
@@ -102,10 +103,13 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 1,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 1,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
@@ -58,7 +58,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
         Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(
         MARCH_TYPES.MINI_MILITARY
       );
     });
@@ -76,7 +76,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
         Mutations.UPDATE_DOT_TYPE_DURATION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(8);
+      expect(commitSpy.mock.calls[0][1].duration).toBe(8);
     });
 
     it("changing direction", () => {
@@ -92,9 +92,7 @@ describe("components/menu-right/ContInPlaceEditor", () => {
         Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.direction).toBe(
-        DIRECTIONS.S
-      );
+      expect(commitSpy.mock.calls[0][1].direction).toBe(DIRECTIONS.S);
     });
 
     it("can delete if more than one continuity exists for the dot type", async () => {

--- a/tests/unit/components/menu-right/DotTypeEditor.spec.ts
+++ b/tests/unit/components/menu-right/DotTypeEditor.spec.ts
@@ -8,6 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/DotTypeEditor", () => {
   let editor: Wrapper<Vue>;
@@ -59,7 +60,10 @@ describe("components/menu-right/DotTypeEditor", () => {
     expect(commitSpy).not.toHaveBeenCalled();
     addInPlaceBtn.trigger("click");
     await editor.vm.$nextTick();
-    expect(commitSpy).toHaveBeenCalledWith("addContinuity", expect.anything());
+    expect(commitSpy).toHaveBeenCalledWith(
+      Mutations.ADD_CONTINUITY,
+      expect.anything()
+    );
     expect(commitSpy.mock.calls[0][1].continuity instanceof ContInPlace).toBe(
       true
     );
@@ -73,7 +77,10 @@ describe("components/menu-right/DotTypeEditor", () => {
     expect(commitSpy).not.toHaveBeenCalled();
     addETFDynamicBtn.trigger("click");
     await editor.vm.$nextTick();
-    expect(commitSpy).toHaveBeenCalledWith("addContinuity", expect.anything());
+    expect(commitSpy).toHaveBeenCalledWith(
+      Mutations.ADD_CONTINUITY,
+      expect.anything()
+    );
     expect(
       commitSpy.mock.calls[0][1].continuity instanceof ContETFDynamic
     ).toBe(true);

--- a/tests/unit/components/menu-right/DotTypeEditor.spec.ts
+++ b/tests/unit/components/menu-right/DotTypeEditor.spec.ts
@@ -9,6 +9,7 @@ import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import { Mutations } from "@/store/mutations";
+import { CONT_IDS } from "@/models/continuity/BaseCont";
 
 describe("components/menu-right/DotTypeEditor", () => {
   let editor: Wrapper<Vue>;
@@ -64,9 +65,7 @@ describe("components/menu-right/DotTypeEditor", () => {
       Mutations.ADD_CONTINUITY,
       expect.anything()
     );
-    expect(commitSpy.mock.calls[0][1].continuity instanceof ContInPlace).toBe(
-      true
-    );
+    expect(commitSpy.mock.calls[0][1].contID).toBe(CONT_IDS.IN_PLACE);
   });
 
   it("add eight to five dynamic continuity", async () => {
@@ -81,8 +80,6 @@ describe("components/menu-right/DotTypeEditor", () => {
       Mutations.ADD_CONTINUITY,
       expect.anything()
     );
-    expect(
-      commitSpy.mock.calls[0][1].continuity instanceof ContETFDynamic
-    ).toBe(true);
+    expect(commitSpy.mock.calls[0][1].contID).toBe(CONT_IDS.ETF_DYNAMIC);
   });
 });

--- a/tests/unit/components/menu-right/MenuRight.spec.ts
+++ b/tests/unit/components/menu-right/MenuRight.spec.ts
@@ -8,6 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/MenuRight", () => {
   let menu: Wrapper<Vue>;
@@ -54,6 +55,6 @@ describe("components/menu-right/MenuRight", () => {
     expect(commitSpy).not.toHaveBeenCalled();
     addBtn.trigger("click");
     await menu.vm.$nextTick();
-    expect(commitSpy).toHaveBeenCalledWith("addDotType");
+    expect(commitSpy).toHaveBeenCalledWith(Mutations.ADD_DOT_TYPE);
   });
 });

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -7,6 +7,7 @@ import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import ContEven from "@/models/continuity/ContEven";
 import DotAppearance from "@/models/DotAppearance";
 import { Mutations } from "@/store/mutations";
+import { CONT_IDS } from "@/models/continuity/BaseCont";
 
 describe("store/mutations", () => {
   let store: Store<CalChartState>;
@@ -61,7 +62,7 @@ describe("store/mutations", () => {
       expect(oldDotTypes[1][0] instanceof ContETFDynamic).toBe(true);
       store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: 1,
-        continuity: new ContEven(),
+        contID: CONT_IDS.EVEN,
       });
       const newDotTypes = store.state.show.stuntSheets[0].dotTypes;
       expect(newDotTypes[0]).toHaveLength(1);
@@ -94,10 +95,10 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0][0].duration).toBe(0);
       expect(oldDotTypes[1]).toHaveLength(1);
       expect(oldDotTypes[1][0] instanceof ContETFDynamic).toBe(true);
-      store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
+      store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
         dotTypeIndex: 0,
         continuityIndex: 0,
-        continuity: new ContInPlace({ duration: 8 }),
+        duration: 8,
       });
       const newDotTypes = store.state.show.stuntSheets[0].dotTypes;
       expect(newDotTypes[0]).toHaveLength(1);

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -6,6 +6,7 @@ import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import ContEven from "@/models/continuity/ContEven";
 import DotAppearance from "@/models/DotAppearance";
+import { Mutations } from "@/store/mutations";
 
 describe("store/mutations", () => {
   let store: Store<CalChartState>;
@@ -27,7 +28,7 @@ describe("store/mutations", () => {
 
     it("adds a new dot type to the end of the array", () => {
       expect(store.state.show.stuntSheets[0].dotTypes).toHaveLength(2);
-      store.commit("addDotType");
+      store.commit(Mutations.ADD_DOT_TYPE);
       expect(store.state.show.stuntSheets[0].dotTypes).toHaveLength(3);
     });
     it("adds a new dot appereance to the end of the array", () => {
@@ -58,7 +59,7 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0][0] instanceof ContInPlace).toBe(true);
       expect(oldDotTypes[1]).toHaveLength(1);
       expect(oldDotTypes[1][0] instanceof ContETFDynamic).toBe(true);
-      store.commit("addContinuity", {
+      store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: 1,
         continuity: new ContEven(),
       });
@@ -93,7 +94,7 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0][0].duration).toBe(0);
       expect(oldDotTypes[1]).toHaveLength(1);
       expect(oldDotTypes[1][0] instanceof ContETFDynamic).toBe(true);
-      store.commit("updateDotTypeContinuity", {
+      store.commit(Mutations.UPDATE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: 0,
         continuityIndex: 0,
         continuity: new ContInPlace({ duration: 8 }),
@@ -127,7 +128,7 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0]).toHaveLength(2);
       expect(oldDotTypes[0][0] instanceof ContInPlace).toBe(true);
       expect(oldDotTypes[0][1] instanceof ContETFDynamic).toBe(true);
-      store.commit("deleteDotTypeContinuity", {
+      store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: 0,
         continuityIndex: 0,
       });
@@ -151,19 +152,19 @@ describe("store/mutations", () => {
     });
 
     it("increments selectedSS at the end of stuntsheet", () => {
-      store.commit("incrementBeat");
+      store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(0);
     });
 
     it("increments beat in the middle of a stuntsheet", () => {
-      store.commit("incrementBeat");
+      store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(1);
     });
 
     it("does nothing at end of show", () => {
-      store.commit("incrementBeat");
+      store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(2);
       store.commit("incrementBeat");
@@ -186,19 +187,19 @@ describe("store/mutations", () => {
     });
 
     it("decrements selectedSS at the beginning of stuntsheet", () => {
-      store.commit("decrementBeat");
+      store.commit(Mutations.DECREMENT_BEAT);
       expect(store.state.selectedSS).toBe(0);
       expect(store.state.beat).toBe(1);
     });
 
     it("decrements beat in the middle of a stuntsheet", () => {
-      store.commit("decrementBeat");
+      store.commit(Mutations.DECREMENT_BEAT);
       expect(store.state.selectedSS).toBe(0);
       expect(store.state.beat).toBe(0);
     });
 
     it("does nothing at beginning of show", () => {
-      store.commit("decrementBeat");
+      store.commit(Mutations.DECREMENT_BEAT);
       expect(store.state.selectedSS).toBe(0);
       expect(store.state.beat).toBe(0);
     });

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -34,7 +34,7 @@ describe("store/mutations", () => {
     });
     it("adds a new dot appereance to the end of the array", () => {
       expect(store.state.show.stuntSheets[0].dotAppearances).toHaveLength(2);
-      store.commit("addDotType");
+      store.commit(Mutations.ADD_DOT_TYPE);
       expect(store.state.show.stuntSheets[0].dotAppearances).toHaveLength(3);
     });
   });

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -3,6 +3,7 @@ import { GlobalStore } from "@/store";
 import BaseTool from "@/tools/BaseTool";
 import BaseMoveTool from "@/tools/BaseMoveTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { Mutations } from "@/store/mutations";
 
 describe("tools/ToolSingleDot", () => {
   let tool: BaseTool;
@@ -28,7 +29,9 @@ describe("tools/ToolSingleDot", () => {
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
-      expect(GlobalStore.commit).toHaveBeenCalledWith("addDot", { x: 0, y: 2 });
+      expect(GlobalStore.commit).toHaveBeenCalledWith(Mutations.ADD_DOTS, [
+        { x: 0, y: 2 },
+      ]);
     });
 
     it("removes a dot if it exists in the spot", () => {
@@ -42,7 +45,9 @@ describe("tools/ToolSingleDot", () => {
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
-      expect(GlobalStore.commit).toHaveBeenCalledWith("removeDot", 0);
+      expect(GlobalStore.commit).toHaveBeenCalledWith(Mutations.REMOVE_DOTS, [
+        0,
+      ]);
     });
   });
 
@@ -56,7 +61,7 @@ describe("tools/ToolSingleDot", () => {
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
       expect(GlobalStore.commit).toHaveBeenCalledWith(
-        "setGrapherToolDots",
+        Mutations.SET_GRAPHER_TOOL_DOTS,
         expect.anything()
       );
       const grapherToolDots: StuntSheetDot[] = (GlobalStore.commit as jest.Mock)


### PR DESCRIPTION
Adding an undo/redo system.

## Description

This closely follows the outline by Anthony Gore:
https://vuejsdevelopers.com/2017/11/13/vue-js-vuex-undo-redo/

What we do is we have the undo system implemented as a stack of Store Commit changes.  When we do an undo, we go back to an initial state and redo all of the Store commit commands.  With CalChart, not every Store commit is a change we want to undo, so we have a filter where we only save certain commits.

Using this change to also clean up several things to make thing easier:

1. Adding Undo/Redo buttons at the bottom of the screen.
2. Changing all the commit keywords to Enums so it's easier to characterize, catalog them.
3. Making sure that the store.commit commands are all "primitive" copy like objects.  For instance, when adding a new dot, pass a partial<Dot> (or a json equivalent) instead of the Dot so that it gets constructed in the state itself.

Have not done the unit tests yet.

## Pre-PR checklist

- [ ] Ran `npm run serve` and:
  - [ ] Checked basic functionality
  - [ ] Checked that errors are handled
- [ ] Ran `npm run lint`
- [ ] Ran `npm run test:unit`
- [ ] Ran `npm run test:e2e` and ran relevant tests
- [ ] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
