### PR TITLE
Address test failures from 7f95d1fdbe2119b09266bdbf097d43806bbe0750

### DIFF
--- a/src/components/grapher/GrapherDots.vue
+++ b/src/components/grapher/GrapherDots.vue
@@ -5,6 +5,7 @@
       :key="`${dot.id}-dots--dot`"
       class="grapher-dots--dot"
       data-test="grapher-dots--dot"
+      :data-test-selected="selectedDotIds.includes(dot.id)"
       :transform="`translate(${dot.xAtBeat(beat)}, ${dot.yAtBeat(beat)})`"
       :dotTypeIndex="dot.dotTypeIndex"
       :label="indexedDotLabels[index]"

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -75,7 +75,7 @@ export default Vue.extend({
       const tool: BaseTool = new ToolConstructor();
       this.$store.commit("setToolSelected", tool);
       if (!tool.supportsSelection) {
-        this.$store.commit("clearSelectedDots");
+        this.$store.commit("clearSelectedDotIds");
       }
     },
   },

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -103,21 +103,30 @@ describe("tools/ToolSingleDot", () => {
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 0);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      0
+    );
 
     cy.get('[data-test="menu-bottom-tool--select-box-move').click();
 
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
-    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      1
+    );
 
     cy.get('[data-test="menu-bottom-tool--add-rm').click();
 
     cy.mousedownGrapher(20, 16).mouseupGrapher(20, 16);
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 3);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 0);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      0
+    );
   });
 
   it("clicking between box and lasso should not clear out selection", () => {
@@ -128,23 +137,35 @@ describe("tools/ToolSingleDot", () => {
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 0);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      0
+    );
 
     cy.get('[data-test="menu-bottom-tool--select-box-move').click();
 
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
-    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      1
+    );
 
     cy.get('[data-test="menu-bottom-tool--select-lasso-move').click();
 
-    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      1
+    );
 
     cy.get('[data-test="menu-bottom-tool--select-box-move').click();
 
-    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
-    cy.get('[data-test="grapher-dots--dot-selected"]').should("have.length", 1);
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
+    cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
+      "have.length",
+      1
+    );
   });
 });


### PR DESCRIPTION
## Description

Address test failures from 7f95d1fdbe2119b09266bdbf097d43806bbe0750

I made changes to transition `clearSelectedDots` to `clearSelectedDotIds` in d56b43da4dc807837cdd3e8d9af7ce4c34f7031b, I guess this branch did not rebase on top of that commit. I'm not sure why Github didn't alert because I think we require an up to date branch? :shrug: 

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
