### PR TITLE
108: Clicking add dot tool should "forget" selection

### DIFF
--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -74,7 +74,7 @@ export default Vue.extend({
       ].tool;
       const tool: BaseTool = new ToolConstructor();
       this.$store.commit("setToolSelected", tool);
-      if (!tool.supportsSelection()) {
+      if (!tool.supportsSelection) {
         this.$store.commit("clearSelectedDots");
       }
     },

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -74,6 +74,9 @@ export default Vue.extend({
       ].tool;
       const tool: BaseTool = new ToolConstructor();
       this.$store.commit("setToolSelected", tool);
+      if (!tool.supportsSelection()) {
+        this.$store.commit("clearSelectedDots");
+      }
     },
   },
 });

--- a/src/tools/BaseMoveTool.ts
+++ b/src/tools/BaseMoveTool.ts
@@ -55,4 +55,8 @@ export default abstract class BaseMoveTool {
   onMouseMoveInternal(event: MouseEvent): void {}
   /* eslint-enable @typescript-eslint/no-unused-vars,
     @typescript-eslint/no-empty-function */
+
+  supportsSelection(): boolean {
+    return false;
+  }
 }

--- a/src/tools/BaseMoveTool.ts
+++ b/src/tools/BaseMoveTool.ts
@@ -6,7 +6,7 @@ import BaseTool from "./BaseTool";
  * pressed.  Derived tools implement onMouseDown/Up/Move to do tool specific
  * actions.
  */
-export default abstract class BaseMoveTool {
+export default abstract class BaseMoveTool extends BaseTool {
   static enablePan(enable: boolean): void {
     const grapherSvgPanZoom: SvgPanZoom.Instance | undefined =
       GlobalStore.state.grapherSvgPanZoom;
@@ -56,7 +56,5 @@ export default abstract class BaseMoveTool {
   /* eslint-enable @typescript-eslint/no-unused-vars,
     @typescript-eslint/no-empty-function */
 
-  supportsSelection(): boolean {
-    return false;
-  }
+  supportsSelection = false;
 }

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -83,6 +83,9 @@ export default abstract class BaseTool {
   abstract onMouseDown(event: MouseEvent): void;
   abstract onMouseUp(event: MouseEvent): void;
   abstract onMouseMove(event: MouseEvent): void;
+
+  // does the tool support selections
+  abstract supportsSelection(): boolean;
 }
 
 export interface ToolConstructor {

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -85,7 +85,7 @@ export default abstract class BaseTool {
   abstract onMouseMove(event: MouseEvent): void;
 
   // does the tool support selections
-  abstract supportsSelection(): boolean;
+  abstract readonly supportsSelection: boolean;
 }
 
 export interface ToolConstructor {

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -15,6 +15,10 @@ export abstract class ToolSelectMove extends BaseMoveTool {
   private moveToolStart: [number, number] | null = null;
   protected selectionLassoStart: [number, number] | null = null;
 
+  supportsSelection(): boolean {
+    return true;
+  }
+
   onMouseDownInternal(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinates(event);
     const existingDotIndex = BaseTool.findDotAtEvent(event);

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -15,9 +15,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
   private moveToolStart: [number, number] | null = null;
   protected selectionLassoStart: [number, number] | null = null;
 
-  supportsSelection(): boolean {
-    return true;
-  }
+  supportsSelection = true;
 
   onMouseDownInternal(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinates(event);

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -94,4 +94,57 @@ describe("tools/ToolSingleDot", () => {
       .should("have.attr", "cx", "6")
       .should("have.attr", "cy", "8");
   });
+
+  it("clicking add should clear out selection", () => {
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 0);
+
+    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+
+    cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+
+    cy.get('[data-test="menu-bottom-tool--add-rm').click();
+
+    cy.mousedownGrapher(20, 16).mouseupGrapher(20, 16);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 3);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 0);
+  });
+
+  it("clicking between box and lasso should not clear out selection", () => {
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 0);
+
+    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+
+    cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+
+    cy.get('[data-test="menu-bottom-tool--select-lasso-move').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+
+    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+  });
 });

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -103,6 +103,7 @@ describe("components/grapher/Grapher.vue", () => {
         onMouseDown: jest.fn(),
         onMouseUp: jest.fn(),
         onMouseMove: jest.fn(),
+        supportsSelection: jest.fn(),
       };
       store = generateStore({ toolSelected: mockTool });
       wrapper = mount(Grapher, {

--- a/tests/unit/components/grapher/Grapher.spec.ts
+++ b/tests/unit/components/grapher/Grapher.spec.ts
@@ -103,7 +103,7 @@ describe("components/grapher/Grapher.vue", () => {
         onMouseDown: jest.fn(),
         onMouseUp: jest.fn(),
         onMouseMove: jest.fn(),
-        supportsSelection: jest.fn(),
+        supportsSelection: false,
       };
       store = generateStore({ toolSelected: mockTool });
       wrapper = mount(Grapher, {


### PR DESCRIPTION
Fixing issue by adding a boolean on if we support selection for a tool.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
