### PR TITLE
Adding New show menu item

### DIFF
--- a/src/components/menu-left/MenuLeft.vue
+++ b/src/components/menu-left/MenuLeft.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="menu-left">
+    <b-field :label="`Show: ${title}`" data-test="menu-left--title" />
     <b-field
       :label="`Beat: ${beatString} / ${selectedSSBeats}`"
       data-test="menu-left--beat"
@@ -116,6 +117,9 @@ export default Vue.extend({
       const selectedSS = this.$store.getters
         .getSelectedStuntSheet as StuntSheet;
       return selectedSS.beats;
+    },
+    title(): string {
+      return this.$store.state.show.title;
     },
   },
   methods: {

--- a/src/components/menu-top/LoadModal.vue
+++ b/src/components/menu-top/LoadModal.vue
@@ -103,10 +103,15 @@ export default Vue.extend({
         reader.readAsText(this.file);
       } else if (this.file.name.includes(".shw")) {
         reader.onload = (): void => {
-          if (reader.result && reader.result instanceof ArrayBuffer) {
+          if (
+            reader.result &&
+            this.file &&
+            reader.result instanceof ArrayBuffer
+          ) {
             try {
               this.showLoadState = new InitialLoadShwState({
                 showData: reader.result,
+                fileName: this.file.name,
               });
               this.showPreview = this.showLoadState.getInitialState();
             } catch (e) {

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -9,7 +9,7 @@
       <template slot="start">
         <b-navbar-dropdown label="File" data-test="menu-top--file">
           <b-navbar-item data-test="menu-top--new-show" @click="newShow">
-            New Show
+            New Show (ctrl-N)
           </b-navbar-item>
 
           <hr class="navbar-divider" />

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -8,8 +8,8 @@
       </template>
       <template slot="start">
         <b-navbar-dropdown label="File" data-test="menu-top--file">
-          <b-navbar-item data-test="menu-top--selected-show">
-            Selected: {{ showTitle }}
+          <b-navbar-item data-test="menu-top--new-show" @click="newShow">
+            New Show
           </b-navbar-item>
 
           <hr class="navbar-divider" />
@@ -91,6 +91,7 @@
 </template>
 
 <script lang="ts">
+import InitialShowState from "@/models/InitialShowState";
 import { Mutations } from "@/store/mutations";
 import Vue from "vue";
 import FileModal from "./FileModal.vue";
@@ -154,6 +155,11 @@ export default Vue.extend({
       const jsonData = JSON.stringify(this.$store.state.show);
       const blob = new Blob([jsonData], { type: "text/plain;charset=utf-8;" });
       return URL.createObjectURL(blob);
+    },
+  },
+  methods: {
+    newShow(): void {
+      this.$store.commit(Mutations.SET_SHOW, new InitialShowState());
     },
   },
 });

--- a/src/models/InitialLoadShowState.ts
+++ b/src/models/InitialLoadShowState.ts
@@ -11,6 +11,7 @@ export class InitialLoadShwState extends InitialShowState {
   metadataVersion: number = METADATA_VERSION;
 
   showData: ArrayBuffer | undefined;
+  defaultTitle = "";
 
   constructor(json: Partial<InitialLoadShwState> = {}) {
     super();
@@ -23,7 +24,7 @@ export class InitialLoadShwState extends InitialShowState {
    */
   getInitialState(): Show {
     if (this.showData) {
-      return loadShowFromBuffer(this.showData);
+      return loadShowFromBuffer(this.defaultTitle, this.showData);
     }
     return new Show();
   }

--- a/src/models/InitialLoadShowState.ts
+++ b/src/models/InitialLoadShowState.ts
@@ -11,7 +11,7 @@ export class InitialLoadShwState extends InitialShowState {
   metadataVersion: number = METADATA_VERSION;
 
   showData: ArrayBuffer | undefined;
-  defaultTitle = "";
+  fileName = "";
 
   constructor(json: Partial<InitialLoadShwState> = {}) {
     super();
@@ -24,7 +24,7 @@ export class InitialLoadShwState extends InitialShowState {
    */
   getInitialState(): Show {
     if (this.showData) {
-      return loadShowFromBuffer(this.defaultTitle, this.showData);
+      return loadShowFromBuffer(this.fileName, this.showData);
     }
     return new Show();
   }

--- a/src/models/util/LoadShow.ts
+++ b/src/models/util/LoadShow.ts
@@ -38,10 +38,13 @@ function IsCalChart3(buffer: ArrayBuffer): ParseCalChart | null {
  * @returns Returns either a new [Show] or will throw an error that can be
  * displayed to the user
  */
-export const loadShowFromBuffer = (buffer: ArrayBuffer): Show => {
-  const parser = IsCalChart3(buffer);
+export const loadShowFromBuffer = (
+  defaultTitle: string,
+  buffer: ArrayBuffer
+): Show => {
+  let parser = IsCalChart3(buffer);
   if (parser) {
-    return parser.ParseShow(buffer);
+    return parser.ParseShow(defaultTitle, buffer);
   }
   throw new Error("file is not a CalChart show file.");
 };

--- a/src/models/util/LoadShow.ts
+++ b/src/models/util/LoadShow.ts
@@ -39,12 +39,12 @@ function IsCalChart3(buffer: ArrayBuffer): ParseCalChart | null {
  * displayed to the user
  */
 export const loadShowFromBuffer = (
-  defaultTitle: string,
+  fileName: string,
   buffer: ArrayBuffer
 ): Show => {
-  let parser = IsCalChart3(buffer);
+  const parser = IsCalChart3(buffer);
   if (parser) {
-    return parser.ParseShow(defaultTitle, buffer);
+    return parser.ParseShow(fileName.replace(/\.[^/.]+$/, ""), buffer);
   }
   throw new Error("file is not a CalChart show file.");
 };

--- a/src/models/util/ParseCalChart.ts
+++ b/src/models/util/ParseCalChart.ts
@@ -9,5 +9,5 @@ import Show from "../Show";
  * @returns The parsed show
  */
 export interface ParseCalChart {
-  ParseShow(buffer: ArrayBuffer): Show;
+  ParseShow(defaultTitle: string, buffer: ArrayBuffer): Show;
 }

--- a/src/models/util/ParseCalChart31.ts
+++ b/src/models/util/ParseCalChart31.ts
@@ -99,7 +99,7 @@ import { ParseCalChart } from "./ParseCalChart";
 export class ParseCalChart31 implements ParseCalChart {
   private numberDots = 0;
 
-  ParseShow(inputBuffer: ArrayBuffer): Show {
+  ParseShow(defaultTitle: string, inputBuffer: ArrayBuffer): Show {
     // we know the header for a CalChart3.1 show is 8 bytes.  Remove it.
     const buffer = new DataView(inputBuffer, 0, inputBuffer.byteLength);
     // CalChart3.1 is more complicated a format so we parse the blocks inline.
@@ -110,7 +110,7 @@ export class ParseCalChart31 implements ParseCalChart {
     offset += 4;
 
     const show = new Show({
-      title: "",
+      title: defaultTitle,
       stuntSheets: [],
     });
 

--- a/src/models/util/ParseCalChart34.ts
+++ b/src/models/util/ParseCalChart34.ts
@@ -119,8 +119,10 @@ import { ParseCalChart } from "./ParseCalChart";
 
 export class ParseCalChart34 implements ParseCalChart {
   private numberDots = 0;
+  private defaultTitle = "";
 
-  ParseShow(inputBuffer: ArrayBuffer): Show {
+  ParseShow(defaultTitle: string, inputBuffer: ArrayBuffer): Show {
+    this.defaultTitle = defaultTitle;
     // we know the header for a CalChart3.5 show is 8 bytes.  Remove it.
     const buffer = new DataView(inputBuffer, 8, inputBuffer.byteLength - 8);
     const split = splitDataViewIntoChunks(buffer);
@@ -132,7 +134,7 @@ export class ParseCalChart34 implements ParseCalChart {
 
   ParseSHOW(block: DataView): Show {
     const show = new Show({
-      title: "",
+      title: this.defaultTitle,
       stuntSheets: [],
     });
     const split = splitDataViewIntoChunks(block);

--- a/src/store/hotkeys.ts
+++ b/src/store/hotkeys.ts
@@ -1,14 +1,19 @@
 import { CalChartState } from ".";
 import { Store } from "vuex";
+import { Mutations } from "./mutations";
+import InitialShowState from "@/models/InitialShowState";
 
 export const HotKeyHandler = (
   store: Store<CalChartState>,
   event: KeyboardEvent
 ): void => {
   if (event.key === "ArrowLeft") {
-    store.commit("decrementBeat");
+    store.commit(Mutations.DECREMENT_BEAT);
   }
   if (event.key === "ArrowRight") {
-    store.commit("incrementBeat");
+    store.commit(Mutations.INCREMENT_BEAT);
+  }
+  if (event.key === "n" && event.ctrlKey) {
+    store.commit(Mutations.SET_SHOW, new InitialShowState());
   }
 };

--- a/tests/e2e/specs/menu-top/FileModal.spec.js
+++ b/tests/e2e/specs/menu-top/FileModal.spec.js
@@ -42,9 +42,7 @@ describe("components/menu-top/FileModal", () => {
 
     cy.get('[data-test="menu-top--file"]').click();
 
-    cy.get('[data-test="menu-top--selected-show"]').contains(
-      "Ariana Grande Show"
-    );
+    cy.get('[data-test="menu-left--title"]').contains("Ariana Grande Show");
   });
 
   it("field changes shape upon adjusting hashes and middle of field", () => {

--- a/tests/e2e/specs/menu-top/MenuTop.spec.js
+++ b/tests/e2e/specs/menu-top/MenuTop.spec.js
@@ -26,7 +26,7 @@ describe("components/menu-top/MenuTop", () => {
     });
 
     it("shows selected show title", () => {
-      cy.get('[data-test="menu-top--selected-show"]').contains("Example Show");
+      cy.get('[data-test="menu-left--title"]').contains("Example Show");
     });
 
     it('clicking "Edit Show Details" opens show modal', () => {

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -23,12 +23,9 @@ describe("components/menu-top/MenuTop", () => {
   });
 
   describe("file dropdown", () => {
-    it("shows the show title", () => {
-      const selectedShow = wrapper.find(
-        '[data-test="menu-top--selected-show"]'
-      );
-      expect(selectedShow.exists()).toBeTruthy();
-      expect(selectedShow.text()).toBe("Selected: Example Show");
+    it("new show", () => {
+      const newShow = wrapper.find('[data-test="menu-top--new-show"]');
+      expect(newShow.exists()).toBeTruthy();
     });
 
     it('sets fileModal to true upon clicking "Edit Show Details"', async () => {

--- a/tests/unit/models/util/LoadShow.spec.ts
+++ b/tests/unit/models/util/LoadShow.spec.ts
@@ -5,7 +5,7 @@ describe("models/util/LoadShow", () => {
   describe("Testing loadShowFromBuffer", () => {
     it("loading empty data", () => {
       expect(() => {
-        loadShowFromBuffer(new ArrayBuffer(8));
+        loadShowFromBuffer("", new ArrayBuffer(8));
       }).toThrow("file is not a CalChart show file.");
     });
 
@@ -15,7 +15,7 @@ describe("models/util/LoadShow", () => {
       const dataArray = Uint8Array.from(atob(base64String), (c) =>
         c.charCodeAt(0)
       );
-      const show = loadShowFromBuffer(dataArray.buffer);
+      const show = loadShowFromBuffer("", dataArray.buffer);
       expect(show).not.toBeNull();
       expect(show instanceof Show).toBeTruthy();
       expect(show.dotLabels.length).toBe(1);

--- a/tests/unit/models/util/ParseCalChart34.spec.ts
+++ b/tests/unit/models/util/ParseCalChart34.spec.ts
@@ -9,12 +9,15 @@ describe("models/util/ParseCalChart34", () => {
       const dataArray = Uint8Array.from(atob(base64String), (c) =>
         c.charCodeAt(0)
       );
-      const show = new ParseCalChart34().ParseShow(dataArray.buffer);
+      const show = new ParseCalChart34().ParseShow(
+        "simple show name",
+        dataArray.buffer
+      );
       expect(show).not.toBeNull();
       expect(show instanceof Show).toBeTruthy();
       expect(show.dotLabels.length).toBe(1);
       expect(show.dotLabels).toStrictEqual(["A0"]);
-      expect(show.title).toStrictEqual("");
+      expect(show.title).toStrictEqual("simple show name");
       expect(show.stuntSheets.length).toBe(2);
       expect(show.stuntSheets[0].title).toBe("1");
       expect(show.stuntSheets[1].title).toBe("sheet2");

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -168,7 +168,7 @@ describe("store/mutations", () => {
       store.commit(Mutations.INCREMENT_BEAT);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(2);
-      store.commit("incrementBeat");
+      store.commit(Mutations.INITIAL_SHOW_STATE);
       expect(store.state.selectedSS).toBe(1);
       expect(store.state.beat).toBe(2);
     });


### PR DESCRIPTION
## Description

Adding a file menu item for creating a new show.
Moving the show name to be part of left menu.

<img width="258" alt="image" src="https://user-images.githubusercontent.com/6156360/106399541-157f2900-63ce-11eb-9485-379668e9991b.png">

When we load a CalChart3 show, if the show has no title, use the file name.

<img width="216" alt="image" src="https://user-images.githubusercontent.com/6156360/106399575-54ad7a00-63ce-11eb-9fa4-30d6827a0be6.png">


[What does your PR add or fix?]

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
