### PR TITLE
Adding a dot needs to cause the flows to be regenerated.

### DIFF
--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -136,6 +136,7 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.addDots(jsons.map((json) => new StuntSheetDot(json)));
+    state.show.generateFlows(state.selectedSS);
   },
   [Mutations.MOVE_DOTS](
     state,

--- a/tests/e2e/specs/continuity/BasicInteraction.spec.js
+++ b/tests/e2e/specs/continuity/BasicInteraction.spec.js
@@ -1,0 +1,53 @@
+describe("continuity/interactions", () => {
+  beforeEach(() => {
+    cy.visit("/").get('[data-test="menu-bottom-tool--add-rm"]').click();
+  });
+
+  it("add dot, set cont, should move", () => {
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "transform", "translate(12, 8)");
+
+    // Add a new eight to five static continuity for the first dot type
+    cy.get('[data-test="menu-right--add-continuity"]').click();
+    cy.get('[data-test="menu-right--add-etf-static"]').click();
+
+    // Clicking forward should move 1
+    cy.get('[data-test="menu-left--increment-beat"]').click();
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "transform", "translate(12, 9)");
+
+    // Clicking backward should move back 1
+    cy.get('[data-test="menu-left--decrement-beat"]').click();
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "transform", "translate(12, 8)");
+  });
+
+  it("set cont, add dot, should move", () => {
+    // Add a new eight to five static continuity for the first dot type
+    cy.get('[data-test="menu-right--add-continuity"]').click();
+    cy.get('[data-test="menu-right--add-etf-static"]').click();
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "transform", "translate(12, 8)");
+
+    // Clicking forward should move 1
+    cy.get('[data-test="menu-left--increment-beat"]').click();
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "transform", "translate(12, 9)");
+
+    // Clicking backward should move back 1
+    cy.get('[data-test="menu-left--decrement-beat"]').click();
+    cy.get('[data-test="grapher-dots--dot"]')
+      .should("have.length", 1)
+      .should("have.attr", "transform", "translate(12, 8)");
+  });
+});


### PR DESCRIPTION
## Description

Fixes issue \_\_

Noticed that when you created a continuity, and then added a dot, the new dot doesn't follow the continuity.  Looks like we need to have the flow regenerated when we add it.

Added an e2e test for catching and verifying the fix.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
