### PR TITLE
Menu right  Dot Type Appearance Editor#108

### DIFF
--- a/src/components/menu-right/DotAppearanceModal.vue
+++ b/src/components/menu-right/DotAppearanceModal.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="modal-card" data-test="dot-appearance-modal">
     <header class="modal-card-head">
-      <p class="modal-card-title">Dot type {{dotTypeIndex}} Appearance</p>
+      <p class="modal-card-title">Dot type {{ dotTypeIndex }} Appearance</p>
     </header>
 
     <section class="modal-card-body">
       <svg viewBox="-1 -1 2 2" class="column">
-        <Dot 
+        <Dot
           :key="`menu-right-dot-${dotTypeIndex}-preview`"
           :dotTypeIndex="dotTypeIndex"
           :labeled="false"
@@ -14,19 +14,23 @@
       </svg>
       <div class="column">
         <b-field>
-            <b-checkbox v-model="dotAppearance.filled">Filled</b-checkbox>
+          <b-checkbox v-model="dotAppearance.filled">Filled</b-checkbox>
         </b-field>
         <b-field>
-            <b-checkbox v-model="dotAppearance.fwSlash">Forward-slashed</b-checkbox>
+          <b-checkbox v-model="dotAppearance.fwSlash"
+            >Forward-slashed</b-checkbox
+          >
         </b-field>
         <b-field>
-            <b-checkbox v-model="dotAppearance.bwSlash">Backward-slashed</b-checkbox>
+          <b-checkbox v-model="dotAppearance.bwSlash"
+            >Backward-slashed</b-checkbox
+          >
         </b-field>
-        <b-field label="Fill Color" >
-            <b-input v-model="dotAppearance.fill"></b-input>
+        <b-field label="Fill Color">
+          <b-input v-model="dotAppearance.fill"></b-input>
         </b-field>
-        <b-field label="Line Color" >
-            <b-input v-model="dotAppearance.color"></b-input>
+        <b-field label="Line Color">
+          <b-input v-model="dotAppearance.color"></b-input>
         </b-field>
       </div>
     </section>
@@ -45,7 +49,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import Dot from "@/components/grapher/Dot.vue"
+import Dot from "@/components/grapher/Dot.vue";
 import DotAppearance from "@/models/DotAppearance";
 
 /**
@@ -61,7 +65,9 @@ export default Vue.extend({
   },
   computed: {
     dotAppearance(): DotAppearance {
-      return this.$store.getters.getSelectedStuntSheet.dotAppearances[this.dotTypeIndex];
+      return this.$store.getters.getSelectedStuntSheet.dotAppearances[
+        this.dotTypeIndex
+      ];
     },
   },
 });
@@ -72,5 +78,4 @@ export default Vue.extend({
   float: left;
   width: 50%;
 }
-
 </style>

--- a/src/components/menu-right/DotAppearanceModal.vue
+++ b/src/components/menu-right/DotAppearanceModal.vue
@@ -26,11 +26,11 @@
             >Backward-slashed</b-checkbox
           >
         </b-field>
-        <b-field label="Fill Color">
-          <b-input v-model="dotAppearance.fill"></b-input>
+        <b-field>
+          <input type="color" v-model="dotAppearance.fill" /> Fill Color
         </b-field>
-        <b-field label="Line Color">
-          <b-input v-model="dotAppearance.color"></b-input>
+        <b-field>
+          <input type="color" v-model="dotAppearance.color" /> Line Color
         </b-field>
       </div>
     </section>

--- a/src/components/menu-right/DotAppearanceModal.vue
+++ b/src/components/menu-right/DotAppearanceModal.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="modal-card" data-test="dot-appearance-modal">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Dot type {{dotTypeIndex}} Appearance</p>
+    </header>
+
+    <section class="modal-card-body">
+      <svg viewBox="-1 -1 2 2" class="column">
+        <Dot 
+          :key="`menu-right-dot-${dotTypeIndex}-preview`"
+          :dotTypeIndex="dotTypeIndex"
+          :labeled="false"
+        />
+      </svg>
+      <div class="column">
+        <b-field>
+            <b-checkbox v-model="dotAppearance.filled">Filled</b-checkbox>
+        </b-field>
+        <b-field>
+            <b-checkbox v-model="dotAppearance.fwSlash">Forward-slashed</b-checkbox>
+        </b-field>
+        <b-field>
+            <b-checkbox v-model="dotAppearance.bwSlash">Backward-slashed</b-checkbox>
+        </b-field>
+        <b-field label="Fill Color" >
+            <b-input v-model="dotAppearance.fill"></b-input>
+        </b-field>
+        <b-field label="Line Color" >
+            <b-input v-model="dotAppearance.color"></b-input>
+        </b-field>
+      </div>
+    </section>
+
+    <footer class="modal-card-foot">
+      <b-button
+        type="is-primary"
+        data-test="dot-appearance-modal--close"
+        @click="$parent.close()"
+      >
+        Close
+      </b-button>
+    </footer>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Dot from "@/components/grapher/Dot.vue"
+import DotAppearance from "@/models/DotAppearance";
+
+/**
+ * Change a dot type's appearance
+ */
+export default Vue.extend({
+  name: "DotAppearanceModal",
+  components: {
+    Dot,
+  },
+  props: {
+    dotTypeIndex: Number,
+  },
+  computed: {
+    dotAppearance(): DotAppearance {
+      return this.$store.getters.getSelectedStuntSheet.dotAppearances[this.dotTypeIndex];
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.column {
+  float: left;
+  width: 50%;
+}
+
+</style>

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="my-2">
-    <p data-test="menu-right--dot-type">Dot Type {{ dotTypeIndex }}</p>
+    <b data-test="menu-right--dot-type">Dot Type {{ dotTypeIndex }}</b>
+    <svg viewBox="-1 -1 2 2" 
+      class="menu-right-dot-appearance">
+    <Dot 
+      :key="`menu-right-dot-${dotTypeIndex}-preview`"
+      :dotTypeIndex="dotTypeIndex"
+      :labeled="false"
+    />
+    </svg>
     <ContEditorHelper
       v-for="(continuity, index) in dotType"
       :key="`continuity--${dotTypeIndex}--${index}`"
@@ -53,6 +61,7 @@ import ContEven from "@/models/continuity/ContEven";
 import StuntSheet from "@/models/StuntSheet";
 import Vue from "vue";
 import ContEditorHelper from "./ContEditorHelper.vue";
+import Dot from "@/components/grapher/Dot.vue";
 
 /**
  * View/Edit all continuiuties for a dot type
@@ -61,6 +70,7 @@ export default Vue.extend({
   name: "DotTypeEditor",
   components: {
     ContEditorHelper,
+    Dot,
   },
   props: {
     dotTypeIndex: {
@@ -104,4 +114,10 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.menu-right-dot-appearance {
+  vertical-align: middle;
+  float: right;
+  width: 10%;
+  height: 10%;
+}</style>

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -2,12 +2,14 @@
   <div class="my-2">
     <b data-test="menu-right--dot-type">Dot Type {{ dotTypeIndex }}</b>
     <svg viewBox="-1 -1 2 2" 
-      class="menu-right-dot-appearance">
-    <Dot 
-      :key="`menu-right-dot-${dotTypeIndex}-preview`"
-      :dotTypeIndex="dotTypeIndex"
-      :labeled="false"
-    />
+      class="menu-right-dot-appearance"
+      @click="dotAppearanceModalActive = true">
+      <Dot 
+        :key="`menu-right-dot-${dotTypeIndex}-preview`"
+        :data-test="`menu-right-dot-${dotTypeIndex}-preview`"
+        :dotTypeIndex="dotTypeIndex"
+        :labeled="false"
+      />
     </svg>
     <ContEditorHelper
       v-for="(continuity, index) in dotType"
@@ -49,6 +51,14 @@
       </b-dropdown>
     </div>
     <hr />
+    <b-modal
+      :active.sync="dotAppearanceModalActive"
+      has-modal-card
+      trap-focus
+      data-test="menu-right-dot-appearance-modal"
+    >
+      <DotAppearanceModal :dotTypeIndex="dotTypeIndex"/>
+    </b-modal>
   </div>
 </template>
 
@@ -62,15 +72,20 @@ import StuntSheet from "@/models/StuntSheet";
 import Vue from "vue";
 import ContEditorHelper from "./ContEditorHelper.vue";
 import Dot from "@/components/grapher/Dot.vue";
+import DotAppearanceModal from "./DotAppearanceModal.vue"
 
 /**
  * View/Edit all continuiuties for a dot type
  */
 export default Vue.extend({
   name: "DotTypeEditor",
+  data: () => ({
+    dotAppearanceModalActive: false,
+  }),
   components: {
     ContEditorHelper,
     Dot,
+    DotAppearanceModal
   },
   props: {
     dotTypeIndex: {

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="my-2">
     <b data-test="menu-right--dot-type">Dot Type {{ dotTypeIndex }}</b>
-    <svg viewBox="-1 -1 2 2" 
+    <svg
+      viewBox="-1 -1 2 2"
       class="menu-right-dot-appearance"
-      @click="dotAppearanceModalActive = true">
-      <Dot 
+      @click="dotAppearanceModalActive = true"
+    >
+      <Dot
         :key="`menu-right-dot-${dotTypeIndex}-preview`"
         :data-test="`menu-right-dot-${dotTypeIndex}-preview`"
         :dotTypeIndex="dotTypeIndex"
@@ -57,7 +59,7 @@
       trap-focus
       data-test="menu-right-dot-appearance-modal"
     >
-      <DotAppearanceModal :dotTypeIndex="dotTypeIndex"/>
+      <DotAppearanceModal :dotTypeIndex="dotTypeIndex" />
     </b-modal>
   </div>
 </template>
@@ -72,7 +74,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Vue from "vue";
 import ContEditorHelper from "./ContEditorHelper.vue";
 import Dot from "@/components/grapher/Dot.vue";
-import DotAppearanceModal from "./DotAppearanceModal.vue"
+import DotAppearanceModal from "./DotAppearanceModal.vue";
 
 /**
  * View/Edit all continuiuties for a dot type
@@ -85,7 +87,7 @@ export default Vue.extend({
   components: {
     ContEditorHelper,
     Dot,
-    DotAppearanceModal
+    DotAppearanceModal,
   },
   props: {
     dotTypeIndex: {
@@ -135,4 +137,5 @@ export default Vue.extend({
   float: right;
   width: 10%;
   height: 10%;
-}</style>
+}
+</style>

--- a/src/models/DotAppearance.ts
+++ b/src/models/DotAppearance.ts
@@ -2,7 +2,7 @@ import Serializable from "./util/Serializable";
 /**
  * Defines appearance of a dot
  *
- * @property filled 
+ * @property filled
  * @property fill
  * @property color
  * @property fwSlash

--- a/src/models/DotAppearance.ts
+++ b/src/models/DotAppearance.ts
@@ -2,11 +2,11 @@ import Serializable from "./util/Serializable";
 /**
  * Defines appearance of a dot
  *
- * @property filled         - Wether the dot is filled
- * @property fill           - The fill color of a dot
- * @property color          - The border color of a dot and its slash
- * @property slashed        - Wether the dot has a slash
- * @property angle          - The angle of the slash
+ * @property filled 
+ * @property fill
+ * @property color
+ * @property fwSlash
+ * @property bwSlash
  */
 export default class DotAppearance extends Serializable<DotAppearance> {
   filled = true;

--- a/tests/unit/components/menu-right/DotTypeEditor.spec.ts
+++ b/tests/unit/components/menu-right/DotTypeEditor.spec.ts
@@ -8,7 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
-import DotAppearance from "@/models/DotAppearance"
+import DotAppearance from "@/models/DotAppearance";
 
 describe("components/menu-right/DotTypeEditor", () => {
   let editor: Wrapper<Vue>;
@@ -22,7 +22,7 @@ describe("components/menu-right/DotTypeEditor", () => {
         [new ContETFDynamic(), new ContInPlace()],
         [new ContInPlace()],
       ],
-      dotAppearances: [new DotAppearance, new DotAppearance],
+      dotAppearances: [new DotAppearance(), new DotAppearance()],
     }),
     new StuntSheet({ beats: 8, title: "b" }),
   ];
@@ -82,9 +82,7 @@ describe("components/menu-right/DotTypeEditor", () => {
   });
 
   it("renders the dot appearance", async () => {
-    const appearance = editor.find(
-      '[data-test="menu-right-dot-0-preview"]'
-    );
+    const appearance = editor.find('[data-test="menu-right-dot-0-preview"]');
     expect(appearance.exists()).toBe(true);
     expect(appearance.props("dotTypeIndex")).toBe(0);
   });

--- a/tests/unit/components/menu-right/DotTypeEditor.spec.ts
+++ b/tests/unit/components/menu-right/DotTypeEditor.spec.ts
@@ -8,6 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import DotAppearance from "@/models/DotAppearance"
 
 describe("components/menu-right/DotTypeEditor", () => {
   let editor: Wrapper<Vue>;
@@ -21,6 +22,7 @@ describe("components/menu-right/DotTypeEditor", () => {
         [new ContETFDynamic(), new ContInPlace()],
         [new ContInPlace()],
       ],
+      dotAppearances: [new DotAppearance, new DotAppearance],
     }),
     new StuntSheet({ beats: 8, title: "b" }),
   ];
@@ -77,5 +79,13 @@ describe("components/menu-right/DotTypeEditor", () => {
     expect(
       commitSpy.mock.calls[0][1].continuity instanceof ContETFDynamic
     ).toBe(true);
+  });
+
+  it("renders the dot appearance", async () => {
+    const appearance = editor.find(
+      '[data-test="menu-right-dot-0-preview"]'
+    );
+    expect(appearance.exists()).toBe(true);
+    expect(appearance.props("dotTypeIndex")).toBe(0);
   });
 });

--- a/tests/unit/components/menu-right/MenuRight.spec.ts
+++ b/tests/unit/components/menu-right/MenuRight.spec.ts
@@ -8,7 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
-import DotAppearance from '@/models/DotAppearance';
+import DotAppearance from "@/models/DotAppearance";
 
 describe("components/menu-right/MenuRight", () => {
   let menu: Wrapper<Vue>;
@@ -22,7 +22,7 @@ describe("components/menu-right/MenuRight", () => {
         [new ContInPlace()],
         [new ContETFDynamic(), new ContInPlace()],
       ],
-      dotAppearances: [new DotAppearance, new DotAppearance]
+      dotAppearances: [new DotAppearance(), new DotAppearance()],
     }),
     new StuntSheet({ beats: 8, title: "b" }),
   ];

--- a/tests/unit/components/menu-right/MenuRight.spec.ts
+++ b/tests/unit/components/menu-right/MenuRight.spec.ts
@@ -8,6 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import DotAppearance from '@/models/DotAppearance';
 
 describe("components/menu-right/MenuRight", () => {
   let menu: Wrapper<Vue>;
@@ -21,6 +22,7 @@ describe("components/menu-right/MenuRight", () => {
         [new ContInPlace()],
         [new ContETFDynamic(), new ContInPlace()],
       ],
+      dotAppearances: [new DotAppearance, new DotAppearance]
     }),
     new StuntSheet({ beats: 8, title: "b" }),
   ];


### PR DESCRIPTION
## Description

Fixes issue #108

This adds a preview of a dot type's appearance to menu right to the right of a dot's name:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/29964426/105564283-64460800-5cd6-11eb-83d3-516caaeb9358.png">

Clicking on that preview will open up a modal to edit the appearance of the dot type:
<img width="1779" alt="image" src="https://user-images.githubusercontent.com/29964426/105564317-7f187c80-5cd6-11eb-85a0-f52fd6a5f8f4.png">

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/29964426/105564369-ab33fd80-5cd6-11eb-9fbd-1287ca2aa25c.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/29964426/105564479-21d0fb00-5cd7-11eb-97d8-a66d04849bd0.png">

