### PR TITLE
Fixing where adding or removing a sheet doesn't start at hup.

### DIFF
--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -103,12 +103,12 @@ export const mutations: MutationTree<CalChartState> = {
       })
     );
     state.selectedSS = state.show.stuntSheets.length - 1;
-    state.beat = 1;
+    state.beat = 0;
   },
   [Mutations.DELETE_STUNT_SHEET](state): void {
     state.show.stuntSheets.splice(state.selectedSS, 1);
     state.selectedSS = Math.max(0, state.selectedSS - 1);
-    state.beat = 1;
+    state.beat = 0;
   },
 
   // Show -> Field

--- a/tests/e2e/specs/menu-left/MenuLeft.spec.js
+++ b/tests/e2e/specs/menu-left/MenuLeft.spec.js
@@ -49,6 +49,7 @@ describe("components/menu-left/MenuLeft", () => {
     // Add new stuntsheet
     cy.get('[data-test="menu-left--add-ss"]').click();
 
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "Hup! / 16");
     cy.get('[data-test="menu-left--ss"]')
       .should("have.length", 2)
       .eq(1)
@@ -121,5 +122,32 @@ describe("components/menu-left/MenuLeft", () => {
     cy.get('[data-test="grapher-dots--dot"]')
       .should("have.length", 1)
       .should("have.attr", "transform", "translate(8, 8)");
+  });
+
+  it("Creating and deleting a stunt sheet", () => {
+    cy.visit("/");
+
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "Hup! / 16");
+    // Add new stuntsheet
+    cy.get('[data-test="menu-left--add-ss"]').click();
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "Hup! / 16");
+    cy.get('[data-test="menu-left--ss"]')
+      .should("have.length", 2)
+      .eq(1)
+      .should("have.class", "is-active");
+
+    // Edit the second stuntsheet to have title "Script YOLO" and 4 beats
+    cy.get('[data-test="menu-left--ss"]')
+      .eq(1)
+      .find(".stuntsheet-edit")
+      .should("be.visible")
+      .click();
+
+    cy.get('[data-test="menu-left--ss-modal"]').should("be.visible");
+
+    cy.get('[data-test="ss-modal--delete"]').click();
+
+    // Check that the stuntsheet title and beats have been updated
+    cy.get('[data-test="menu-left--beat"]').should("include.text", "Hup! / 16");
   });
 });


### PR DESCRIPTION
## Description

Fixes issue \_\_

When you add or remove a sheet, it resets to be 1, but it should be beat 0.

Adding a unit test to catch this.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
