### PR TITLE
Fixing up error spew when multiple points overlap.

### DIFF
--- a/src/components/grapher/GrapherTool.vue
+++ b/src/components/grapher/GrapherTool.vue
@@ -11,8 +11,8 @@
     />
     <g v-if="showDotLabels">
       <text
-        v-for="dot in grapherToolDotLabels"
-        :key="`${dot[0].x}-${dot[0].y}-tool--dottext`"
+        v-for="(dot, index) in grapherToolDotLabels"
+        :key="`${index}-tool--dottext`"
         class="grapher-tool--dottext"
         :x="dot[0].x"
         :y="dot[0].y - 1"


### PR DESCRIPTION
## Description

When you selected multiple points that were overlapping with each other and move, you would see lots of console spew about multiple DOM having the same name.

Giving points unique names based on the index.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
