### PR TITLE
Refactoring CalChart as prep to add the undo system.

### DIFF
--- a/src/components/grapher/Grapher.vue
+++ b/src/components/grapher/Grapher.vue
@@ -24,6 +24,7 @@ import GrapherDots from "./GrapherDots.vue";
 import GrapherTool from "./GrapherTool.vue";
 import svgPanZoom from "svg-pan-zoom";
 import BaseTool from "@/tools/BaseTool";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Holds the components for rendering the field, dots, tools, etc.
@@ -43,7 +44,7 @@ export default Vue.extend({
       controlIconsEnabled: true,
       dblClickZoomEnabled: false,
     });
-    this.$store.commit("setGrapherSvgPanZoom", svgPanZoomInstance);
+    this.$store.commit(Mutations.SET_GRAPHER_SVG_PAN_ZOOM, svgPanZoomInstance);
 
     window.addEventListener("resize", this.onResize);
   },

--- a/src/components/menu-bottom/MenuBottom.vue
+++ b/src/components/menu-bottom/MenuBottom.vue
@@ -27,6 +27,7 @@ import BaseTool, { ToolConstructor } from "@/tools/BaseTool";
 import ToolBoxSelect from "@/tools/ToolBoxSelect";
 import ToolLassoSelect from "@/tools/ToolLassoSelect";
 import ToolSingleDot from "@/tools/ToolSingleDot";
+import { Mutations } from "@/store/mutations";
 
 interface ToolData {
   label: string;
@@ -73,9 +74,9 @@ export default Vue.extend({
         toolIndex
       ].tool;
       const tool: BaseTool = new ToolConstructor();
-      this.$store.commit("setToolSelected", tool);
+      this.$store.commit(Mutations.SET_TOOL_SELECTED, tool);
       if (!tool.supportsSelection) {
-        this.$store.commit("clearSelectedDotIds");
+        this.$store.commit(Mutations.CLEAR_SELECTED_DOTS);
       }
     },
   },

--- a/src/components/menu-left/MenuLeft.vue
+++ b/src/components/menu-left/MenuLeft.vue
@@ -71,6 +71,7 @@
 </template>
 
 <script lang="ts">
+import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 import StuntSheet from "../../models/StuntSheet";
 import StuntSheetModal from "./StuntSheetModal.vue";
@@ -91,7 +92,7 @@ export default Vue.extend({
         return this.$store.state.beat;
       },
       set(beat: number): void {
-        this.$store.commit("setBeat", beat);
+        this.$store.commit(Mutations.SET_BEAT, beat);
       },
     },
     beatString(): string {
@@ -107,8 +108,8 @@ export default Vue.extend({
         return this.$store.state.selectedSS;
       },
       set(selectedSS: number): void {
-        this.$store.commit("setSelectedSS", selectedSS);
-        this.$store.commit("setBeat", 0);
+        this.$store.commit(Mutations.SET_SELECTED_SS, selectedSS);
+        this.$store.commit(Mutations.SET_BEAT, 0);
       },
     },
     selectedSSBeats(): number {
@@ -119,13 +120,13 @@ export default Vue.extend({
   },
   methods: {
     addStuntSheet(): void {
-      this.$store.commit("addStuntSheet");
+      this.$store.commit(Mutations.ADD_STUNT_SHEET);
     },
     incrementBeat(): void {
-      this.$store.commit("incrementBeat");
+      this.$store.commit(Mutations.INCREMENT_BEAT);
     },
     decrementBeat(): void {
-      this.$store.commit("decrementBeat");
+      this.$store.commit(Mutations.DECREMENT_BEAT);
     },
   },
 });

--- a/src/components/menu-left/StuntSheetModal.vue
+++ b/src/components/menu-left/StuntSheetModal.vue
@@ -40,6 +40,7 @@
 </template>
 
 <script lang="ts">
+import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 
 /**
@@ -54,7 +55,7 @@ export default Vue.extend({
         return stuntSheet.title;
       },
       set(title: string): void {
-        this.$store.commit("setStuntSheetTitle", title);
+        this.$store.commit(Mutations.SET_STUNT_SHEET_TITLE, title);
       },
     },
 
@@ -64,7 +65,7 @@ export default Vue.extend({
         return stuntSheet.beats;
       },
       set(beats: number): void {
-        this.$store.commit("setStuntSheetBeats", beats);
+        this.$store.commit(Mutations.SET_STUNT_SHEET_BEATS, beats);
       },
     },
 
@@ -74,7 +75,7 @@ export default Vue.extend({
   },
   methods: {
     deleteSS(): void {
-      this.$store.commit("deleteStuntSheet");
+      this.$store.commit(Mutations.DELETE_STUNT_SHEET);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (this.$parent as any).close();
     },

--- a/src/components/menu-right/ContETFDynamicEditor.vue
+++ b/src/components/menu-right/ContETFDynamicEditor.vue
@@ -48,6 +48,7 @@ import ContETFDynamic, {
 } from "@/models/continuity/ContETFDynamic";
 import { MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an Eight to Five Static continuity
@@ -80,15 +81,10 @@ export default Vue.extend({
         return continuity.eightToFiveType;
       },
       set(etfType: ETF_DYNAMIC_TYPES): void {
-        const continuity: ContETFDynamic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.eightToFiveType = etfType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_ETF_TYPE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          etfType: etfType,
         });
       },
     },
@@ -101,15 +97,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContETFDynamic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity: continuity,
+          marchType: marchType,
         });
       },
     },
@@ -121,7 +112,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/ContETFStaticEditor.vue
+++ b/src/components/menu-right/ContETFStaticEditor.vue
@@ -53,6 +53,7 @@ import Vue from "vue";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an ETF-Static continuity
@@ -95,15 +96,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContETFStatic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          marchType: marchType,
         });
       },
     },
@@ -116,16 +112,10 @@ export default Vue.extend({
         return continuity.marchingDirection;
       },
       set(direction: number): void {
-        const continuity: ContETFStatic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchingDirection = direction;
-        continuity.facingDirection = direction;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity: continuity,
+          direction: direction,
         });
       },
     },
@@ -138,15 +128,10 @@ export default Vue.extend({
         return continuity.duration;
       },
       set(duration: number): void {
-        const continuity: ContETFStatic = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.duration = duration;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          duration: duration,
         });
       },
     },
@@ -158,7 +143,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/ContEvenEditor.vue
+++ b/src/components/menu-right/ContEvenEditor.vue
@@ -39,6 +39,7 @@ import Vue from "vue";
 import ContEven from "@/models/continuity/ContEven";
 import { MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an In Place continuity
@@ -78,15 +79,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContEven = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          marchType: marchType,
         });
       },
     },
@@ -99,15 +95,10 @@ export default Vue.extend({
         return continuity.duration;
       },
       set(duration: number): void {
-        const continuity: ContEven = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.duration = duration;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          duration: duration,
         });
       },
     },
@@ -119,7 +110,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/ContInPlaceEditor.vue
+++ b/src/components/menu-right/ContInPlaceEditor.vue
@@ -53,6 +53,7 @@ import Vue from "vue";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit an In Place continuity
@@ -101,15 +102,10 @@ export default Vue.extend({
         return continuity.marchType;
       },
       set(marchType: MARCH_TYPES): void {
-        const continuity: ContInPlace = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.marchType = marchType;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_MARCH_STYLE, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          marchType: marchType,
         });
       },
     },
@@ -122,15 +118,10 @@ export default Vue.extend({
         return continuity.direction;
       },
       set(direction: number): void {
-        const continuity: ContInPlace = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.direction = direction;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity: continuity,
+          direction: direction,
         });
       },
     },
@@ -143,15 +134,10 @@ export default Vue.extend({
         return continuity.duration;
       },
       set(duration: number): void {
-        const continuity: ContInPlace = this.$store.getters.getContinuity(
-          this.dotTypeIndex,
-          this.continuityIndex
-        );
-        continuity.duration = duration;
-        this.$store.commit("updateDotTypeContinuity", {
+        this.$store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
           dotTypeIndex: this.dotTypeIndex,
           continuityIndex: this.continuityIndex,
-          continuity,
+          duration: duration,
         });
       },
     },
@@ -163,7 +149,7 @@ export default Vue.extend({
   },
   methods: {
     deleteContinuity() {
-      this.$store.commit("deleteDotTypeContinuity", {
+      this.$store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
         continuityIndex: this.continuityIndex,
       });

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script lang="ts">
-import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
+import { BaseCont, CONT_IDS } from "@/models/continuity/BaseCont";
 import StuntSheet from "@/models/StuntSheet";
 import Vue from "vue";
 import ContEditorHelper from "./ContEditorHelper.vue";

--- a/src/components/menu-right/DotTypeEditor.vue
+++ b/src/components/menu-right/DotTypeEditor.vue
@@ -45,14 +45,11 @@
 </template>
 
 <script lang="ts">
-import BaseCont from "@/models/continuity/BaseCont";
-import ContETFDynamic from "@/models/continuity/ContETFDynamic";
-import ContETFStatic from "@/models/continuity/ContETFStatic";
-import ContInPlace from "@/models/continuity/ContInPlace";
-import ContEven from "@/models/continuity/ContEven";
+import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
 import StuntSheet from "@/models/StuntSheet";
 import Vue from "vue";
 import ContEditorHelper from "./ContEditorHelper.vue";
+import { Mutations } from "@/store/mutations";
 
 /**
  * View/Edit all continuiuties for a dot type
@@ -77,27 +74,27 @@ export default Vue.extend({
   },
   methods: {
     addContInPlace() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContInPlace(),
+        contID: CONT_IDS.IN_PLACE,
       });
     },
     addContETFDynamic() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContETFDynamic(),
+        contID: CONT_IDS.ETF_DYNAMIC,
       });
     },
     addContETFStatic() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContETFStatic(),
+        contID: CONT_IDS.ETF_STATIC,
       });
     },
     addContEven() {
-      this.$store.commit("addContinuity", {
+      this.$store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: this.dotTypeIndex,
-        continuity: new ContEven(),
+        contID: CONT_IDS.EVEN,
       });
     },
   },

--- a/src/components/menu-right/MenuRight.vue
+++ b/src/components/menu-right/MenuRight.vue
@@ -23,6 +23,7 @@ import DotTypeEditor from "./DotTypeEditor.vue";
 import BaseCont from "@/models/continuity/BaseCont";
 import Vue from "vue";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 export default Vue.extend({
   name: "MenuRight",
@@ -38,7 +39,7 @@ export default Vue.extend({
   },
   methods: {
     addDotType() {
-      this.$store.commit("addDotType");
+      this.$store.commit(Mutations.ADD_DOT_TYPE);
     },
   },
 });

--- a/src/components/menu-right/MenuRight.vue
+++ b/src/components/menu-right/MenuRight.vue
@@ -20,7 +20,7 @@
 
 <script lang="ts">
 import DotTypeEditor from "./DotTypeEditor.vue";
-import BaseCont from "@/models/continuity/BaseCont";
+import { BaseCont } from "@/models/continuity/BaseCont";
 import Vue from "vue";
 import StuntSheet from "@/models/StuntSheet";
 import { Mutations } from "@/store/mutations";

--- a/src/components/menu-top/FileModal.vue
+++ b/src/components/menu-top/FileModal.vue
@@ -53,6 +53,7 @@
 
 <script lang="ts">
 import Vue from "vue";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Show and modify values in the current Show model
@@ -65,7 +66,7 @@ export default Vue.extend({
         return this.$store.getters.getShowTitle;
       },
       set(title: string): void {
-        this.$store.commit("setShowTitle", title);
+        this.$store.commit(Mutations.SET_SHOW_TITLE, title);
       },
     },
 
@@ -74,7 +75,7 @@ export default Vue.extend({
         return this.$store.getters.getFrontHashOffsetY;
       },
       set(offsetY: number): void {
-        this.$store.commit("setFrontHashOffsetY", offsetY);
+        this.$store.commit(Mutations.SET_FRONT_HASH_OFFSET_Y, offsetY);
       },
     },
 
@@ -83,7 +84,7 @@ export default Vue.extend({
         return this.$store.getters.getBackHashOffsetY;
       },
       set(offsetY: number): void {
-        this.$store.commit("setBackHashOffsetY", offsetY);
+        this.$store.commit(Mutations.SET_BACK_HASH_OFFSET_Y, offsetY);
       },
     },
 
@@ -92,7 +93,7 @@ export default Vue.extend({
         return this.$store.getters.getMiddleOfField;
       },
       set(middle: number): void {
-        this.$store.commit("setMiddleOfField", middle);
+        this.$store.commit(Mutations.SET_MIDDLE_OF_FIELD, middle);
       },
     },
   },

--- a/src/components/menu-top/LoadModal.vue
+++ b/src/components/menu-top/LoadModal.vue
@@ -50,7 +50,10 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { InitialLoadShwState, InitialLoadShw4State } from "@/models/InitialLoadShowState";
+import {
+  InitialLoadShwState,
+  InitialLoadShw4State,
+} from "@/models/InitialLoadShowState";
 import Show from "@/models/Show";
 import { Mutations } from "@/store/mutations";
 import InitialShowState from "@/models/InitialShowState";

--- a/src/components/menu-top/LoadModal.vue
+++ b/src/components/menu-top/LoadModal.vue
@@ -50,16 +50,19 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { loadShowFromBuffer } from "@/models/util/LoadShow";
+import { InitialLoadShwState, InitialLoadShw4State } from "@/models/InitialLoadShowState";
 import Show from "@/models/Show";
+import { Mutations } from "@/store/mutations";
+import InitialShowState from "@/models/InitialShowState";
 
 export default Vue.extend({
   name: "LoadModal",
   data: (): {
     file: File | null;
+    showLoadState: InitialShowState | null;
     showPreview: Show | null;
     parseError: string;
-  } => ({ file: null, showPreview: null, parseError: "" }),
+  } => ({ file: null, showLoadState: null, showPreview: null, parseError: "" }),
   computed: {
     numMarchers(): number {
       return this.showPreview && this.showPreview.stuntSheets.length > 0
@@ -83,10 +86,10 @@ export default Vue.extend({
         reader.onload = (): void => {
           if (reader.result) {
             try {
-              if (reader.result)
-                this.showPreview = new Show(
-                  JSON.parse(reader.result as string)
-                );
+              this.showLoadState = new InitialLoadShw4State({
+                showData: reader.result as string,
+              });
+              this.showPreview = this.showLoadState.getInitialState();
             } catch (e) {
               this.parseError = e;
             }
@@ -99,8 +102,10 @@ export default Vue.extend({
         reader.onload = (): void => {
           if (reader.result && reader.result instanceof ArrayBuffer) {
             try {
-              if (reader.result)
-                this.showPreview = loadShowFromBuffer(reader.result);
+              this.showLoadState = new InitialLoadShwState({
+                showData: reader.result,
+              });
+              this.showPreview = this.showLoadState.getInitialState();
             } catch (e) {
               this.parseError = e;
             }
@@ -117,7 +122,7 @@ export default Vue.extend({
       if (!this.showPreview) {
         return;
       }
-      this.$store.commit("setShow", this.showPreview);
+      this.$store.commit(Mutations.SET_SHOW, this.showLoadState);
     },
   },
 });

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -91,6 +91,7 @@
 </template>
 
 <script lang="ts">
+import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 import FileModal from "./FileModal.vue";
 import LoadModal from "./LoadModal.vue";
@@ -118,7 +119,7 @@ export default Vue.extend({
         return this.$store.state.fourStepGrid;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setFourStepGrid", enabled);
+        this.$store.commit(Mutations.SET_FOUR_STEP_GRID, enabled);
       },
     },
 
@@ -127,7 +128,7 @@ export default Vue.extend({
         return this.$store.state.yardlines;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setYardlines", enabled);
+        this.$store.commit(Mutations.SET_YARDLINES, enabled);
       },
     },
 
@@ -136,7 +137,7 @@ export default Vue.extend({
         return this.$store.state.yardlineNumbers;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setYardlineNumbers", enabled);
+        this.$store.commit(Mutations.SET_YARDLINE_NUMBERS, enabled);
       },
     },
 
@@ -145,7 +146,7 @@ export default Vue.extend({
         return this.$store.state.showDotLabels;
       },
       set(enabled: boolean): void {
-        this.$store.commit("setShowDotLabels", enabled);
+        this.$store.commit(Mutations.SET_SHOW_DOT_LABELS, enabled);
       },
     },
 

--- a/src/models/InitialLoadShowState.ts
+++ b/src/models/InitialLoadShowState.ts
@@ -1,0 +1,54 @@
+import InitialShowState from "./InitialShowState";
+import { loadShowFromBuffer } from "@/models/util/LoadShow";
+import Show from "./Show";
+
+// Increment upon making show metadata changes that break previous versions.
+const METADATA_VERSION = 1;
+
+/**
+ */
+export class InitialLoadShwState extends InitialShowState {
+  metadataVersion: number = METADATA_VERSION;
+
+  showData: ArrayBuffer | undefined;
+
+  constructor(json: Partial<InitialLoadShwState> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  /**
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store
+   * the flow based on it's continuities in stuntSheetDot.cachedFlow.
+   */
+  getInitialState(): Show {
+    if (this.showData) {
+      return loadShowFromBuffer(this.showData);
+    }
+    return new Show();
+  }
+}
+
+/**
+ */
+export class InitialLoadShw4State extends InitialShowState {
+  metadataVersion: number = METADATA_VERSION;
+
+  showData: string | undefined;
+
+  constructor(json: Partial<InitialLoadShw4State> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  /**
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store
+   * the flow based on it's continuities in stuntSheetDot.cachedFlow.
+   */
+  getInitialState(): Show {
+    if (this.showData) {
+      return new Show(JSON.parse(this.showData));
+    }
+    return new Show();
+  }
+}

--- a/src/models/InitialShowState.ts
+++ b/src/models/InitialShowState.ts
@@ -1,0 +1,31 @@
+import Serializable from "./util/Serializable";
+import Show from "./Show";
+
+// Increment upon making show metadata changes that break previous versions.
+const METADATA_VERSION = 1;
+
+/**
+ * Defines an object that creates the initial state of a show for Undo system.
+ * This way when we save and restore CalChart we have a way to always get back
+ * to the orignal starting point.
+ *
+ * Initializing a show state for a new show from scratch is the default.  This
+ * can be extended to load shows from other locations, like an array buffer
+ * representing a show from a previous version of CalChart.
+ */
+export default class InitialShowState extends Serializable<InitialShowState> {
+  metadataVersion: number = METADATA_VERSION;
+
+  constructor(json: Partial<InitialShowState> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  /**
+   * For each StuntSheetDot in the specified StuntSheet, calculate and store
+   * the flow based on it's continuities in stuntSheetDot.cachedFlow.
+   */
+  getInitialState(): Show {
+    return new Show();
+  }
+}

--- a/src/models/Show.ts
+++ b/src/models/Show.ts
@@ -1,7 +1,7 @@
 import Field from "./Field";
 import StuntSheet from "./StuntSheet";
 import StuntSheetDot from "./StuntSheetDot";
-import BaseCont from "./continuity/BaseCont";
+import { BaseCont } from "./continuity/BaseCont";
 import { FlowBeat, initializeFlow } from "./util/FlowBeat";
 import Serializable from "./util/Serializable";
 

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -1,5 +1,5 @@
 import StuntSheetDot from "./StuntSheetDot";
-import BaseCont from "./continuity/BaseCont";
+import { BaseCont } from "./continuity/BaseCont";
 import ContInPlace from "./continuity/ContInPlace";
 import Serializable from "./util/Serializable";
 import { loadContinuity } from "./continuity/load-continuity";

--- a/src/models/StuntSheet.ts
+++ b/src/models/StuntSheet.ts
@@ -73,22 +73,27 @@ export default class StuntSheet extends Serializable<StuntSheet> {
     this.fromJson(json);
   }
 
-  addDot(dot: Partial<StuntSheetDot> = {}): void {
-    this.stuntSheetDots.push(new StuntSheetDot(dot));
+  addDots(dots: Partial<StuntSheetDot>[] = []): void {
+    this.stuntSheetDots = this.stuntSheetDots.concat(
+      dots.map((dot) => new StuntSheetDot(dot))
+    );
   }
 
-  removeDot(dotId: number): void {
-    const dotIndex = this.stuntSheetDots.findIndex((dot) => dot.id === dotId);
-    if (dotIndex !== -1) {
-      this.stuntSheetDots.splice(dotIndex, 1);
-    }
+  removeDots(indices: number[]): void {
+    this.stuntSheetDots = this.stuntSheetDots.filter(
+      (dot) => !indices.includes(dot.id)
+    );
   }
 
-  moveDot(dotId: number, position: [number, number]): void {
-    const selectedDot = this.stuntSheetDots.find((dot) => dot.id === dotId);
-    if (selectedDot) {
-      selectedDot.x = position[0];
-      selectedDot.y = position[1];
+  moveDots(newPositions: [number, [number, number]][]): void {
+    for (const newPosition of newPositions) {
+      const selectedDot = this.stuntSheetDots.find(
+        (dot) => dot.id === newPosition[0]
+      );
+      if (selectedDot) {
+        selectedDot.x = newPosition[1][0];
+        selectedDot.y = newPosition[1][1];
+      }
     }
   }
 }

--- a/src/models/continuity/BaseCont.ts
+++ b/src/models/continuity/BaseCont.ts
@@ -10,7 +10,6 @@ import ContFollowLeader from "./ContFollowLeader";
 import ContGateTurn from "./ContGateTurn";
 import ContStepTwo from "./ContStepTwo";
 
-
 /**
  * Defines a unique identifier for each continuity class so that it is possible
  * to deserialize from a JSON string.

--- a/src/models/continuity/BaseCont.ts
+++ b/src/models/continuity/BaseCont.ts
@@ -1,6 +1,15 @@
 import StuntSheetDot from "../StuntSheetDot";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";
+import ContEven from "./ContEven";
+import ContCounterMarch from "./ContCounterMarch";
+import ContInPlace from "./ContInPlace";
+import ContETFStatic from "./ContETFStatic";
+import ContETFDynamic from "./ContETFDynamic";
+import ContFollowLeader from "./ContFollowLeader";
+import ContGateTurn from "./ContGateTurn";
+import ContStepTwo from "./ContStepTwo";
+
 
 /**
  * Defines a unique identifier for each continuity class so that it is possible
@@ -30,7 +39,7 @@ export enum CONT_IDS {
  *                               continuity to bandsmen. Leave blank to use
  *                               the computer generated text.
  */
-export default interface BaseCont {
+export interface BaseCont {
   readonly continuityId: CONT_IDS;
 
   duration: number;
@@ -56,3 +65,29 @@ export default interface BaseCont {
    */
   addToFlow(flow: FlowBeat[], endDot?: StuntSheetDot): void;
 }
+
+/**
+ * Factory function for creating a new continuity
+ *
+ * @param whichCont  - Which continuity to create.
+ */
+export const ContFactory = (whichCont: CONT_IDS): BaseCont => {
+  switch (whichCont) {
+    case CONT_IDS.IN_PLACE:
+      return new ContInPlace();
+    case CONT_IDS.ETF_STATIC:
+      return new ContETFStatic();
+    case CONT_IDS.ETF_DYNAMIC:
+      return new ContETFDynamic();
+    case CONT_IDS.EVEN:
+      return new ContEven();
+    case CONT_IDS.FOLLOW_LEADER:
+      return new ContFollowLeader();
+    case CONT_IDS.COUNTER_MARCH:
+      return new ContCounterMarch();
+    case CONT_IDS.GATE_TURN:
+      return new ContGateTurn();
+    case CONT_IDS.STEP_TWO:
+      return new ContStepTwo();
+  }
+};

--- a/src/models/continuity/ContCounterMarch.ts
+++ b/src/models/continuity/ContCounterMarch.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import StuntSheetDot from "../StuntSheetDot";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";

--- a/src/models/continuity/ContETFDynamic.ts
+++ b/src/models/continuity/ContETFDynamic.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import StuntSheetDot from "../StuntSheetDot";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";

--- a/src/models/continuity/ContETFStatic.ts
+++ b/src/models/continuity/ContETFStatic.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import { DIRECTIONS, MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";
 import Serializable from "../util/Serializable";

--- a/src/models/continuity/ContEven.ts
+++ b/src/models/continuity/ContEven.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";
 import StuntSheetDot from "../StuntSheetDot";

--- a/src/models/continuity/ContFactory.ts
+++ b/src/models/continuity/ContFactory.ts
@@ -1,5 +1,5 @@
 import ContEven from "./ContEven";
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import ContCounterMarch from "./ContCounterMarch";
 import ContInPlace from "./ContInPlace";
 import ContETFStatic from "./ContETFStatic";
@@ -11,11 +11,7 @@ import ContStepTwo from "./ContStepTwo";
 /**
  * Factory function for creating a new continuity
  *
- * @param offsetX    - How many steps to march. Positive is north, negative is
- *                     south.
- * @param direction? - To enforce a direction to face, set this parameter. If
- *                     undefined, the marcher will face the direction they are
- *                     marching.
+ * @param whichCont  - Which continuity to create.
  */
 export const ContFactory = (whichCont: CONT_IDS): BaseCont => {
   switch (whichCont) {

--- a/src/models/continuity/ContFactory.ts
+++ b/src/models/continuity/ContFactory.ts
@@ -1,0 +1,39 @@
+import ContEven from "./ContEven";
+import BaseCont, { CONT_IDS } from "./BaseCont";
+import ContCounterMarch from "./ContCounterMarch";
+import ContInPlace from "./ContInPlace";
+import ContETFStatic from "./ContETFStatic";
+import ContETFDynamic from "./ContETFDynamic";
+import ContFollowLeader from "./ContFollowLeader";
+import ContGateTurn from "./ContGateTurn";
+import ContStepTwo from "./ContStepTwo";
+
+/**
+ * Factory function for creating a new continuity
+ *
+ * @param offsetX    - How many steps to march. Positive is north, negative is
+ *                     south.
+ * @param direction? - To enforce a direction to face, set this parameter. If
+ *                     undefined, the marcher will face the direction they are
+ *                     marching.
+ */
+export const ContFactory = (whichCont: CONT_IDS): BaseCont => {
+  switch (whichCont) {
+    case CONT_IDS.IN_PLACE:
+      return new ContInPlace();
+    case CONT_IDS.ETF_STATIC:
+      return new ContETFStatic();
+    case CONT_IDS.ETF_DYNAMIC:
+      return new ContETFDynamic();
+    case CONT_IDS.EVEN:
+      return new ContEven();
+    case CONT_IDS.FOLLOW_LEADER:
+      return new ContFollowLeader();
+    case CONT_IDS.COUNTER_MARCH:
+      return new ContCounterMarch();
+    case CONT_IDS.GATE_TURN:
+      return new ContGateTurn();
+    case CONT_IDS.STEP_TWO:
+      return new ContStepTwo();
+  }
+};

--- a/src/models/continuity/ContFollowLeader.ts
+++ b/src/models/continuity/ContFollowLeader.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import StuntSheetDot from "../StuntSheetDot";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";

--- a/src/models/continuity/ContGateTurn.ts
+++ b/src/models/continuity/ContGateTurn.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import StuntSheetDot from "../StuntSheetDot";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";

--- a/src/models/continuity/ContInPlace.ts
+++ b/src/models/continuity/ContInPlace.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import { DIRECTIONS, MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";
 import Serializable from "../util/Serializable";

--- a/src/models/continuity/ContStepTwo.ts
+++ b/src/models/continuity/ContStepTwo.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import StuntSheetDot from "../StuntSheetDot";
 import { MARCH_TYPES } from "../util/constants";
 import { FlowBeat } from "../util/FlowBeat";

--- a/src/models/continuity/load-continuity.ts
+++ b/src/models/continuity/load-continuity.ts
@@ -1,4 +1,4 @@
-import BaseCont, { CONT_IDS } from "./BaseCont";
+import { BaseCont, CONT_IDS } from "./BaseCont";
 import ContInPlace from "./ContInPlace";
 import ContETFDynamic from "./ContETFDynamic";
 import ContEven from "./ContEven";

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,7 +1,7 @@
 import { CalChartState } from ".";
 import StuntSheet from "@/models/StuntSheet";
 import { GetterTree } from "vuex";
-import BaseCont from "@/models/continuity/BaseCont";
+import { BaseCont } from "@/models/continuity/BaseCont";
 
 const getters: GetterTree<CalChartState, CalChartState> = {
   // Show

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,11 +1,12 @@
 import Vue from "vue";
 import Vuex, { Store } from "vuex";
-import mutations from "./mutations";
+import { mutations } from "./mutations";
 import getters from "./getters";
 import Show from "@/models/Show";
 import Serializable from "@/models/util/Serializable";
 import BaseTool from "@/tools/BaseTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import InitialShowState from "@/models/InitialShowState";
 
 Vue.use(Vuex);
 
@@ -13,6 +14,7 @@ Vue.use(Vuex);
  * Defines the global state for the application
  *
  * @property show              - The currently selected show data
+ * @property initialShowState  - Beginning spot for show
  * @property selectedSS        - Index of stuntsheet currently in view
  * @property beat              - The point in time the show is in
  * @property fourStepGrid      - View setting to toggle the grapher grid
@@ -23,6 +25,8 @@ Vue.use(Vuex);
  */
 export class CalChartState extends Serializable<CalChartState> {
   show: Show = new Show();
+
+  initialShowState: InitialShowState = new InitialShowState();
 
   selectedSS = 0;
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -5,13 +5,12 @@ import BaseTool from "@/tools/BaseTool";
 import StuntSheet from "@/models/StuntSheet";
 import StuntSheetDot from "@/models/StuntSheetDot";
 import { MutationTree } from "vuex";
-import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
+import { BaseCont, CONT_IDS, ContFactory } from "@/models/continuity/BaseCont";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic, {
   ETF_DYNAMIC_TYPES,
 } from "@/models/continuity/ContETFDynamic";
 import DotAppearance from "@/models/DotAppearance";
-import { ContFactory } from "@/models/continuity/ContFactory";
 import { MARCH_TYPES } from "@/models/util/constants";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,23 +1,103 @@
 import { CalChartState } from ".";
-import Show from "@/models/Show";
+import InitialShowState from "@/models/InitialShowState";
 import getters from "./getters";
 import BaseTool from "@/tools/BaseTool";
 import StuntSheet from "@/models/StuntSheet";
 import StuntSheetDot from "@/models/StuntSheetDot";
 import { MutationTree } from "vuex";
-import BaseCont from "@/models/continuity/BaseCont";
+import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
 import ContInPlace from "@/models/continuity/ContInPlace";
+import ContETFDynamic, {
+  ETF_DYNAMIC_TYPES,
+} from "@/models/continuity/ContETFDynamic";
 import DotAppearance from "@/models/DotAppearance";
+import { ContFactory } from "@/models/continuity/ContFactory";
+import { MARCH_TYPES } from "@/models/util/constants";
+import ContETFStatic from "@/models/continuity/ContETFStatic";
 
-const mutations: MutationTree<CalChartState> = {
-  // Show
-  setShow(state, show: Show): void {
-    state.show = show;
+export enum Mutations {
+  // Show mutations:
+  SET_SHOW = "Set new Show",
+  SET_SHOW_TITLE = "Set Show title",
+  ADD_STUNT_SHEET = "Add Stunt Sheet",
+  DELETE_STUNT_SHEET = "Delete Stunt Sheet",
+  // Field mutations:
+  SET_FRONT_HASH_OFFSET_Y = "Set front hash offset",
+  SET_BACK_HASH_OFFSET_Y = "Set back has offset",
+  SET_MIDDLE_OF_FIELD = "Set middle of field",
+  // Stuntsheet mutations:
+  ADD_DOTS = "Add Marcher",
+  REMOVE_DOTS = "Remove Marcher",
+  MOVE_DOTS = "Move Marcher",
+  SET_STUNT_SHEET_TITLE = "Set Stunt Sheet title",
+  SET_STUNT_SHEET_BEATS = "Set Stund Sheet beats",
+  ADD_DOT_TYPE = "Add Marcher type",
+  ADD_CONTINUITY = "Add Continuity",
+  // Continuity mutations:
+  UPDATE_DOT_TYPE_MARCH_STYLE = "Update Marcher Step Style",
+  UPDATE_DOT_TYPE_DURATION = "Update Marcher Duration",
+  UPDATE_DOT_TYPE_ETF_TYPE = "Update Marcher Eight To Five Flow",
+  UPDATE_DOT_TYPE_ETF_DIRECTION = "Update Marcher Flow Direction",
+  UPDATE_DOT_TYPE_IN_PLACE_DIRECTION = "Update Marcher Standing Direction",
+  DELETE_DOT_TYPE_CONTINUITY = "Remove Marcher Continuity",
+
+  // View mutations:
+  SET_SELECTED_SS = "setSelectedSS",
+  SET_BEAT = "setBeat",
+  INCREMENT_BEAT = "incrementBeat",
+  DECREMENT_BEAT = "decrementBeat",
+  // Field view mutations:
+  SET_FOUR_STEP_GRID = "setFourStepGrid",
+  SET_YARDLINES = "setYardlines",
+  SET_YARDLINE_NUMBERS = "setYardlineNumbers",
+  SET_SHOW_DOT_LABELS = "setShowDotLabels",
+  // Tools
+  SET_GRAPHER_SVG_PAN_ZOOM = "setGrapherSvgPanZoom",
+  SET_INVERTED_CTM_MATRIX = "setInvertedCTMMatrix",
+  SET_TOOL_SELECTED = "setToolSelected",
+  SET_GRAPHER_TOOL_DOTS = "setGrapherToolDots",
+  // selection
+  CLEAR_SELECTED_DOTS = "clearSelectedDots",
+  ADD_SELECTED_DOTS = "addSelectedDots",
+  TOGGLE_SELECTED_DOTS = "toggleSelectedDots",
+  SET_SELECTION_LASSO = "setSelectionLasso",
+
+  UNDO = "undo",
+  REDO = "redo",
+  INITIAL_SHOW_STATE = "resetShowState",
+}
+
+export const UNDOABLE_ACTIONS = [
+  Mutations.SET_SHOW_TITLE,
+  Mutations.ADD_STUNT_SHEET,
+  Mutations.DELETE_STUNT_SHEET,
+  Mutations.SET_FRONT_HASH_OFFSET_Y,
+  Mutations.SET_BACK_HASH_OFFSET_Y,
+  Mutations.SET_MIDDLE_OF_FIELD,
+  Mutations.ADD_DOTS,
+  Mutations.REMOVE_DOTS,
+  Mutations.MOVE_DOTS,
+  Mutations.SET_STUNT_SHEET_TITLE,
+  Mutations.SET_STUNT_SHEET_BEATS,
+  Mutations.ADD_DOT_TYPE,
+  Mutations.ADD_CONTINUITY,
+  Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
+  Mutations.UPDATE_DOT_TYPE_DURATION,
+  Mutations.UPDATE_DOT_TYPE_ETF_TYPE,
+  Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION,
+  Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION,
+  Mutations.DELETE_DOT_TYPE_CONTINUITY,
+];
+
+export const mutations: MutationTree<CalChartState> = {
+  [Mutations.SET_SHOW](state, initialShowState: InitialShowState): void {
+    state.initialShowState = initialShowState;
+    state.show = state.initialShowState.getInitialState();
   },
-  setShowTitle(state, title: string): void {
+  [Mutations.SET_SHOW_TITLE](state, title: string): void {
     state.show.title = title;
   },
-  addStuntSheet(state): void {
+  [Mutations.ADD_STUNT_SHEET](state): void {
     state.show.stuntSheets.push(
       new StuntSheet({
         title: `Stuntsheet ${state.show.stuntSheets.length + 1}`,
@@ -26,63 +106,63 @@ const mutations: MutationTree<CalChartState> = {
     state.selectedSS = state.show.stuntSheets.length - 1;
     state.beat = 1;
   },
-  deleteStuntSheet(state): void {
+  [Mutations.DELETE_STUNT_SHEET](state): void {
     state.show.stuntSheets.splice(state.selectedSS, 1);
     state.selectedSS = Math.max(0, state.selectedSS - 1);
     state.beat = 1;
   },
 
   // Show -> Field
-  setFrontHashOffsetY(state, offsetY: number): void {
+  [Mutations.SET_FRONT_HASH_OFFSET_Y](state, offsetY: number): void {
     state.show.field.frontHashOffsetY = offsetY;
   },
-  setBackHashOffsetY(state, offsetY: number): void {
+  [Mutations.SET_BACK_HASH_OFFSET_Y](state, offsetY: number): void {
     state.show.field.backHashOffsetY = offsetY;
   },
-  setMiddleOfField(state, middle: number): void {
+  [Mutations.SET_MIDDLE_OF_FIELD](state, middle: number): void {
     state.show.field.middleOfField = middle;
   },
 
   // Show -> StuntSheet
-  removeDot(state, dotId: number): void {
+  [Mutations.REMOVE_DOTS](state, dotIndex: number[]): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.removeDot(dotId);
+    currentSS.removeDots(dotIndex);
   },
-  addDot(state, dot: Partial<StuntSheetDot>): void {
+  [Mutations.ADD_DOTS](state, jsons: Partial<StuntSheetDot>[]): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.addDot(dot);
+    currentSS.addDots(jsons.map((json) => new StuntSheetDot(json)));
   },
-  moveDot(
+  [Mutations.MOVE_DOTS](
     state,
-    { dotId, position }: { dotId: number; position: [number, number] }
+    newPositions: [number, [number, number]][]
   ): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.moveDot(dotId, position);
+    currentSS.moveDots(newPositions);
   },
-  setStuntSheetTitle(state, title: string): void {
+  [Mutations.SET_STUNT_SHEET_TITLE](state, title: string): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.title = title;
   },
-  setStuntSheetBeats(state, beats: number): void {
+  [Mutations.SET_STUNT_SHEET_BEATS](state, beats: number): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.beats = beats;
   },
-  addDotType(state): void {
+  [Mutations.ADD_DOT_TYPE](state): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
@@ -90,35 +170,115 @@ const mutations: MutationTree<CalChartState> = {
     currentSS.dotTypes.push([new ContInPlace()]);
     currentSS.dotAppearances.push(new DotAppearance());
   },
-  addContinuity(
+  [Mutations.ADD_CONTINUITY](
     state,
-    { dotTypeIndex, continuity }: { dotTypeIndex: number; continuity: BaseCont }
+    { dotTypeIndex, contID }: { dotTypeIndex: number; contID: CONT_IDS }
   ): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    currentSS.dotTypes[dotTypeIndex].push(continuity);
+    currentSS.dotTypes[dotTypeIndex].push(ContFactory(contID));
     state.show.generateFlows(state.selectedSS);
   },
 
   // Show -> StuntSheet -> BaseCont
-  updateDotTypeContinuity(
+  [Mutations.UPDATE_DOT_TYPE_MARCH_STYLE](
     state,
     {
       dotTypeIndex,
       continuityIndex,
-      continuity,
-    }: { dotTypeIndex: number; continuityIndex: number; continuity: BaseCont }
+      marchType,
+    }: { dotTypeIndex: number; continuityIndex: number; marchType: MARCH_TYPES }
   ): void {
-    const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+    const getContinuity = getters.getContinuity as (
       state: CalChartState
-    ) => StuntSheet;
-    const currentSS = getSelectedStuntSheet(state);
-    currentSS.dotTypes[dotTypeIndex][continuityIndex] = continuity;
-    state.show.generateFlows(state.selectedSS);
+    ) => (dotTypeIndex: number, continuityIndex: number) => BaseCont;
+    const continuity: BaseCont = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
+    continuity.marchType = marchType;
+    updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
   },
-  deleteDotTypeContinuity(
+  [Mutations.UPDATE_DOT_TYPE_DURATION](
+    state,
+    {
+      dotTypeIndex,
+      continuityIndex,
+      duration,
+    }: { dotTypeIndex: number; continuityIndex: number; duration: number }
+  ): void {
+    const getContinuity = getters.getContinuity as (
+      state: CalChartState
+    ) => (dotTypeIndex: number, continuityIndex: number) => BaseCont;
+    const continuity: BaseCont = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
+    continuity.duration = duration;
+    updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
+  },
+  [Mutations.UPDATE_DOT_TYPE_ETF_TYPE](
+    state,
+    {
+      dotTypeIndex,
+      continuityIndex,
+      etfType,
+    }: {
+      dotTypeIndex: number;
+      continuityIndex: number;
+      etfType: ETF_DYNAMIC_TYPES;
+    }
+  ): void {
+    const getContinuity = getters.getContinuity as (
+      state: CalChartState
+    ) => (dotTypeIndex: number, continuityIndex: number) => ContETFDynamic;
+    const continuity: ContETFDynamic = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
+    continuity.eightToFiveType = etfType;
+    updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
+  },
+  [Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION](
+    state,
+    {
+      dotTypeIndex,
+      continuityIndex,
+      direction,
+    }: { dotTypeIndex: number; continuityIndex: number; direction: number }
+  ): void {
+    const getContinuity = getters.getContinuity as (
+      state: CalChartState
+    ) => (dotTypeIndex: number, continuityIndex: number) => ContETFStatic;
+    const continuity: ContETFStatic = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
+    continuity.marchingDirection = direction;
+    continuity.facingDirection = direction;
+    updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
+  },
+  [Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION](
+    state,
+    {
+      dotTypeIndex,
+      continuityIndex,
+      direction,
+    }: { dotTypeIndex: number; continuityIndex: number; direction: number }
+  ): void {
+    const getContinuity = getters.getContinuity as (
+      state: CalChartState
+    ) => (dotTypeIndex: number, continuityIndex: number) => ContInPlace;
+    const continuity: ContInPlace = getContinuity(state)(
+      dotTypeIndex,
+      continuityIndex
+    );
+    continuity.direction = direction;
+    updateContinuity(state, dotTypeIndex, continuityIndex, continuity);
+  },
+  [Mutations.DELETE_DOT_TYPE_CONTINUITY](
     state,
     {
       dotTypeIndex,
@@ -134,13 +294,13 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // Show controls
-  setSelectedSS(state, selectedSS: number): void {
+  [Mutations.SET_SELECTED_SS](state, selectedSS: number): void {
     state.selectedSS = selectedSS;
   },
-  setBeat(state, beat: number): void {
+  [Mutations.SET_BEAT](state, beat: number): void {
     state.beat = beat;
   },
-  incrementBeat(state): void {
+  [Mutations.INCREMENT_BEAT](state): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
@@ -159,7 +319,7 @@ const mutations: MutationTree<CalChartState> = {
       state.beat += 1;
     }
   },
-  decrementBeat(state): void {
+  [Mutations.DECREMENT_BEAT](state): void {
     if (state.beat - 1 < 0) {
       if (state.selectedSS > 0) {
         // Go to previous stuntsheet's 2nd to last beat
@@ -179,44 +339,50 @@ const mutations: MutationTree<CalChartState> = {
   },
 
   // View Settings
-  setFourStepGrid(state, enabled: boolean): void {
+  [Mutations.SET_FOUR_STEP_GRID](state, enabled: boolean): void {
     state.fourStepGrid = enabled;
   },
-  setYardlines(state, enabled: boolean): void {
+  [Mutations.SET_YARDLINES](state, enabled: boolean): void {
     state.yardlines = enabled;
   },
-  setYardlineNumbers(state, enabled: boolean): void {
+  [Mutations.SET_YARDLINE_NUMBERS](state, enabled: boolean): void {
     state.yardlineNumbers = enabled;
   },
-  setShowDotLabels(state, enabled: boolean): void {
+  [Mutations.SET_SHOW_DOT_LABELS](state, enabled: boolean): void {
     state.showDotLabels = enabled;
   },
 
   // Tools
-  setGrapherSvgPanZoom(state, svgPanZoomInstance: SvgPanZoom.Instance): void {
+  [Mutations.SET_GRAPHER_SVG_PAN_ZOOM](
+    state,
+    svgPanZoomInstance: SvgPanZoom.Instance
+  ): void {
     state.grapherSvgPanZoom = svgPanZoomInstance;
   },
-  setInvertedCTMMatrix(state, matrix: DOMMatrix): void {
+  [Mutations.SET_INVERTED_CTM_MATRIX](state, matrix: DOMMatrix): void {
     state.invertedCTMMatrix = matrix;
   },
-  setToolSelected(state, toolSelected: BaseTool): void {
+  [Mutations.SET_TOOL_SELECTED](state, toolSelected: BaseTool): void {
     state.toolSelected = toolSelected;
     state.grapherToolDots = [];
   },
-  setGrapherToolDots(state, grapherToolDots: StuntSheetDot[]): void {
+  [Mutations.SET_GRAPHER_TOOL_DOTS](
+    state,
+    grapherToolDots: StuntSheetDot[]
+  ): void {
     state.grapherToolDots = grapherToolDots;
   },
 
   // selection
-  clearSelectedDotIds(state): void {
+  [Mutations.CLEAR_SELECTED_DOTS](state): void {
     state.selectedDotIds = [];
   },
-  addSelectedDotIds(state, dotIds: number[]): void {
+  [Mutations.ADD_SELECTED_DOTS](state, dotIds: number[]): void {
     dotIds.forEach((id) => {
       !state.selectedDotIds.includes(id) && state.selectedDotIds.push(id);
     });
   },
-  toggleSelectedDotIds(state, dotIds: number[]): void {
+  [Mutations.TOGGLE_SELECTED_DOTS](state, dotIds: number[]): void {
     // first remove all the items passed in.
     dotIds.forEach((id) => {
       const index = state.selectedDotIds.indexOf(id);
@@ -227,9 +393,32 @@ const mutations: MutationTree<CalChartState> = {
       }
     });
   },
-  setSelectionLasso(state, lasso: [number, number][]): void {
+  [Mutations.SET_SELECTION_LASSO](state, lasso: [number, number][]): void {
     state.selectionLasso = lasso;
+  },
+
+  // Undo system
+  [Mutations.UNDO](): void {
+    // intentionally empty as the Undo system is "sniffing" for this command.
+  },
+  [Mutations.REDO](): void {
+    // intentionally empty as the Undo system is "sniffing" for this command.
+  },
+  [Mutations.INITIAL_SHOW_STATE](state): void {
+    state.show = state.initialShowState.getInitialState();
   },
 };
 
-export default mutations;
+function updateContinuity(
+  state: CalChartState,
+  dotTypeIndex: number,
+  continuityIndex: number,
+  continuity: BaseCont
+) {
+  const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
+    state: CalChartState
+  ) => StuntSheet;
+  const currentSS = getSelectedStuntSheet(state);
+  currentSS.dotTypes[dotTypeIndex][continuityIndex] = continuity;
+  state.show.generateFlows(state.selectedSS);
+}

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -1,5 +1,6 @@
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Defines the functionality of a tool to be used in the Bottom Menu.
@@ -77,7 +78,7 @@ export default abstract class BaseTool {
     if (!ctm) {
       throw new Error("Unable to retrieve wrapper CTM");
     }
-    GlobalStore.commit("setInvertedCTMMatrix", ctm.inverse());
+    GlobalStore.commit(Mutations.SET_INVERTED_CTM_MATRIX, ctm.inverse());
   }
 
   abstract onMouseDown(event: MouseEvent): void;

--- a/src/tools/ToolBoxSelect.ts
+++ b/src/tools/ToolBoxSelect.ts
@@ -1,6 +1,7 @@
 import { ToolConstructor } from "./BaseTool";
 import { ToolSelectMove } from "./ToolSelectMove";
 import { GlobalStore } from "@/store";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Enables Selection, Moving, and Panning via base class
@@ -11,7 +12,7 @@ const ToolBoxSelect: ToolConstructor = class ToolBoxSelect extends ToolSelectMov
     if (this.selectionLassoStart === null) {
       return;
     }
-    GlobalStore.commit("setSelectionLasso", [
+    GlobalStore.commit(Mutations.SET_SELECTION_LASSO, [
       [this.selectionLassoStart[0], this.selectionLassoStart[1]],
       [point[0], this.selectionLassoStart[1]],
       [point[0], point[1]],

--- a/src/tools/ToolLassoSelect.ts
+++ b/src/tools/ToolLassoSelect.ts
@@ -1,6 +1,7 @@
 import { ToolConstructor } from "./BaseTool";
 import { ToolSelectMove } from "./ToolSelectMove";
 import { GlobalStore } from "@/store";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Enables Selection, Moving, and Panning via base class
@@ -13,7 +14,7 @@ const ToolLassoSelect: ToolConstructor = class ToolLassoSelect extends ToolSelec
     }
     const arrayCopy = GlobalStore.state.selectionLasso;
     arrayCopy.push(point);
-    GlobalStore.commit("setSelectionLasso", arrayCopy);
+    GlobalStore.commit(Mutations.SET_TOOL_SELECTED, arrayCopy);
   }
 };
 

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -3,6 +3,7 @@ import BaseMoveTool from "./BaseMoveTool";
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
 import { InsideLasso } from "@/models/util/Lasso";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Enables Selection and Moving.
@@ -29,16 +30,16 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       // if we click on a selected dot, determine if we are toggling selection.
       if (GlobalStore.state.selectedDotIds.includes(existingDot.id)) {
         if (event.altKey) {
-          GlobalStore.commit("toggleSelectedDotIds", [existingDot.id]);
+          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [existingDot.id]);
         }
       } else {
         if (!event.shiftKey) {
-          GlobalStore.commit("clearSelectedDotIds");
+          GlobalStore.commit(Mutations.CLEAR_SELECTED_DOTS);
         }
         if (event.altKey) {
-          GlobalStore.commit("toggleSelectedDotIds", [existingDot.id]);
+          GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [existingDot.id]);
         } else {
-          GlobalStore.commit("addSelectedDotIds", [existingDot.id]);
+          GlobalStore.commit(Mutations.ADD_SELECTED_DOTS, [existingDot.id]);
         }
       }
       this.moveToolStart = [x, y];
@@ -46,9 +47,9 @@ export abstract class ToolSelectMove extends BaseMoveTool {
     } else {
       // if we hvae not clicked on a dot, start a new selection.
       if (!event.shiftKey) {
-        GlobalStore.commit("clearSelectedDotIds");
+        GlobalStore.commit(Mutations.CLEAR_SELECTED_DOTS);
       }
-      GlobalStore.commit("setSelectionLasso", [[x, y]]);
+      GlobalStore.commit(Mutations.SET_SELECTION_LASSO, [[x, y]]);
       this.selectionLassoStart = [x, y];
     }
   }
@@ -64,6 +65,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       ];
       const currentSSDots: StuntSheetDot[] =
         GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
+      const newPositions: [number, [number, number]][] = [];
       GlobalStore.state.selectedDotIds.forEach((id: number) => {
         const selectedDot = currentSSDots.find((dot) => dot.id === id);
         if (!selectedDot) {
@@ -73,13 +75,11 @@ export abstract class ToolSelectMove extends BaseMoveTool {
           selectedDot.x + deltaX,
           selectedDot.y + deltaY,
         ]);
-        GlobalStore.commit("moveDot", {
-          dotId: selectedDot.id,
-          position: [roundedX, roundedY],
-        });
+        newPositions.push([id, [roundedX, roundedY]]);
       });
+      GlobalStore.commit(Mutations.MOVE_DOTS, newPositions);
       // Set the ToolDots to be empty to indicate we're not moving anymore.
-      GlobalStore.commit("setGrapherToolDots", []);
+      GlobalStore.commit(Mutations.SET_GRAPHER_TOOL_DOTS, []);
       // null out moveToolStart to incidcate we're not moving anymore.
       this.moveToolStart = null;
       return;
@@ -93,12 +93,12 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       );
       const dotIdsInLasso = dotsInLasso.map((dot) => dot.id);
       if (event.altKey) {
-        GlobalStore.commit("toggleSelectedDotIds", dotIdsInLasso);
+        GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, dotIdsInLasso);
       } else {
-        GlobalStore.commit("addSelectedDotIds", dotIdsInLasso);
+        GlobalStore.commit(Mutations.ADD_SELECTED_DOTS, dotIdsInLasso);
       }
       // we are done selecting, so clear out the box
-      GlobalStore.commit("setSelectionLasso", []);
+      GlobalStore.commit(Mutations.SET_SELECTION_LASSO, []);
       this.selectionLassoStart = null;
     }
   }
@@ -143,7 +143,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
         })
       );
     });
-    GlobalStore.commit("setGrapherToolDots", grapherToolDots);
+    GlobalStore.commit(Mutations.SET_GRAPHER_TOOL_DOTS, grapherToolDots);
   }
 
   // override this function change the selection lasso.

--- a/src/tools/ToolSingleDot.ts
+++ b/src/tools/ToolSingleDot.ts
@@ -2,6 +2,7 @@ import BaseMoveTool from "./BaseMoveTool";
 import BaseTool, { ToolConstructor } from "./BaseTool";
 import { GlobalStore } from "@/store";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { Mutations } from "@/store/mutations";
 
 /**
  * Add or remove a single dot on click.
@@ -11,15 +12,15 @@ const ToolSingleDot: ToolConstructor = class ToolSingleDot extends BaseMoveTool 
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
     const existingDot = BaseTool.findDotAtEvent(event);
     if (existingDot) {
-      GlobalStore.commit("removeDot", existingDot.id);
+      GlobalStore.commit(Mutations.REMOVE_DOTS, [existingDot.id]);
     } else {
-      GlobalStore.commit("addDot", { x, y });
+      GlobalStore.commit(Mutations.ADD_DOTS, [{ x, y }]);
     }
   }
 
   onMouseMoveInternal(event: MouseEvent): void {
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
-    GlobalStore.commit("setGrapherToolDots", [
+    GlobalStore.commit(Mutations.SET_GRAPHER_TOOL_DOTS, [
       new StuntSheetDot({ x, y, id: -1 }),
     ]);
   }

--- a/tests/unit/components/grapher/GrapherField.spec.ts
+++ b/tests/unit/components/grapher/GrapherField.spec.ts
@@ -5,6 +5,7 @@ import Grapher from "@/components/grapher/Grapher.vue";
 import { CalChartState, generateStore } from "@/store";
 import Show from "@/models/Show";
 import Field from "@/models/Field";
+import { Mutations } from "@/store/mutations";
 
 jest.mock("svg-pan-zoom", () => {
   return {
@@ -72,7 +73,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("does not render four step grid if fourStepGrid is false", async () => {
-      store.commit("setFourStepGrid", false);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -84,14 +85,14 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("replaces yardlines with gridlines if yardlines is false", async () => {
-      store.commit("setYardlines", false);
+      store.commit(Mutations.SET_YARDLINES, false);
       await wrapper.vm.$nextTick();
 
       expect(
         wrapper.find('[data-test="grapher-field--yard-line"]').exists()
       ).toBeFalsy();
 
-      store.commit("setFourStepGrid", true);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, true);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -100,7 +101,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("if yardlineNumbers is false, do not render", async () => {
-      store.commit("setYardlineNumbers", false);
+      store.commit(Mutations.SET_YARDLINE_NUMBERS, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -109,7 +110,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("if showDotLabels is false, do not render", async () => {
-      store.commit("setShowDotLabels", false);
+      store.commit(Mutations.SET_SHOW_DOT_LABELS, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -164,7 +165,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("does not render four step grid if fourStepGrid is false", async () => {
-      store.commit("setFourStepGrid", false);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -176,7 +177,7 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("does not render yardlines if yardlines is false", async () => {
-      store.commit("setYardlines", false);
+      store.commit(Mutations.SET_YARDLINES, false);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -185,14 +186,14 @@ describe("components/grapher/GrapherField.vue", () => {
     });
 
     it("replaces yardlines with gridlines if yardlines is false", async () => {
-      store.commit("setYardlines", false);
+      store.commit(Mutations.SET_YARDLINES, false);
       await wrapper.vm.$nextTick();
 
       expect(
         wrapper.find('[data-test="grapher-field--yard-line"]').exists()
       ).toBeFalsy();
 
-      store.commit("setFourStepGrid", true);
+      store.commit(Mutations.SET_FOUR_STEP_GRID, true);
       await wrapper.vm.$nextTick();
 
       expect(

--- a/tests/unit/components/menu-left/MenuLeft.spec.ts
+++ b/tests/unit/components/menu-left/MenuLeft.spec.ts
@@ -5,6 +5,7 @@ import Vuex, { Store } from "vuex";
 import MenuLeft from "@/components/menu-left/MenuLeft.vue";
 import Show from "@/models/Show";
 import StuntSheet from "@/models/StuntSheet";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-left/MenuLeft", () => {
   let menu: Wrapper<Vue>;
@@ -39,8 +40,8 @@ describe("components/menu-left/MenuLeft", () => {
     ])(
       "Beat control with beat %i and stuntsheet %i",
       async (beat, selectedSS) => {
-        store.commit("setBeat", beat);
-        store.commit("setSelectedSS", selectedSS);
+        store.commit(Mutations.SET_BEAT, beat);
+        store.commit(Mutations.SET_SELECTED_SS, selectedSS);
         await menu.vm.$nextTick();
 
         const beatControl = menu.find('[data-test="menu-left--beat"]');
@@ -58,8 +59,8 @@ describe("components/menu-left/MenuLeft", () => {
     );
 
     it.each([
-      ["decrementBeat", "menu-left--decrement-beat"],
-      ["incrementBeat", "menu-left--increment-beat"],
+      [Mutations.DECREMENT_BEAT, "menu-left--decrement-beat"],
+      [Mutations.INCREMENT_BEAT, "menu-left--increment-beat"],
     ])("Calls %s in store upon clicking button", (commitMsg, selector) => {
       const button = menu.find(`[data-test="${selector}"]`);
       expect(button.exists()).toBeTruthy();
@@ -84,8 +85,8 @@ describe("components/menu-left/MenuLeft", () => {
       menuItem.trigger("click");
       await menu.vm.$nextTick();
 
-      expect(commitSpy).toHaveBeenCalledWith("setSelectedSS", index);
-      expect(commitSpy).toHaveBeenCalledWith("setBeat", 0);
+      expect(commitSpy).toHaveBeenCalledWith(Mutations.SET_SELECTED_SS, index);
+      expect(commitSpy).toHaveBeenCalledWith(Mutations.SET_BEAT, 0);
       expect(menuItem.classes("is-active")).toBeTruthy();
     });
 
@@ -112,7 +113,7 @@ describe("components/menu-left/MenuLeft", () => {
       addButton.trigger("click");
       await menu.vm.$nextTick();
 
-      expect(commitSpy).toHaveBeenCalledWith("addStuntSheet");
+      expect(commitSpy).toHaveBeenCalledWith(Mutations.ADD_STUNT_SHEET);
       expect(menu.findAll('[data-test="menu-left--ss"]')).toHaveLength(4);
     });
   });

--- a/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContETFDynamicEditor.spec.ts
@@ -10,6 +10,7 @@ import ContETFDynamic, {
   ETF_DYNAMIC_TYPES,
 } from "@/models/continuity/ContETFDynamic";
 import { MARCH_TYPES } from "@/models/util/constants";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContETFDynamicEditor", () => {
   let editor: Wrapper<Vue>;
@@ -56,12 +57,10 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectETFType.setValue(ETF_DYNAMIC_TYPES.NSEW);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_ETF_TYPE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.eightToFiveType).toBe(
-        ETF_DYNAMIC_TYPES.NSEW
-      );
+      expect(commitSpy.mock.calls[0][1].etfType).toBe(ETF_DYNAMIC_TYPES.NSEW);
     });
 
     it("changing march type", () => {
@@ -74,10 +73,10 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(
         MARCH_TYPES.MINI_MILITARY
       );
     });
@@ -90,10 +89,13 @@ describe("components/menu-right/ContETFDynamicEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 0,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 0,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContEvenEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContEvenEditor.spec.ts
@@ -8,6 +8,7 @@ import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContEven from "@/models/continuity/ContEven";
 import { MARCH_TYPES } from "@/models/util/constants";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContEvenEditor", () => {
   let editor: Wrapper<Vue>;
@@ -51,12 +52,10 @@ describe("components/menu-right/ContEvenEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.HS);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
-        MARCH_TYPES.HS
-      );
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(MARCH_TYPES.HS);
     });
 
     it("can delete if more than one continuity exists for the dot type", async () => {
@@ -65,10 +64,13 @@ describe("components/menu-right/ContEvenEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 0,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 0,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInETFStaticEditor.spec.ts
@@ -8,6 +8,7 @@ import Show from "@/models/Show";
 import ContETFStatic from "@/models/continuity/ContETFStatic.ts";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContETFStaticEditor", () => {
   let editor: Wrapper<Vue>;
@@ -54,10 +55,10 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(
         MARCH_TYPES.MINI_MILITARY
       );
     });
@@ -72,10 +73,10 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       durationInput.setValue("10");
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_DURATION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(10);
+      expect(commitSpy.mock.calls[0][1].duration).toBe(10);
     });
 
     it("changing direction", () => {
@@ -88,12 +89,10 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectDirection.setValue(`${DIRECTIONS.S}`);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_ETF_DIRECTION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchingDirection).toBe(
-        DIRECTIONS.S
-      );
+      expect(commitSpy.mock.calls[0][1].direction).toBe(DIRECTIONS.S);
     });
 
     it("can delete if more than one continuity exists for the dot type", async () => {
@@ -102,10 +101,13 @@ describe("components/menu-right/ContETFStaticEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 1,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 1,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
+++ b/tests/unit/components/menu-right/ContInPlaceEditor.spec.ts
@@ -8,6 +8,7 @@ import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import { DIRECTIONS, MARCH_TYPES } from "@/models/util/constants";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/ContInPlaceEditor", () => {
   let editor: Wrapper<Vue>;
@@ -54,10 +55,10 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectMarchType.setValue(MARCH_TYPES.MINI_MILITARY);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_MARCH_STYLE,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.marchType).toBe(
+      expect(commitSpy.mock.calls[0][1].marchType).toBe(
         MARCH_TYPES.MINI_MILITARY
       );
     });
@@ -72,10 +73,10 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       durationInput.setValue("8");
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_DURATION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.duration).toBe(8);
+      expect(commitSpy.mock.calls[0][1].duration).toBe(8);
     });
 
     it("changing direction", () => {
@@ -88,12 +89,10 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       selectDirection.setValue(`${DIRECTIONS.S}`);
       expect(commitSpy).toHaveBeenCalledWith(
-        "updateDotTypeContinuity",
+        Mutations.UPDATE_DOT_TYPE_IN_PLACE_DIRECTION,
         expect.anything()
       );
-      expect(commitSpy.mock.calls[0][1].continuity.direction).toBe(
-        DIRECTIONS.S
-      );
+      expect(commitSpy.mock.calls[0][1].direction).toBe(DIRECTIONS.S);
     });
 
     it("can delete if more than one continuity exists for the dot type", async () => {
@@ -102,10 +101,13 @@ describe("components/menu-right/ContInPlaceEditor", () => {
       expect(commitSpy).not.toHaveBeenCalled();
       deleteButton.trigger("click");
       await editor.vm.$nextTick();
-      expect(commitSpy).toHaveBeenCalledWith("deleteDotTypeContinuity", {
-        dotTypeIndex: 0,
-        continuityIndex: 1,
-      });
+      expect(commitSpy).toHaveBeenCalledWith(
+        Mutations.DELETE_DOT_TYPE_CONTINUITY,
+        {
+          dotTypeIndex: 0,
+          continuityIndex: 1,
+        }
+      );
     });
   });
 

--- a/tests/unit/components/menu-right/DotTypeEditor.spec.ts
+++ b/tests/unit/components/menu-right/DotTypeEditor.spec.ts
@@ -8,6 +8,8 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
+import { CONT_IDS } from "@/models/continuity/BaseCont";
 
 describe("components/menu-right/DotTypeEditor", () => {
   let editor: Wrapper<Vue>;
@@ -59,10 +61,11 @@ describe("components/menu-right/DotTypeEditor", () => {
     expect(commitSpy).not.toHaveBeenCalled();
     addInPlaceBtn.trigger("click");
     await editor.vm.$nextTick();
-    expect(commitSpy).toHaveBeenCalledWith("addContinuity", expect.anything());
-    expect(commitSpy.mock.calls[0][1].continuity instanceof ContInPlace).toBe(
-      true
+    expect(commitSpy).toHaveBeenCalledWith(
+      Mutations.ADD_CONTINUITY,
+      expect.anything()
     );
+    expect(commitSpy.mock.calls[0][1].contID).toBe(CONT_IDS.IN_PLACE);
   });
 
   it("add eight to five dynamic continuity", async () => {
@@ -73,9 +76,10 @@ describe("components/menu-right/DotTypeEditor", () => {
     expect(commitSpy).not.toHaveBeenCalled();
     addETFDynamicBtn.trigger("click");
     await editor.vm.$nextTick();
-    expect(commitSpy).toHaveBeenCalledWith("addContinuity", expect.anything());
-    expect(
-      commitSpy.mock.calls[0][1].continuity instanceof ContETFDynamic
-    ).toBe(true);
+    expect(commitSpy).toHaveBeenCalledWith(
+      Mutations.ADD_CONTINUITY,
+      expect.anything()
+    );
+    expect(commitSpy.mock.calls[0][1].contID).toBe(CONT_IDS.ETF_DYNAMIC);
   });
 });

--- a/tests/unit/components/menu-right/MenuRight.spec.ts
+++ b/tests/unit/components/menu-right/MenuRight.spec.ts
@@ -8,6 +8,7 @@ import StuntSheet from "@/models/StuntSheet";
 import Show from "@/models/Show";
 import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
+import { Mutations } from "@/store/mutations";
 
 describe("components/menu-right/MenuRight", () => {
   let menu: Wrapper<Vue>;
@@ -54,6 +55,6 @@ describe("components/menu-right/MenuRight", () => {
     expect(commitSpy).not.toHaveBeenCalled();
     addBtn.trigger("click");
     await menu.vm.$nextTick();
-    expect(commitSpy).toHaveBeenCalledWith("addDotType");
+    expect(commitSpy).toHaveBeenCalledWith(Mutations.ADD_DOT_TYPE);
   });
 });

--- a/tests/unit/models/continuity/load-continuity.spec.ts
+++ b/tests/unit/models/continuity/load-continuity.spec.ts
@@ -2,7 +2,7 @@ import ContInPlace from "@/models/continuity/ContInPlace";
 import { MARCH_TYPES } from "@/models/util/constants";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import ContEven from "@/models/continuity/ContEven";
-import BaseCont, { CONT_IDS } from "@/models/continuity/BaseCont";
+import { BaseCont, CONT_IDS } from "@/models/continuity/BaseCont";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 import ContFollowLeader from "@/models/continuity/ContFollowLeader";
 import ContCounterMarch from "@/models/continuity/ContCounterMarch";

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -6,6 +6,8 @@ import ContInPlace from "@/models/continuity/ContInPlace";
 import ContETFDynamic from "@/models/continuity/ContETFDynamic";
 import ContEven from "@/models/continuity/ContEven";
 import DotAppearance from "@/models/DotAppearance";
+import { Mutations } from "@/store/mutations";
+import { CONT_IDS } from "@/models/continuity/BaseCont";
 
 describe("store/mutations", () => {
   let store: Store<CalChartState>;
@@ -27,12 +29,12 @@ describe("store/mutations", () => {
 
     it("adds a new dot type to the end of the array", () => {
       expect(store.state.show.stuntSheets[0].dotTypes).toHaveLength(2);
-      store.commit("addDotType");
+      store.commit(Mutations.ADD_DOT_TYPE);
       expect(store.state.show.stuntSheets[0].dotTypes).toHaveLength(3);
     });
     it("adds a new dot appereance to the end of the array", () => {
       expect(store.state.show.stuntSheets[0].dotAppearances).toHaveLength(2);
-      store.commit("addDotType");
+      store.commit(Mutations.ADD_DOT_TYPE);
       expect(store.state.show.stuntSheets[0].dotAppearances).toHaveLength(3);
     });
   });
@@ -58,9 +60,9 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0][0] instanceof ContInPlace).toBe(true);
       expect(oldDotTypes[1]).toHaveLength(1);
       expect(oldDotTypes[1][0] instanceof ContETFDynamic).toBe(true);
-      store.commit("addContinuity", {
+      store.commit(Mutations.ADD_CONTINUITY, {
         dotTypeIndex: 1,
-        continuity: new ContEven(),
+        contID: CONT_IDS.EVEN,
       });
       const newDotTypes = store.state.show.stuntSheets[0].dotTypes;
       expect(newDotTypes[0]).toHaveLength(1);
@@ -93,10 +95,10 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0][0].duration).toBe(0);
       expect(oldDotTypes[1]).toHaveLength(1);
       expect(oldDotTypes[1][0] instanceof ContETFDynamic).toBe(true);
-      store.commit("updateDotTypeContinuity", {
+      store.commit(Mutations.UPDATE_DOT_TYPE_DURATION, {
         dotTypeIndex: 0,
         continuityIndex: 0,
-        continuity: new ContInPlace({ duration: 8 }),
+        duration: 8,
       });
       const newDotTypes = store.state.show.stuntSheets[0].dotTypes;
       expect(newDotTypes[0]).toHaveLength(1);
@@ -127,7 +129,7 @@ describe("store/mutations", () => {
       expect(oldDotTypes[0]).toHaveLength(2);
       expect(oldDotTypes[0][0] instanceof ContInPlace).toBe(true);
       expect(oldDotTypes[0][1] instanceof ContETFDynamic).toBe(true);
-      store.commit("deleteDotTypeContinuity", {
+      store.commit(Mutations.DELETE_DOT_TYPE_CONTINUITY, {
         dotTypeIndex: 0,
         continuityIndex: 0,
       });
@@ -151,19 +153,19 @@ describe("store/mutations", () => {
     });
 
     it("increments selectedSS at the end of stuntsheet", () => {
-      store.commit("incrementBeat");
+      store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(0);
     });
 
     it("increments beat in the middle of a stuntsheet", () => {
-      store.commit("incrementBeat");
+      store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(1);
     });
 
     it("does nothing at end of show", () => {
-      store.commit("incrementBeat");
+      store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(2);
       store.commit("incrementBeat");
@@ -186,19 +188,19 @@ describe("store/mutations", () => {
     });
 
     it("decrements selectedSS at the beginning of stuntsheet", () => {
-      store.commit("decrementBeat");
+      store.commit(Mutations.DECREMENT_BEAT);
       expect(store.state.selectedSS).toBe(0);
       expect(store.state.beat).toBe(1);
     });
 
     it("decrements beat in the middle of a stuntsheet", () => {
-      store.commit("decrementBeat");
+      store.commit(Mutations.DECREMENT_BEAT);
       expect(store.state.selectedSS).toBe(0);
       expect(store.state.beat).toBe(0);
     });
 
     it("does nothing at beginning of show", () => {
-      store.commit("decrementBeat");
+      store.commit(Mutations.DECREMENT_BEAT);
       expect(store.state.selectedSS).toBe(0);
       expect(store.state.beat).toBe(0);
     });

--- a/tests/unit/tools/ToolSingleDot.spec.ts
+++ b/tests/unit/tools/ToolSingleDot.spec.ts
@@ -3,6 +3,7 @@ import { GlobalStore } from "@/store";
 import BaseTool from "@/tools/BaseTool";
 import BaseMoveTool from "@/tools/BaseMoveTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { Mutations } from "@/store/mutations";
 
 describe("tools/ToolSingleDot", () => {
   let tool: BaseTool;
@@ -28,7 +29,9 @@ describe("tools/ToolSingleDot", () => {
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
-      expect(GlobalStore.commit).toHaveBeenCalledWith("addDot", { x: 0, y: 2 });
+      expect(GlobalStore.commit).toHaveBeenCalledWith(Mutations.ADD_DOTS, [
+        { x: 0, y: 2 },
+      ]);
     });
 
     it("removes a dot if it exists in the spot", () => {
@@ -42,7 +45,9 @@ describe("tools/ToolSingleDot", () => {
 
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
-      expect(GlobalStore.commit).toHaveBeenCalledWith("removeDot", 0);
+      expect(GlobalStore.commit).toHaveBeenCalledWith(Mutations.REMOVE_DOTS, [
+        0,
+      ]);
     });
   });
 
@@ -56,7 +61,7 @@ describe("tools/ToolSingleDot", () => {
       expect(BaseTool.convertClientCoordinates).toHaveBeenCalled();
       expect(GlobalStore.commit).toHaveBeenCalledTimes(1);
       expect(GlobalStore.commit).toHaveBeenCalledWith(
-        "setGrapherToolDots",
+        Mutations.SET_GRAPHER_TOOL_DOTS,
         expect.anything()
       );
       const grapherToolDots: StuntSheetDot[] = (GlobalStore.commit as jest.Mock)


### PR DESCRIPTION
## Description

This refactors much of the code to prep everything for the undo system.  This is the first part of the change which should make the second part much easier to understand.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
