### PR TITLE
Undo system

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,8 @@
     <MenuTop />
     <MenuLeft />
     <Grapher />
-    <MenuBottom />
+    <MenuBottomTools />
+    <MenuBottomUndo />
     <MenuRight />
     <Issues />
   </div>
@@ -15,7 +16,8 @@ import MenuTop from "./components/menu-top/MenuTop.vue";
 import MenuLeft from "./components/menu-left/MenuLeft.vue";
 import Grapher from "./components/grapher/Grapher.vue";
 import MenuRight from "./components/menu-right/MenuRight.vue";
-import MenuBottom from "./components/menu-bottom/MenuBottom.vue";
+import MenuBottomTools from "./components/menu-bottom/MenuBottomTools.vue";
+import MenuBottomUndo from "./components/menu-bottom/MenuBottomUndo.vue";
 import Issues from "./components/Issues.vue";
 import { HotKeyHandler } from "./store/hotkeys";
 
@@ -26,7 +28,8 @@ export default Vue.extend({
     MenuLeft,
     Grapher,
     MenuRight,
-    MenuBottom,
+    MenuBottomTools,
+    MenuBottomUndo,
     Issues,
   },
   created() {
@@ -64,11 +67,12 @@ body,
 #app {
   display: grid;
   grid-template-columns: 200px auto 275px;
-  grid-template-rows: $navbar-height auto 36px 175px; // See Bulma for navbar-height
+  grid-template-rows: $navbar-height auto 40px 40px 120px; // See Bulma for navbar-height
   grid-template-areas:
     "menu-top menu-top menu-top"
     "menu-left grapher menu-right"
-    "menu-left menu-bottom menu-right"
+    "menu-left menu-bottom-tools menu-right"
+    "menu-left menu-bottom-undo menu-right"
     "menu-left issues menu-right";
 }
 </style>

--- a/src/components/Issues.vue
+++ b/src/components/Issues.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
       });
       if (this.filter === "current") {
         return issues.filter((issue: Issue) => {
-          const currentSS: number = this.$store.state.selectedSS;
+          const currentSS: number = this.$store.getters.getSelectedStuntIndex;
           return issue.stuntSheets.some((ss: number) => {
             return ss === currentSS;
           });

--- a/src/components/grapher/GrapherDots.vue
+++ b/src/components/grapher/GrapherDots.vue
@@ -35,15 +35,17 @@ export default Vue.extend({
       return this.$store.state.showDotLabels;
     },
     selectedDotIds(): number[] {
-      return this.$store.state.selectedDotIds;
+      return this.$store.getters.getSelectedDotIds;
     },
     dotsWithLabels(): [string, StuntSheetDot][] {
       const show: Show = this.$store.state.show;
-      return show.dotsWithLabelsForSS(this.$store.state.selectedSS);
+      return show.dotsWithLabelsForSS(
+        this.$store.getters.getSelectedStuntIndex
+      );
     },
     beat: {
       get(): number {
-        return this.$store.state.beat;
+        return this.$store.getters.getBeat;
       },
     },
   },

--- a/src/components/menu-bottom/MenuBottomTools.vue
+++ b/src/components/menu-bottom/MenuBottomTools.vue
@@ -1,16 +1,16 @@
 <template>
-  <div class="menu-bottom">
+  <div class="menu-bottom-tools">
     <div class="buttons">
       <b-tooltip
         v-for="(toolData, index) in toolDataList"
         :key="`${toolData.icon}-toolData`"
         :label="toolData.label"
-        data-test="menu-bottom--tooltip"
+        data-test="menu-bottom-tools--tooltip"
       >
         <b-button
           :type="toolSelectedIndex === index ? 'is-primary' : 'is-light'"
           :icon-left="toolData.icon"
-          :data-test="`menu-bottom-tool--${toolData['data-test']}`"
+          :data-test="`menu-bottom-tools-tool--${toolData['data-test']}`"
           @click="setTool(index)"
         />
       </b-tooltip>
@@ -37,7 +37,7 @@ interface ToolData {
 }
 
 export default Vue.extend({
-  name: "MenuBottom",
+  name: "MenuBottomTools",
   data: (): {
     toolDataList: ToolData[];
     toolSelectedIndex: number;
@@ -70,6 +70,7 @@ export default Vue.extend({
   methods: {
     setTool(toolIndex: number): void {
       this.$data.toolSelectedIndex = toolIndex;
+      console.log("which tool ", toolIndex);
       const ToolConstructor: ToolConstructor = this.$data.toolDataList[
         toolIndex
       ].tool;
@@ -84,11 +85,11 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
-.menu-bottom {
-  grid-area: menu-bottom;
+.menu-bottom-tools {
+  grid-area: menu-bottom-tools;
 }
 
 .buttons {
-  height: 36px;
+  height: 24px;
 }
 </style>

--- a/src/components/menu-bottom/MenuBottomUndo.vue
+++ b/src/components/menu-bottom/MenuBottomUndo.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="menu-bottom-undo">
+    <div class="buttons">
+      <p class="control" v-if="canUndo">
+        <b-tooltip :label="undoName" data-test="menu-bottom-undo--tooltip-undo">
+          <b-button
+            icon-left="undo"
+            data-test="menu-bottom-undo-tool--undo"
+            @click="undo"
+          />
+        </b-tooltip>
+      </p>
+      <p class="control" v-else>
+        <b-button
+          disabled
+          icon-left="undo"
+          data-test="menu-bottom-undo-tool--undo"
+        />
+      </p>
+      <p class="control" v-if="canRedo">
+        <b-tooltip :label="redoName" data-test="menu-bottom-undo--tooltip-redo">
+          <b-button
+            icon-left="redo"
+            data-test="menu-bottom-undo-tool--redo"
+            @click="redo"
+          />
+        </b-tooltip>
+      </p>
+      <p class="control" v-else>
+        <b-button
+          disabled
+          icon-left="redo"
+          data-test="menu-bottom-undo-tool--redo"
+        />
+      </p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+/**
+ * Handles setting and modifying the tools used in Grapher
+ */
+import { Mutations } from "@/store/mutations";
+import Vue from "vue";
+
+export default Vue.extend({
+  name: "MenuBottomUndo",
+  computed: {
+    canUndo(): boolean {
+      return this.$store.getters.getCanUndo;
+    },
+    undoName(): string {
+      return "Undo " + this.$store.getters.getUndoName;
+    },
+    redoName(): string {
+      return "Redo " + this.$store.getters.getRedoName;
+    },
+    canRedo(): boolean {
+      return this.$store.getters.getCanRedo;
+    },
+  },
+  // },
+  methods: {
+    undo(): void {
+      this.$store.commit(Mutations.UNDO);
+    },
+    redo(): void {
+      this.$store.commit(Mutations.REDO);
+    },
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.menu-bottom-undo {
+  grid-area: menu-bottom-undo;
+}
+
+.buttons {
+  height: 24px;
+}
+</style>

--- a/src/components/menu-left/MenuLeft.vue
+++ b/src/components/menu-left/MenuLeft.vue
@@ -97,23 +97,23 @@ export default Vue.extend({
   computed: {
     beat: {
       get(): number {
-        return this.$store.state.beat;
+        return this.$store.getters.getBeat;
       },
       set(beat: number): void {
         this.$store.commit(Mutations.SET_BEAT, beat);
       },
     },
     beatString(): string {
-      return this.$store.state.beat === 0
+      return this.$store.getters.getBeat === 0
         ? "Hup!"
-        : this.$store.state.beat.toString();
+        : this.$store.getters.getBeat.toString();
     },
     stuntSheets(): StuntSheet[] {
       return this.$store.state.show.stuntSheets;
     },
     selectedSS: {
       get(): number {
-        return this.$store.state.selectedSS;
+        return this.$store.getters.getSelectedStuntIndex;
       },
       set(selectedSS: number): void {
         this.$store.commit(Mutations.SET_SELECTED_SS, selectedSS);

--- a/src/components/menu-right/SelectedDotEditor.vue
+++ b/src/components/menu-right/SelectedDotEditor.vue
@@ -41,8 +41,8 @@ export default Vue.extend({
   name: "SelectedDotEditor",
   computed: {
     dotsWithLabels(): [string, StuntSheetDot][] {
-      const { selectedDotIds, show, selectedSS } = this.$store
-        .state as CalChartState;
+      const { show } = this.$store.state as CalChartState;
+      const { selectedDotIds, selectedSS } = show;
       const dotsWithLabels = show.dotsWithLabelsForSS(selectedSS);
       return dotsWithLabels.filter(([, dot]) =>
         selectedDotIds.includes(dot.id)

--- a/src/components/menu-top/LoadModal.vue
+++ b/src/components/menu-top/LoadModal.vue
@@ -130,7 +130,7 @@ export default Vue.extend({
       if (!this.showPreview) {
         return;
       }
-      this.$store.commit(Mutations.SET_SHOW, this.showLoadState);
+      this.$store.commit(Mutations.SET_NEW_SHOW, this.showLoadState);
     },
   },
 });

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -9,7 +9,7 @@
       <template slot="start">
         <b-navbar-dropdown label="File" data-test="menu-top--file">
           <b-navbar-item data-test="menu-top--new-show" @click="newShow">
-            New Show (ctrl-N)
+            New Show
           </b-navbar-item>
 
           <hr class="navbar-divider" />
@@ -26,14 +26,24 @@
             data-test="menu-top--load-show"
             @click="loadModalActive = true"
           >
-            Load Show
+            Open
+          </b-navbar-item>
+        </b-navbar-dropdown>
+
+        <b-navbar-dropdown label="Edit" data-test="menu-top--edit">
+          <b-navbar-item data-test="menu-top--edit-undo" @click="undo">
+            Undo {{ undoName }} (⌘ Z)
           </b-navbar-item>
 
+          <b-navbar-item data-test="menu-top--edit-redo" @click="redo">
+            Redo {{ redoName }} (shift ⌘ Z)
+          </b-navbar-item>
+          <hr class="navbar-divider" />
           <b-navbar-item
-            data-test="menu-top--file-edit"
+            data-test="menu-top--edit-show-details"
             @click="fileModalActive = true"
           >
-            Edit Show Details
+            Show Details
           </b-navbar-item>
         </b-navbar-dropdown>
 
@@ -156,10 +166,22 @@ export default Vue.extend({
       const blob = new Blob([jsonData], { type: "text/plain;charset=utf-8;" });
       return URL.createObjectURL(blob);
     },
+    undoName(): string {
+      return this.$store.getters.getUndoName;
+    },
+    redoName(): string {
+      return this.$store.getters.getRedoName;
+    },
   },
   methods: {
+    undo(): void {
+      this.$store.commit(Mutations.UNDO);
+    },
+    redo(): void {
+      this.$store.commit(Mutations.REDO);
+    },
     newShow(): void {
-      this.$store.commit(Mutations.SET_SHOW, new InitialShowState());
+      this.$store.commit(Mutations.SET_NEW_SHOW, new InitialShowState());
     },
   },
 });

--- a/src/models/Show.ts
+++ b/src/models/Show.ts
@@ -11,6 +11,7 @@ const METADATA_VERSION = 1;
 
 /**
  * Defines all metadata to edit, render, and animate a Calchart show.
+ * These would be items we would want to be saved and restored, or undoable.
  *
  * @property metadataVersion - Upon loading the show, determines what
  *                             migrations are needed to make the show
@@ -19,6 +20,9 @@ const METADATA_VERSION = 1;
  * @property dotLabels       - A list of names used for each dot
  * @property field           - Defines the sizing of the field
  * @property stuntSheets     - The set of all StuntSheet objects
+ * @property selectedSS      - The currently selected Stunt Sheet
+ * @property beat            - The point in time the show is in
+ * @property selectedDotIds  - which dotIDs are selected
  */
 export default class Show extends Serializable<Show> {
   metadataVersion: number = METADATA_VERSION;
@@ -30,6 +34,12 @@ export default class Show extends Serializable<Show> {
   field: Field = new Field();
 
   stuntSheets: StuntSheet[] = [new StuntSheet({ title: "Stuntsheet 1" })];
+
+  selectedSS = 0;
+
+  beat = 0;
+
+  selectedDotIds: number[] = [];
 
   issues: Issue[] = [];
 

--- a/src/models/UndoRedo.ts
+++ b/src/models/UndoRedo.ts
@@ -171,7 +171,7 @@ export class UndoRedo extends Serializable<UndoRedo> {
         mutation: MutationPayload /*, state: CalChartState */
       ) => {
         if (UNDOABLE_ACTIONS.includes(mutation.type as Mutations)) {
-          if (this.stateSnapshots.length === this.maxSnapshots) {
+          if (this.currentShapshot + 1 === this.maxSnapshots) {
             this.stateSnapshots.shift();
           } else {
             this.currentShapshot = this.currentShapshot + 1;

--- a/src/models/UndoRedo.ts
+++ b/src/models/UndoRedo.ts
@@ -7,118 +7,122 @@ import Show from "./Show";
 // Increment upon making show metadata changes that break previous versions.
 const METADATA_VERSION = 1;
 
-// The UndoRedo holds snapshots of the show over time.
-//
-// States are held as pairs of the show, and the action that happened to get
-// to that show.  This is useful for displaying that information to the user
-// so they know what the undo/do action will do.
-//
-// shapshots
-// ----------------------------------------------------------
-// | state0, "action" | state1, "action" | state2, "action" |
-// ----------------------------------------------------------
-//                            ^
-// currentSnapshot == 1 ------+
-//
-// When a new undoable commit occurs, UndoRedo will snapshot the current state
-// and append it to the end if there is room.  Otherwise, we shift the entire
-// undo state by one to make room.
-//
-// if a new undoable commit happens when you are in the middle of an undo stack
-// (for instance, you've undo a move and then do another move), we remove all
-// the items after the current snapshot and start appending from there.
-//
-//
-// here is a diagram of what we expect to occur with a series of commits, undo, redo actions.
-//
-// snapshots
-// --------------------
-// | initialState, "" |
-// --------------------
-// currentSnapshot == 0
-// Undoable should be 0, redoable should be 0
-//
-// commit
-// Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
-// snapshots.
-// ---------------------------------------
-// | initialState, "" | state0, "action" |
-// ---------------------------------------
-// currentSnapshot == 1
-// undoable should be 1, redoable should be 0
-//
-// undo:
-// Set currentSnapshot back by 1.  restore state at currentSnapshot.
-// snapshots
-// ---------------------------------------
-// | initialState, "" | state0, "action" |
-// ---------------------------------------
-// currentSnapshot == 0
-// undoable should be 0, redoable should be 1
-//
-// undo:
-// Should be no-op
-// snapshots
-// ---------------------------------------
-// | initialState, "" | state0, "action" |
-// ---------------------------------------
-// currentSnapshot == 0
-// undoable should be 0, redoable should be 1
-//
-// redo:
-// Set currentSnapshot forward by 1.  restore state at currentSnapshot.
-// snapshots
-// ---------------------------------------
-// | initialState, "" | state0, "action" |
-// ---------------------------------------
-// currentSnapshot == 1
-// undoable should be 1, redoable should be 0
-//
-// redo:
-// Should be no-op
-// snapshots
-// ---------------------------------------
-// | initialState, "" | state0, "action" |
-// ---------------------------------------
-// currentSnapshot == 1
-// undoable should be 1, redoable should be 0
-//
-// commit
-// Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
-// snapshots
-// ----------------------------------------------------------
-// | initialState, "" | state0, "action" | state1, "action" |
-// ----------------------------------------------------------
-// currentSnapshot == 2
-// undoable should be 1, redoable should be 0
-//
-// undo:
-// restore state at currentSnapshot.  Set currentSnapshot back by 1
-// snapshots
-// ----------------------------------------------------------
-// | initialState, "" | state0, "action" | state1, "action" |
-// ----------------------------------------------------------
-// currentSnapshot == 1
-// undoable should be 1, redoable should be 1
-//
-// commit
-// Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
-// snapshots
-// ----------------------------------------------------------
-// | initialState, "" | state0, "action" | state2, "action" |
-// ----------------------------------------------------------
-// currentSnapshot == 2
-// undoable should be 1, redoable should be 0
-//
-// assume limit of 3
-// commit
-// rotate snapshots by 1 left.  override new state at currentShapshot-1.
-// snapshots
-// ----------------------------------------------------------
-// | state0, "action" | state2, "action" | state3, "action" |
-// ----------------------------------------------------------
-// currentSnapshot == 2
-// undoable should be 1, redoable should be 0
+/**
+ *  The UndoRedo holds snapshots of the show over time.
+ *
+ * States are held as pairs of the show, and the action that happened to get
+ * to that show.  This is useful for displaying that information to the user
+ * so they know what the undo/do action will do.
+ *
+ * shapshots
+ * ----------------------------------------------------------
+ * | state0, "action" | state1, "action" | state2, "action" |
+ * ----------------------------------------------------------
+ *                            ^
+ * currentSnapshot == 1 ------+
+ *
+ * When a new undoable commit occurs, UndoRedo will snapshot the current state
+ * and append it to the end if there is room.  Otherwise, we shift the entire
+ * undo state by one to make room.
+ *
+ * if a new undoable commit happens when you are in the middle of an undo stack
+ * (for instance, you've undo a move and then do another move), we remove all
+ * the items after the current snapshot and start appending from there.
+ *
+ *
+ * here is a diagram of what we expect to occur with a series of commits, undo, redo actions.
+ *
+ * snapshots
+ * --------------------
+ * | initialState, "" |
+ * --------------------
+ * currentSnapshot == 0
+ * Undoable should be 0, redoable should be 0
+ *
+ * commit
+ * Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
+ * snapshots.
+ * ---------------------------------------
+ * | initialState, "" | state0, "action" |
+ * ---------------------------------------
+ * currentSnapshot == 1
+ * undoable should be 1, redoable should be 0
+ *
+ * undo:
+ * Set currentSnapshot back by 1.  restore state at currentSnapshot.
+ * snapshots
+ * ---------------------------------------
+ * | initialState, "" | state0, "action" |
+ * ---------------------------------------
+ * currentSnapshot == 0
+ * undoable should be 0, redoable should be 1
+ *
+ * undo:
+ * Should be no-op
+ * snapshots
+ * ---------------------------------------
+ * | initialState, "" | state0, "action" |
+ * ---------------------------------------
+ * currentSnapshot == 0
+ * undoable should be 0, redoable should be 1
+ *
+ * redo:
+ * Set currentSnapshot forward by 1.  restore state at currentSnapshot.
+ * snapshots
+ * ---------------------------------------
+ * | initialState, "" | state0, "action" |
+ * ---------------------------------------
+ * currentSnapshot == 1
+ * undoable should be 1, redoable should be 0
+ *
+ * redo:
+ * Should be no-op
+ * snapshots
+ * ---------------------------------------
+ * | initialState, "" | state0, "action" |
+ * ---------------------------------------
+ * currentSnapshot == 1
+ * undoable should be 1, redoable should be 0
+ *
+ * commit
+ * Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
+ * snapshots
+ * ----------------------------------------------------------
+ * | initialState, "" | state0, "action" | state1, "action" |
+ * ----------------------------------------------------------
+ * currentSnapshot == 2
+ * undoable should be 1, redoable should be 0
+ *
+ * undo:
+ * restore state at currentSnapshot.  Set currentSnapshot back by 1
+ * snapshots
+ * ----------------------------------------------------------
+ * | initialState, "" | state0, "action" | state1, "action" |
+ * ----------------------------------------------------------
+ * currentSnapshot == 1
+ * undoable should be 1, redoable should be 1
+ *
+ * commit
+ * Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
+ * snapshots
+ * ----------------------------------------------------------
+ * | initialState, "" | state0, "action" | state2, "action" |
+ * ----------------------------------------------------------
+ * currentSnapshot == 2
+ * undoable should be 1, redoable should be 0
+ *
+ * assume limit of 3
+ * commit
+ * rotate snapshots by 1 left.  override new state at currentShapshot-1.
+ * snapshots
+ * ----------------------------------------------------------
+ * | state0, "action" | state2, "action" | state3, "action" |
+ * ----------------------------------------------------------
+ * currentSnapshot == 2
+ * undoable should be 1, redoable should be 0
+ *
+ * Inspiration for the undo system from https://vuejsdevelopers.com/2017/11/13/vue-js-vuex-undo-redo/
+ */
 
 export class UndoRedo extends Serializable<UndoRedo> {
   metadataVersion: number = METADATA_VERSION;
@@ -160,7 +164,7 @@ export class UndoRedo extends Serializable<UndoRedo> {
 
   createPlugin() {
     return (store: Store<CalChartState>): void => {
-      this.stateSnapshots = [[JSON.stringify(store.state.show), ""]];
+      this.reinitializeUndoRedo(store.state.show);
       // called when the store is initialized
       // State could be useful in the future.
       store.subscribe((
@@ -168,10 +172,7 @@ export class UndoRedo extends Serializable<UndoRedo> {
       ) => {
         if (UNDOABLE_ACTIONS.includes(mutation.type as Mutations)) {
           if (this.stateSnapshots.length === this.maxSnapshots) {
-            this.stateSnapshots = this.stateSnapshots.slice(
-              1,
-              this.stateSnapshots.length
-            );
+            this.stateSnapshots.shift();
           } else {
             this.currentShapshot = this.currentShapshot + 1;
             this.stateSnapshots = this.stateSnapshots.slice(

--- a/src/models/UndoRedo.ts
+++ b/src/models/UndoRedo.ts
@@ -1,0 +1,210 @@
+import { Mutations, UNDOABLE_ACTIONS } from "@/store/mutations";
+import { CalChartState } from "@/store";
+import Serializable from "./util/Serializable";
+import { MutationPayload, Store } from "vuex";
+import Show from "./Show";
+
+// Increment upon making show metadata changes that break previous versions.
+const METADATA_VERSION = 1;
+
+// The UndoRedo holds snapshots of the show over time.
+//
+// States are held as pairs of the show, and the action that happened to get
+// to that show.  This is useful for displaying that information to the user
+// so they know what the undo/do action will do.
+//
+// shapshots
+// ----------------------------------------------------------
+// | state0, "action" | state1, "action" | state2, "action" |
+// ----------------------------------------------------------
+//                            ^
+// currentSnapshot == 1 ------+
+//
+// When a new undoable commit occurs, UndoRedo will snapshot the current state
+// and append it to the end if there is room.  Otherwise, we shift the entire
+// undo state by one to make room.
+//
+// if a new undoable commit happens when you are in the middle of an undo stack
+// (for instance, you've undo a move and then do another move), we remove all
+// the items after the current snapshot and start appending from there.
+//
+//
+// here is a diagram of what we expect to occur with a series of commits, undo, redo actions.
+//
+// snapshots
+// --------------------
+// | initialState, "" |
+// --------------------
+// currentSnapshot == 0
+// Undoable should be 0, redoable should be 0
+//
+// commit
+// Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
+// snapshots.
+// ---------------------------------------
+// | initialState, "" | state0, "action" |
+// ---------------------------------------
+// currentSnapshot == 1
+// undoable should be 1, redoable should be 0
+//
+// undo:
+// Set currentSnapshot back by 1.  restore state at currentSnapshot.
+// snapshots
+// ---------------------------------------
+// | initialState, "" | state0, "action" |
+// ---------------------------------------
+// currentSnapshot == 0
+// undoable should be 0, redoable should be 1
+//
+// undo:
+// Should be no-op
+// snapshots
+// ---------------------------------------
+// | initialState, "" | state0, "action" |
+// ---------------------------------------
+// currentSnapshot == 0
+// undoable should be 0, redoable should be 1
+//
+// redo:
+// Set currentSnapshot forward by 1.  restore state at currentSnapshot.
+// snapshots
+// ---------------------------------------
+// | initialState, "" | state0, "action" |
+// ---------------------------------------
+// currentSnapshot == 1
+// undoable should be 1, redoable should be 0
+//
+// redo:
+// Should be no-op
+// snapshots
+// ---------------------------------------
+// | initialState, "" | state0, "action" |
+// ---------------------------------------
+// currentSnapshot == 1
+// undoable should be 1, redoable should be 0
+//
+// commit
+// Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
+// snapshots
+// ----------------------------------------------------------
+// | initialState, "" | state0, "action" | state1, "action" |
+// ----------------------------------------------------------
+// currentSnapshot == 2
+// undoable should be 1, redoable should be 0
+//
+// undo:
+// restore state at currentSnapshot.  Set currentSnapshot back by 1
+// snapshots
+// ----------------------------------------------------------
+// | initialState, "" | state0, "action" | state1, "action" |
+// ----------------------------------------------------------
+// currentSnapshot == 1
+// undoable should be 1, redoable should be 1
+//
+// commit
+// Set currentShapshot forward by 1.  preserve [0, currentSnapshot+1).  Append new state.
+// snapshots
+// ----------------------------------------------------------
+// | initialState, "" | state0, "action" | state2, "action" |
+// ----------------------------------------------------------
+// currentSnapshot == 2
+// undoable should be 1, redoable should be 0
+//
+// assume limit of 3
+// commit
+// rotate snapshots by 1 left.  override new state at currentShapshot-1.
+// snapshots
+// ----------------------------------------------------------
+// | state0, "action" | state2, "action" | state3, "action" |
+// ----------------------------------------------------------
+// currentSnapshot == 2
+// undoable should be 1, redoable should be 0
+
+export class UndoRedo extends Serializable<UndoRedo> {
+  metadataVersion: number = METADATA_VERSION;
+
+  // probably needs to be a pair, one of the state, and one describing what just happened.
+  stateSnapshots: [string, string][] = [];
+  currentShapshot = 0;
+  maxSnapshots = 10;
+
+  constructor(json: Partial<UndoRedo> = {}) {
+    super();
+    this.fromJson(json);
+  }
+
+  canUndo(): boolean {
+    return this.currentShapshot > 0;
+  }
+
+  undoString(): string {
+    // going to need to be a string that got us to this state.
+    return this.canUndo() ? this.stateSnapshots[this.currentShapshot][1] : "";
+  }
+
+  canRedo(): boolean {
+    return this.currentShapshot < this.stateSnapshots.length - 1;
+  }
+
+  redoString(): string {
+    // going to need to be the string of the next snapshot state.
+    return this.canRedo()
+      ? this.stateSnapshots[this.currentShapshot + 1][1]
+      : "";
+  }
+
+  reinitializeUndoRedo(show: Show): void {
+    this.stateSnapshots = [[JSON.stringify(show), ""]];
+    this.currentShapshot = 0;
+  }
+
+  createPlugin() {
+    return (store: Store<CalChartState>): void => {
+      this.stateSnapshots = [[JSON.stringify(store.state.show), ""]];
+      // called when the store is initialized
+      // State could be useful in the future.
+      store.subscribe((
+        mutation: MutationPayload /*, state: CalChartState */
+      ) => {
+        if (UNDOABLE_ACTIONS.includes(mutation.type as Mutations)) {
+          if (this.stateSnapshots.length === this.maxSnapshots) {
+            this.stateSnapshots = this.stateSnapshots.slice(
+              1,
+              this.stateSnapshots.length
+            );
+          } else {
+            this.currentShapshot = this.currentShapshot + 1;
+            this.stateSnapshots = this.stateSnapshots.slice(
+              0,
+              this.currentShapshot
+            );
+          }
+          this.stateSnapshots.push([
+            JSON.stringify(store.state.show),
+            mutation.type,
+          ]);
+        }
+        if (mutation.type === Mutations.UNDO) {
+          if (!this.canUndo()) {
+            return;
+          }
+          this.currentShapshot = this.currentShapshot - 1;
+          store.commit(
+            Mutations.SET_SHOW,
+            new Show(JSON.parse(this.stateSnapshots[this.currentShapshot][0]))
+          );
+        }
+        if (mutation.type === Mutations.REDO) {
+          if (!this.canRedo()) {
+            return;
+          }
+          this.currentShapshot = this.currentShapshot + 1;
+          store.commit(
+            Mutations.SET_SHOW,
+            new Show(JSON.parse(this.stateSnapshots[this.currentShapshot][0]))
+          );
+        }
+      });
+    };
+  }
+}

--- a/src/models/util/ParseCalChart31.ts
+++ b/src/models/util/ParseCalChart31.ts
@@ -259,6 +259,7 @@ export class ParseCalChart31 implements ParseCalChart {
           x: calChart3To4ConvertX(readInt16(buffer, offset)),
           y: calChart3To4ConvertY(readInt16(buffer, offset + 2)),
           dotLabelIndex: index,
+          id: index,
         })
       );
       offset += 4;

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -7,8 +7,12 @@ const getters: GetterTree<CalChartState, CalChartState> = {
   // Show
   getShowTitle: (state): string => state.show.title,
 
+  // Show -> Beat
+  getBeat: (state): number => state.show.beat,
+
   // Show -> Dots
   getDotLabels: (state): string[] => state.show.dotLabels,
+  getSelectedDotIds: (state): number[] => state.show.selectedDotIds,
 
   // Show -> Field
   getFrontHashOffsetY: (state): number => state.show.field.frontHashOffsetY,
@@ -16,15 +20,22 @@ const getters: GetterTree<CalChartState, CalChartState> = {
   getMiddleOfField: (state): number => state.show.field.middleOfField,
 
   // Show -> StuntSheet
+  getSelectedStuntIndex: (state): number => state.show.selectedSS,
   getSelectedStuntSheet: (state): StuntSheet =>
-    state.show.stuntSheets[state.selectedSS],
+    state.show.stuntSheets[state.show.selectedSS],
   getContinuity: (state) => (
     dotTypeIndex: number,
     continuityIndex: number
   ): BaseCont =>
-    state.show.stuntSheets[state.selectedSS].dotTypes[dotTypeIndex][
+    state.show.stuntSheets[state.show.selectedSS].dotTypes[dotTypeIndex][
       continuityIndex
     ],
+
+  // Undo
+  getCanUndo: (state): boolean => state.undoRedo.canUndo(),
+  getUndoName: (state): string => state.undoRedo.undoString(),
+  getCanRedo: (state): boolean => state.undoRedo.canRedo(),
+  getRedoName: (state): string => state.undoRedo.redoString(),
 };
 
 export default getters;

--- a/src/store/hotkeys.ts
+++ b/src/store/hotkeys.ts
@@ -1,7 +1,6 @@
 import { CalChartState } from ".";
 import { Store } from "vuex";
 import { Mutations } from "./mutations";
-import InitialShowState from "@/models/InitialShowState";
 
 export const HotKeyHandler = (
   store: Store<CalChartState>,
@@ -13,7 +12,10 @@ export const HotKeyHandler = (
   if (event.key === "ArrowRight") {
     store.commit(Mutations.INCREMENT_BEAT);
   }
-  if (event.key === "n" && event.ctrlKey) {
-    store.commit(Mutations.SET_SHOW, new InitialShowState());
+  if (event.key === "z" && event.metaKey && !event.shiftKey) {
+    store.commit(Mutations.UNDO);
+  }
+  if (event.key === "z" && event.metaKey && event.shiftKey) {
+    store.commit(Mutations.REDO);
   }
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,17 +6,15 @@ import Show from "@/models/Show";
 import Serializable from "@/models/util/Serializable";
 import BaseTool from "@/tools/BaseTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
-import InitialShowState from "@/models/InitialShowState";
+import { UndoRedo } from "@/models/UndoRedo";
 
 Vue.use(Vuex);
 
 /**
- * Defines the global state for the application
+ * Defines the global state for the application.
  *
  * @property show              - The currently selected show data
- * @property initialShowState  - Beginning spot for show
- * @property selectedSS        - Index of stuntsheet currently in view
- * @property beat              - The point in time the show is in
+ * @property undoRedo          - The undoRedo state
  * @property fourStepGrid      - View setting to toggle the grapher grid
  * @property grapherSvgPanZoom - Initialized upon mounting Grapher
  * @property invertedCTMMatrix - Used to calculate clientX/Y to SVG X/Y
@@ -26,11 +24,7 @@ Vue.use(Vuex);
 export class CalChartState extends Serializable<CalChartState> {
   show: Show = new Show();
 
-  initialShowState: InitialShowState = new InitialShowState();
-
-  selectedSS = 0;
-
-  beat = 0;
+  undoRedo: UndoRedo = new UndoRedo();
 
   fourStepGrid = true;
 
@@ -43,8 +37,6 @@ export class CalChartState extends Serializable<CalChartState> {
   grapherSvgPanZoom?: SvgPanZoom.Instance;
 
   invertedCTMMatrix?: DOMMatrix;
-
-  selectedDotIds: number[] = [];
 
   toolSelected?: BaseTool;
 
@@ -62,11 +54,14 @@ export class CalChartState extends Serializable<CalChartState> {
 
 export const generateStore = (
   json: Partial<CalChartState> = {}
-): Store<CalChartState> =>
-  new Vuex.Store({
-    state: new CalChartState(json),
+): Store<CalChartState> => {
+  const show = new CalChartState(json);
+  return new Vuex.Store({
+    state: show,
     mutations,
     getters,
+    plugins: [show.undoRedo.createPlugin()],
   });
+};
 
 export const GlobalStore = generateStore();

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -14,10 +14,12 @@ import DotAppearance from "@/models/DotAppearance";
 import { MARCH_TYPES } from "@/models/util/constants";
 import ContETFStatic from "@/models/continuity/ContETFStatic";
 import ContGateTurn from "@/models/continuity/ContGateTurn";
+import Show from "@/models/Show";
 
 export enum Mutations {
   // Show mutations:
-  SET_SHOW = "Set new Show",
+  SET_NEW_SHOW = "Set new Show",
+  SET_SHOW = "Set show state",
   SET_SHOW_TITLE = "Set Show title",
   ADD_STUNT_SHEET = "Add Stunt Sheet",
   DELETE_STUNT_SHEET = "Delete Stunt Sheet",
@@ -66,7 +68,6 @@ export enum Mutations {
 
   UNDO = "undo",
   REDO = "redo",
-  INITIAL_SHOW_STATE = "resetShowState",
 }
 
 export const UNDOABLE_ACTIONS = [
@@ -95,9 +96,13 @@ export const UNDOABLE_ACTIONS = [
 
 export const mutations: MutationTree<CalChartState> = {
   [Mutations.SET_SHOW](state, initialShowState: InitialShowState): void {
-    state.initialShowState = initialShowState;
-    state.show = state.initialShowState.getInitialState();
+    state.show = initialShowState.getInitialState();
     state.show.calculateIssuesDeep();
+    state.undoRedo.reinitializeUndoRedo(state.show);
+  },
+  [Mutations.SET_SHOW](state, show: Show): void {
+    state.show = show;
+    state.show.beat = 0;
   },
   [Mutations.SET_SHOW_TITLE](state, title: string): void {
     state.show.title = title;
@@ -109,14 +114,14 @@ export const mutations: MutationTree<CalChartState> = {
         title: `Stuntsheet ${state.show.stuntSheets.length + 1}`,
       })
     );
-    state.selectedSS = state.show.stuntSheets.length - 1;
-    state.beat = 0;
+    state.show.selectedSS = state.show.stuntSheets.length - 1;
+    state.show.beat = 0;
     state.show.calculateIssuesShallow();
   },
   [Mutations.DELETE_STUNT_SHEET](state): void {
-    state.show.stuntSheets.splice(state.selectedSS, 1);
-    state.selectedSS = Math.max(0, state.selectedSS - 1);
-    state.beat = 0;
+    state.show.stuntSheets.splice(state.show.selectedSS, 1);
+    state.show.selectedSS = Math.max(0, state.show.selectedSS - 1);
+    state.show.beat = 0;
     state.show.calculateIssuesShallow();
   },
 
@@ -139,7 +144,7 @@ export const mutations: MutationTree<CalChartState> = {
     const currentSS = getSelectedStuntSheet(state);
     currentSS.removeDots(dotIndex);
     state.show.calculateIssuesShallow();
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
   [Mutations.ADD_DOTS](state, jsons: Partial<StuntSheetDot>[]): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
@@ -147,9 +152,9 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.addDots(jsons.map((json) => new StuntSheetDot(json)));
-    state.show.generateFlows(state.selectedSS);
+    state.show.generateFlows(state.show.selectedSS);
     state.show.calculateIssuesShallow();
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
   [Mutations.MOVE_DOTS](
     state,
@@ -160,26 +165,26 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.moveDots(newPositions);
-    state.show.generateFlows(state.selectedSS);
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    state.show.generateFlows(state.show.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
   [Mutations.UPDATE_SELECTED_DOTS_DOT_TYPE](state, dotTypeIndex: number): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
       state: CalChartState
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
-    const { selectedDotIds } = state;
+    const { selectedDotIds } = state.show;
     if (selectedDotIds.length) {
       selectedDotIds.forEach((dotId) => {
         const dot = currentSS.stuntSheetDots.find((dot) => dot.id === dotId);
         if (dot) {
           dot.dotTypeIndex = dotTypeIndex;
-          dot.calculateIssuesShallow(state.selectedSS, dotId);
+          dot.calculateIssuesShallow(state.show.selectedSS, dotId);
         }
       });
-      state.show.generateFlows(state.selectedSS);
+      state.show.generateFlows(state.show.selectedSS);
     }
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
   [Mutations.SET_STUNT_SHEET_TITLE](state, title: string): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
@@ -187,7 +192,7 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.title = title;
-    currentSS.calculateIssuesShallow(state.selectedSS);
+    currentSS.calculateIssuesShallow(state.show.selectedSS);
   },
   [Mutations.SET_STUNT_SHEET_BEATS](state, beats: number): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
@@ -195,7 +200,7 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.beats = beats;
-    currentSS.calculateIssuesShallow(state.selectedSS);
+    currentSS.calculateIssuesShallow(state.show.selectedSS);
   },
   [Mutations.ADD_DOT_TYPE](state): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
@@ -204,7 +209,7 @@ export const mutations: MutationTree<CalChartState> = {
     const currentSS = getSelectedStuntSheet(state);
     currentSS.dotTypes.push([new ContInPlace()]);
     currentSS.dotAppearances.push(new DotAppearance());
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
   [Mutations.ADD_CONTINUITY](
     state,
@@ -215,8 +220,8 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.dotTypes[dotTypeIndex].push(ContFactory(contID));
-    state.show.generateFlows(state.selectedSS);
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    state.show.generateFlows(state.show.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
 
   // Show -> StuntSheet -> BaseCont
@@ -345,16 +350,16 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS = getSelectedStuntSheet(state);
     currentSS.dotTypes[dotTypeIndex].splice(continuityIndex, 1);
-    state.show.generateFlows(state.selectedSS);
-    currentSS.calculateIssuesDeep(state.selectedSS);
+    state.show.generateFlows(state.show.selectedSS);
+    currentSS.calculateIssuesDeep(state.show.selectedSS);
   },
 
   // Show controls
   [Mutations.SET_SELECTED_SS](state, selectedSS: number): void {
-    state.selectedSS = selectedSS;
+    state.show.selectedSS = selectedSS;
   },
   [Mutations.SET_BEAT](state, beat: number): void {
-    state.beat = beat;
+    state.show.beat = beat;
   },
   [Mutations.INCREMENT_BEAT](state): void {
     const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
@@ -362,35 +367,35 @@ export const mutations: MutationTree<CalChartState> = {
     ) => StuntSheet;
     const currentSS: StuntSheet = getSelectedStuntSheet(state);
 
-    if (state.beat + 1 >= currentSS.beats) {
-      if (state.selectedSS + 1 < state.show.stuntSheets.length) {
+    if (state.show.beat + 1 >= currentSS.beats) {
+      if (state.show.selectedSS + 1 < state.show.stuntSheets.length) {
         // Go to next stuntsheet's Hup! beat
-        state.selectedSS += 1;
-        state.beat = 0;
+        state.show.selectedSS += 1;
+        state.show.beat = 0;
       } else {
         // If the last stuntsheet, go to the last beat
-        state.beat = currentSS.beats;
+        state.show.beat = currentSS.beats;
       }
     } else {
-      state.beat += 1;
+      state.show.beat += 1;
     }
   },
   [Mutations.DECREMENT_BEAT](state): void {
-    if (state.beat - 1 < 0) {
-      if (state.selectedSS > 0) {
+    if (state.show.beat - 1 < 0) {
+      if (state.show.selectedSS > 0) {
         // Go to previous stuntsheet's 2nd to last beat
-        state.selectedSS -= 1;
+        state.show.selectedSS -= 1;
         const getSelectedStuntSheet = getters.getSelectedStuntSheet as (
           state: CalChartState
         ) => StuntSheet;
         const currentSS: StuntSheet = getSelectedStuntSheet(state);
-        state.beat = currentSS.beats - 1;
+        state.show.beat = currentSS.beats - 1;
       } else {
         // If the first stuntsheet, go to Hup! beat
-        state.beat = 0;
+        state.show.beat = 0;
       }
     } else {
-      state.beat -= 1;
+      state.show.beat -= 1;
     }
   },
 
@@ -431,21 +436,22 @@ export const mutations: MutationTree<CalChartState> = {
 
   // selection
   [Mutations.CLEAR_SELECTED_DOTS](state): void {
-    state.selectedDotIds = [];
+    state.show.selectedDotIds = [];
   },
   [Mutations.ADD_SELECTED_DOTS](state, dotIds: number[]): void {
     dotIds.forEach((id) => {
-      !state.selectedDotIds.includes(id) && state.selectedDotIds.push(id);
+      !state.show.selectedDotIds.includes(id) &&
+        state.show.selectedDotIds.push(id);
     });
   },
   [Mutations.TOGGLE_SELECTED_DOTS](state, dotIds: number[]): void {
     // first remove all the items passed in.
     dotIds.forEach((id) => {
-      const index = state.selectedDotIds.indexOf(id);
+      const index = state.show.selectedDotIds.indexOf(id);
       if (index > -1) {
-        state.selectedDotIds.splice(index, 1);
+        state.show.selectedDotIds.splice(index, 1);
       } else {
-        state.selectedDotIds.push(id);
+        state.show.selectedDotIds.push(id);
       }
     });
   },
@@ -460,9 +466,6 @@ export const mutations: MutationTree<CalChartState> = {
   [Mutations.REDO](): void {
     // intentionally empty as the Undo system is "sniffing" for this command.
   },
-  [Mutations.INITIAL_SHOW_STATE](state): void {
-    state.show = state.initialShowState.getInitialState();
-  },
 };
 
 function updateContinuity(
@@ -476,6 +479,6 @@ function updateContinuity(
   ) => StuntSheet;
   const currentSS = getSelectedStuntSheet(state);
   currentSS.dotTypes[dotTypeIndex][continuityIndex] = continuity;
-  state.show.generateFlows(state.selectedSS);
-  currentSS.calculateIssuesDeep(state.selectedSS);
+  state.show.generateFlows(state.show.selectedSS);
+  currentSS.calculateIssuesDeep(state.show.selectedSS);
 }

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -58,7 +58,7 @@ export default abstract class BaseTool {
     const [x, y] = BaseTool.convertClientCoordinatesRounded(event);
     const stuntSheetDots: StuntSheetDot[] =
       GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
-    const beat = GlobalStore.state.beat;
+    const beat = GlobalStore.getters.getBeat;
     return stuntSheetDots.find((dot: StuntSheetDot): boolean => {
       return x === dot.xAtBeat(beat) && y === dot.yAtBeat(beat);
     });

--- a/src/tools/ToolSelectMove.ts
+++ b/src/tools/ToolSelectMove.ts
@@ -28,7 +28,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
 
     if (existingDot) {
       // if we click on a selected dot, determine if we are toggling selection.
-      if (GlobalStore.state.selectedDotIds.includes(existingDot.id)) {
+      if (GlobalStore.getters.getSelectedDotIds.includes(existingDot.id)) {
         if (event.altKey) {
           GlobalStore.commit(Mutations.TOGGLE_SELECTED_DOTS, [existingDot.id]);
         }
@@ -66,7 +66,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       const currentSSDots: StuntSheetDot[] =
         GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
       const newPositions: [number, [number, number]][] = [];
-      GlobalStore.state.selectedDotIds.forEach((id: number) => {
+      GlobalStore.getters.getSelectedDotIds.forEach((id: number) => {
         const selectedDot = currentSSDots.find((dot) => dot.id === id);
         if (!selectedDot) {
           return;
@@ -88,7 +88,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
       // Complete the selection by finding everything in the selection box.
       const stuntSheetDots: StuntSheetDot[] =
         GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
-      const beat = GlobalStore.state.beat;
+      const beat = GlobalStore.state.show.beat;
       const dotsInLasso = stuntSheetDots.filter((dot) =>
         InsideLasso(GlobalStore.state.selectionLasso, [
           dot.xAtBeat(beat),
@@ -130,7 +130,7 @@ export abstract class ToolSelectMove extends BaseMoveTool {
     const currentSSDots: StuntSheetDot[] =
       GlobalStore.getters.getSelectedStuntSheet.stuntSheetDots;
     const grapherToolDots: StuntSheetDot[] = [];
-    GlobalStore.state.selectedDotIds.forEach((id: number) => {
+    GlobalStore.getters.getSelectedDotIds.forEach((id: number) => {
       const selectedDot = currentSSDots.find((dot) => dot.id === id);
       if (!selectedDot) {
         return;

--- a/tests/e2e/specs/App.spec.js
+++ b/tests/e2e/specs/App.spec.js
@@ -10,6 +10,8 @@ describe("App.vue", () => {
 
     cy.get('[data-test="app"]').find(".menu-right");
 
-    cy.get('[data-test="app"]').find(".menu-bottom");
+    cy.get('[data-test="app"]').find(".menu-bottom-tools");
+
+    cy.get('[data-test="app"]').find(".menu-bottom-undo");
   });
 });

--- a/tests/e2e/specs/continuity/BasicInteraction.spec.js
+++ b/tests/e2e/specs/continuity/BasicInteraction.spec.js
@@ -1,6 +1,6 @@
 describe("continuity/interactions", () => {
   beforeEach(() => {
-    cy.visit("/").get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.visit("/").get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
   });
 
   it("add dot, set cont, should move", () => {

--- a/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
+++ b/tests/e2e/specs/menu-bottom/MenuBottom.spec.js
@@ -1,29 +1,29 @@
-describe("components/menu-bottom/MenuBottom", () => {
+describe("components/menu-bottom/MenuBottomTools", () => {
   beforeEach(() => {
     cy.visit("/");
   });
 
   it("all buttons are rendered and box select is selected", () => {
-    cy.get('[data-test="menu-bottom--tooltip"]').should("have.length", 3);
+    cy.get('[data-test="menu-bottom-tools--tooltip"]').should("have.length", 3);
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move"]').should(
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move"]').should(
       "have.class",
       "is-primary"
     );
 
-    cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
+    cy.get('[data-test="menu-bottom-tools--tooltip"] .is-light').should(
       "have.length",
       2
     );
   });
 
   it("clicking on add/remove single dot disables box", () => {
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .should("not.have.class", "is-primary")
       .click()
       .should("have.class", "is-primary");
 
-    cy.get('[data-test="menu-bottom--tooltip"] .is-light').should(
+    cy.get('[data-test="menu-bottom-tools--tooltip"] .is-light').should(
       "have.length",
       2
     );
@@ -33,9 +33,9 @@ describe("components/menu-bottom/MenuBottom", () => {
   });
 
   it("clicking from and to pan/zoom enables pan/zoom", () => {
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move"]')
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move"]')
       .should("not.have.class", "is-primary")
       .click()
       .should("have.class", "is-primary");
@@ -47,7 +47,7 @@ describe("components/menu-bottom/MenuBottom", () => {
   // #66 - Skipping due to flakey test
   it.skip("control key enables pan/zoom", () => {
     // Starting tool is add/remove single dot
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .click()
       .should("have.class", "is-primary");
 
@@ -68,7 +68,7 @@ describe("components/menu-bottom/MenuBottom", () => {
         .should("lessThan", oldX);
     });
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').should(
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').should(
       "have.class",
       "is-primary"
     );

--- a/tests/e2e/specs/menu-left/MenuLeft.spec.js
+++ b/tests/e2e/specs/menu-left/MenuLeft.spec.js
@@ -37,7 +37,7 @@ describe("components/menu-left/MenuLeft", () => {
     // Add a stuntsheet dot (4, 4) to the first stuntsheet
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .click()
       .mousedownGrapher(4, 4)
       .mouseupGrapher(4, 4);
@@ -88,7 +88,7 @@ describe("components/menu-left/MenuLeft", () => {
     // Add a stuntsheet dot (8, 8) to the first stuntsheet
     cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]')
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]')
       .click()
       .mousedownGrapher(8, 8)
       .mouseupGrapher(8, 8);

--- a/tests/e2e/specs/menu-top/FileModal.spec.js
+++ b/tests/e2e/specs/menu-top/FileModal.spec.js
@@ -2,9 +2,9 @@ describe("components/menu-top/FileModal", () => {
   beforeEach(() => {
     cy.visit("/");
 
-    cy.get('[data-test="menu-top--file"]').click();
+    cy.get('[data-test="menu-top--edit"]').click();
 
-    cy.get('[data-test="menu-top--file-edit"]').click();
+    cy.get('[data-test="menu-top--edit-show-details"]').click();
 
     cy.get('[data-test="menu-top--file-modal"]').should("be.visible");
   });

--- a/tests/e2e/specs/menu-top/MenuTop.spec.js
+++ b/tests/e2e/specs/menu-top/MenuTop.spec.js
@@ -7,8 +7,8 @@ describe("components/menu-top/MenuTop", () => {
     cy.get('[data-test="menu-top--file"]')
       .find('[data-test="menu-top--load-show"]')
       .should("not.be.visible");
-    cy.get('[data-test="menu-top--file"]')
-      .find('[data-test="menu-top--file-edit"]')
+    cy.get('[data-test="menu-top--edit"]')
+      .find('[data-test="menu-top--edit-show-details"]')
       .should("not.be.visible");
     cy.get('[data-test="menu-top--view"]')
       .find('[data-test="menu-top--view-grid"]')
@@ -21,20 +21,13 @@ describe("components/menu-top/MenuTop", () => {
     });
 
     it("dropdown is visible upon clicking", () => {
+      cy.get('[data-test="menu-top--new-show"]').should("be.visible");
       cy.get('[data-test="menu-top--load-show"]').should("be.visible");
-      cy.get('[data-test="menu-top--file-edit"]').should("be.visible");
+      cy.get('[data-test="menu-top--save-show"]').should("be.visible");
     });
 
     it("shows selected show title", () => {
       cy.get('[data-test="menu-left--title"]').contains("Example Show");
-    });
-
-    it('clicking "Edit Show Details" opens show modal', () => {
-      cy.get('[data-test="menu-top--file-modal"]').should("not.be.visible");
-
-      cy.get('[data-test="menu-top--file-edit"]').click();
-
-      cy.get('[data-test="menu-top--file-modal"]').should("be.visible");
     });
 
     it('clicking "Load Show Details" opens load modal', () => {
@@ -43,6 +36,26 @@ describe("components/menu-top/MenuTop", () => {
       cy.get('[data-test="menu-top--load-show"]').click();
 
       cy.get('[data-test="menu-top--load-modal"]').should("be.visible");
+    });
+  });
+
+  describe("edit dropdown", () => {
+    beforeEach(() => {
+      cy.get('[data-test="menu-top--edit"]').click();
+    });
+
+    it("dropdown is visible upon clicking", () => {
+      cy.get('[data-test="menu-top--edit-undo"]').should("be.visible");
+      cy.get('[data-test="menu-top--edit-redo"]').should("be.visible");
+      cy.get('[data-test="menu-top--edit-show-details"]').should("be.visible");
+    });
+
+    it('clicking "Edit Show Details" opens show modal', () => {
+      cy.get('[data-test="menu-top--file-modal"]').should("not.be.visible");
+
+      cy.get('[data-test="menu-top--edit-show-details"]').click();
+
+      cy.get('[data-test="menu-top--file-modal"]').should("be.visible");
     });
   });
 

--- a/tests/e2e/specs/tools/ToolBoxSelect.spec.js
+++ b/tests/e2e/specs/tools/ToolBoxSelect.spec.js
@@ -1,7 +1,7 @@
 describe("tools/ToolBoxSelect", () => {
   beforeEach(() => {
     cy.visit("/")
-      .get('[data-test="menu-bottom-tool--select-box-move"]')
+      .get('[data-test="menu-bottom-tools-tool--select-box-move"]')
       .click();
   });
 
@@ -47,7 +47,7 @@ describe("tools/ToolBoxSelect", () => {
   });
   it("make sure selection works", () => {
     // Create 2 dots at 12, 8 and 12, 6.
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
     cy.mousedownGrapher(12, 6).mouseupGrapher(12, 6);
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
@@ -63,7 +63,7 @@ describe("tools/ToolBoxSelect", () => {
     );
 
     // Select dot at 12, 8
-    cy.get('[data-test="menu-bottom-tool--select-box-move"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move"]').click();
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
     cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
       "have.length",

--- a/tests/e2e/specs/tools/ToolLassoSelect.spec.js
+++ b/tests/e2e/specs/tools/ToolLassoSelect.spec.js
@@ -5,7 +5,7 @@ describe("tools/ToolLassoSelect", () => {
 
   it("make sure selection works", () => {
     // Create 2 dots at 12, 8 and 12, 6
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
     cy.mousedownGrapher(12, 6).mouseupGrapher(12, 6);
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
@@ -21,7 +21,7 @@ describe("tools/ToolLassoSelect", () => {
     );
 
     // Draw a line that does not intersect with the dots
-    cy.get('[data-test="menu-bottom-tool--select-lasso-move"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-lasso-move"]').click();
     cy.mousedownGrapher(24, 2).mousemoveGrapher(10, 10).mouseupGrapher(24, 2);
     cy.get('[data-test="grapher-tool--selection-lasso"]').should(
       "have.attr",

--- a/tests/e2e/specs/tools/ToolSingleDot.spec.js
+++ b/tests/e2e/specs/tools/ToolSingleDot.spec.js
@@ -1,6 +1,6 @@
 describe("tools/ToolSingleDot", () => {
   beforeEach(() => {
-    cy.visit("/").get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.visit("/").get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
   });
 
   it("clicking adds, then removes a dot", () => {
@@ -23,7 +23,7 @@ describe("tools/ToolSingleDot", () => {
   });
 
   it("After panning and zooming, adding a dot is still accurate", () => {
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     // eslint-disable-next-line cypress/require-data-selectors
     cy.get("#svg-pan-zoom-zoom-out").click().click();
@@ -32,7 +32,7 @@ describe("tools/ToolSingleDot", () => {
     cy.mousemoveGrapher(24, 2);
     cy.mouseupGrapher(24, 2);
 
-    cy.get('[data-test="menu-bottom-tool--add-rm"]').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
@@ -108,7 +108,7 @@ describe("tools/ToolSingleDot", () => {
       0
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
@@ -118,7 +118,7 @@ describe("tools/ToolSingleDot", () => {
       1
     );
 
-    cy.get('[data-test="menu-bottom-tool--add-rm').click();
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm').click();
 
     cy.mousedownGrapher(20, 16).mouseupGrapher(20, 16);
 
@@ -142,7 +142,7 @@ describe("tools/ToolSingleDot", () => {
       0
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
 
@@ -193,7 +193,7 @@ describe("tools/ToolSingleDot", () => {
       0
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.mousedownGrapher(16, 12).mouseupGrapher(16, 12);
 
@@ -203,7 +203,7 @@ describe("tools/ToolSingleDot", () => {
       1
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-lasso-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-lasso-move').click();
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
     cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(
@@ -211,7 +211,7 @@ describe("tools/ToolSingleDot", () => {
       1
     );
 
-    cy.get('[data-test="menu-bottom-tool--select-box-move').click();
+    cy.get('[data-test="menu-bottom-tools-tool--select-box-move').click();
 
     cy.get('[data-test="grapher-dots--dot"]').should("have.length", 2);
     cy.get('[data-test="grapher-dots--dot"][data-test-selected="true"]').should(

--- a/tests/e2e/specs/undo/undoAdd.spec.js
+++ b/tests/e2e/specs/undo/undoAdd.spec.js
@@ -1,0 +1,62 @@
+describe("undo/add", () => {
+  beforeEach(() => {
+    cy.visit("/")
+      .get('[data-test="menu-bottom-tools-tool--select-box-move"]')
+      .click();
+  });
+  it("clicking add, undo, should have no dot, then redo has dot", () => {
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.disabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
+
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.enabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
+
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.disabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.enabled");
+
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').should("be.enabled");
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').should("be.disabled");
+  });
+
+  it("clicking add, change cont, undo, undo, redo, redo should do cont", () => {
+    cy.get('[data-test="menu-bottom-tools-tool--add-rm"]').click();
+
+    cy.mousedownGrapher(12, 8).mouseupGrapher(12, 8);
+
+    cy.get('[data-test="grapher-dots--dot"]').should("have.length", 1);
+
+    cy.get('[data-test="cont-in-place--march-type"]')
+      .should("have.length", 1)
+      .should("have.value", "HS");
+
+    cy.get('[data-test="cont-in-place--march-type"]').select("MM");
+    cy.get('[data-test="cont-in-place--march-type"]')
+      .should("have.length", 1)
+      .should("have.value", "MM");
+
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').click();
+    cy.get('[data-test="menu-bottom-undo-tool--undo"]').click();
+
+    cy.get('[data-test="grapher-dots--dot"]').should("not.exist");
+
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
+    cy.get('[data-test="menu-bottom-undo-tool--redo"]').click();
+
+    cy.get('[data-test="cont-in-place--march-type"]')
+      .should("have.length", 1)
+      .should("have.value", "MM");
+  });
+});

--- a/tests/unit/App.spec.ts
+++ b/tests/unit/App.spec.ts
@@ -4,7 +4,8 @@ import MenuTop from "@/components/menu-top/MenuTop.vue";
 import MenuLeft from "@/components/menu-left/MenuLeft.vue";
 import Grapher from "@/components/grapher/Grapher.vue";
 import MenuRight from "@/components/menu-right/MenuRight.vue";
-import MenuBottom from "@/components/menu-bottom/MenuBottom.vue";
+import MenuBottomTools from "@/components/menu-bottom/MenuBottomTools.vue";
+import MenuBottomUndo from "@/components/menu-bottom/MenuBottomUndo.vue";
 
 describe("App.vue", () => {
   it("Renders the menus and grapher", () => {
@@ -13,6 +14,7 @@ describe("App.vue", () => {
     expect(app.findComponent(MenuLeft).exists()).toBeTruthy();
     expect(app.findComponent(Grapher).exists()).toBeTruthy();
     expect(app.findComponent(MenuRight).exists()).toBeTruthy();
-    expect(app.findComponent(MenuBottom).exists()).toBeTruthy();
+    expect(app.findComponent(MenuBottomTools).exists()).toBeTruthy();
+    expect(app.findComponent(MenuBottomUndo).exists()).toBeTruthy();
   });
 });

--- a/tests/unit/components/menu-bottom/MenuBottom.spec.ts
+++ b/tests/unit/components/menu-bottom/MenuBottom.spec.ts
@@ -2,7 +2,7 @@ import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
 import Buefy from "buefy";
 import { generateStore, CalChartState } from "@/store";
 import Vuex, { Store } from "vuex";
-import MenuBottom from "@/components/menu-bottom/MenuBottom.vue";
+import MenuBottomTools from "@/components/menu-bottom/MenuBottomTools.vue";
 import ToolSingleDot from "@/tools/ToolSingleDot";
 import ToolBoxSelect from "@/tools/ToolBoxSelect";
 import BaseTool from "@/tools/BaseTool";
@@ -16,7 +16,7 @@ const setupHelper = () => {
   localVue.use(Vuex);
   localVue.use(Buefy);
   const store = generateStore({});
-  const menu = mount(MenuBottom, {
+  const menu = mount(MenuBottomTools, {
     store,
     localVue,
   });
@@ -27,7 +27,7 @@ const setupHelper = () => {
   };
 };
 
-describe("components/menu-bottom/MenuBottom", () => {
+describe("components/menu-bottom-tools/MenuBottom", () => {
   describe("tool buttons", () => {
     let store: Store<CalChartState>;
     let menu: Wrapper<Vue>;
@@ -38,9 +38,9 @@ describe("components/menu-bottom/MenuBottom", () => {
     });
 
     it("renders the correct amount of tools", () => {
-      expect(menu.findAll('[data-test="menu-bottom--tooltip"]')).toHaveLength(
-        3
-      );
+      expect(
+        menu.findAll('[data-test="menu-bottom-tools--tooltip"]')
+      ).toHaveLength(3);
     });
 
     it("on mount, selects the pan and zoom tool", () => {
@@ -49,21 +49,25 @@ describe("components/menu-bottom/MenuBottom", () => {
       expect(ToolBoxSelect).toHaveBeenCalled();
       expect(toolSelected.constructor).toBe(ToolBoxSelect);
       const panZoomBtn = menu.find(
-        '[data-test="menu-bottom-tool--select-box-move"]'
+        '[data-test="menu-bottom-tools-tool--select-box-move"]'
       );
       expect(panZoomBtn.exists()).toBeTruthy();
       expect(panZoomBtn.props("type")).toBe("is-primary");
     });
 
     it("add/remove single dot has type is-light when it is unselected", () => {
-      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      const addRmBtn = menu.find(
+        '[data-test="menu-bottom-tools-tool--add-rm"]'
+      );
       expect(addRmBtn.props("type")).toBe("is-light");
     });
 
     it("clicking add/remove single dot disables box select", async () => {
       expect(ToolSingleDot).not.toHaveBeenCalled();
 
-      const addRmBtn = menu.find('[data-test="menu-bottom-tool--add-rm"]');
+      const addRmBtn = menu.find(
+        '[data-test="menu-bottom-tools-tool--add-rm"]'
+      );
       addRmBtn.trigger("click");
       await menu.vm.$nextTick();
 
@@ -76,14 +80,14 @@ describe("components/menu-bottom/MenuBottom", () => {
 
     it("select box is no longer selected", () => {
       const panZoomBtn = menu.find(
-        '[data-test="menu-bottom-tool--select-box-move"]'
+        '[data-test="menu-bottom-tools-tool--select-box-move"]'
       );
       expect(panZoomBtn.props("type")).toBe("is-light");
     });
 
     it("clicking select box enables box", async () => {
       const panZoomBtn = menu.find(
-        '[data-test="menu-bottom-tool--select-box-move"]'
+        '[data-test="menu-bottom-tools-tool--select-box-move"]'
       );
       panZoomBtn.trigger("click");
       await menu.vm.$nextTick();

--- a/tests/unit/components/menu-left/MenuLeft.spec.ts
+++ b/tests/unit/components/menu-left/MenuLeft.spec.ts
@@ -16,7 +16,9 @@ describe("components/menu-left/MenuLeft", () => {
     new StuntSheet({ beats: 8, title: "b" }),
     new StuntSheet({ beats: 12, title: "c" }),
   ];
-  const show = new Show({ stuntSheets });
+  const show = new Show({
+    stuntSheets,
+  });
 
   beforeEach(() => {
     // Mock out store and mount
@@ -79,7 +81,7 @@ describe("components/menu-left/MenuLeft", () => {
       const stuntSheet = stuntSheets[index];
       const menuItem = menu.findAll('[data-test="menu-left--ss"]').at(index);
       expect(menuItem.text()).toContain(`${index + 1}) ${stuntSheet.title}`);
-      expect(menuItem.classes("is-active")).toBe(index === 0);
+      expect(menuItem.classes("is-active")).toBe(false);
 
       commitSpy.mockClear();
       menuItem.trigger("click");

--- a/tests/unit/components/menu-left/StuntSheetModal.spec.ts
+++ b/tests/unit/components/menu-left/StuntSheetModal.spec.ts
@@ -59,7 +59,7 @@ describe("components/menu-left/StuntSheetModal", () => {
       new StuntSheet({ title: "a" }),
       new StuntSheet({ title: "b" }),
     ];
-    store.state.selectedSS = 0;
+    store.state.show.selectedSS = 0;
     const parentCloseMock = jest.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (wrapper.vm.$parent as any).close = parentCloseMock;

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -33,10 +33,12 @@ describe("components/menu-top/MenuTop", () => {
         wrapper.find('[data-test="menu-top--file-modal"]').props("active")
       ).toBe(false);
       expect(
-        wrapper.find('[data-test="menu-top--file-edit"]').exists()
+        wrapper.find('[data-test="menu-top--edit-show-details"]').exists()
       ).toBeTruthy();
 
-      wrapper.find('[data-test="menu-top--file-edit"]').trigger("click");
+      wrapper
+        .find('[data-test="menu-top--edit-show-details"]')
+        .trigger("click");
       await wrapper.vm.$nextTick();
 
       expect(

--- a/tests/unit/models/UndoRedo.spec.ts
+++ b/tests/unit/models/UndoRedo.spec.ts
@@ -1,0 +1,133 @@
+import { createLocalVue } from "@vue/test-utils";
+import Vue, { VueConstructor } from "vue";
+import Vuex, { Store } from "vuex";
+import { CalChartState, generateStore } from "@/store";
+import { Mutations } from "@/store/mutations";
+
+describe("models/UndoRedo", () => {
+  let localVue: VueConstructor<Vue>;
+  beforeAll(() => {
+    localVue = createLocalVue();
+    localVue.use(Vuex);
+  });
+
+  it("testing Undo", () => {
+    const store = generateStore({});
+    store.state.undoRedo.maxSnapshots = 3;
+    expect(store.state.undoRedo.currentShapshot).toBe(0);
+    expect(store.state.undoRedo.canUndo()).toBeFalsy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe("");
+    expect(store.state.undoRedo.redoString()).toBe("");
+
+    // commit
+    store.commit(Mutations.ADD_DOTS, [{ x: 1, y: 1 }]);
+    expect(store.state.undoRedo.currentShapshot).toBe(1);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe(Mutations.ADD_DOTS);
+    expect(store.state.undoRedo.redoString()).toBe("");
+
+    // undo
+    store.commit(Mutations.UNDO);
+    expect(store.state.undoRedo.currentShapshot).toBe(0);
+    expect(store.state.undoRedo.canUndo()).toBeFalsy();
+    expect(store.state.undoRedo.canRedo()).toBeTruthy();
+    expect(store.state.undoRedo.undoString()).toBe("");
+    expect(store.state.undoRedo.redoString()).toBe(Mutations.ADD_DOTS);
+
+    // undo, should be no-op
+    store.commit(Mutations.UNDO);
+    expect(store.state.undoRedo.currentShapshot).toBe(0);
+    expect(store.state.undoRedo.canUndo()).toBeFalsy();
+    expect(store.state.undoRedo.canRedo()).toBeTruthy();
+    expect(store.state.undoRedo.undoString()).toBe("");
+    expect(store.state.undoRedo.redoString()).toBe(Mutations.ADD_DOTS);
+
+    // redo
+    store.commit(Mutations.REDO);
+    expect(store.state.undoRedo.currentShapshot).toBe(1);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe(Mutations.ADD_DOTS);
+    expect(store.state.undoRedo.redoString()).toBe("");
+
+    // redo, should be no-op
+    store.commit(Mutations.REDO);
+    expect(store.state.undoRedo.currentShapshot).toBe(1);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe(Mutations.ADD_DOTS);
+    expect(store.state.undoRedo.redoString()).toBe("");
+
+    // commit
+    store.commit(Mutations.SET_STUNT_SHEET_BEATS, { beats: 8 });
+    expect(store.state.undoRedo.currentShapshot).toBe(2);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe(
+      Mutations.SET_STUNT_SHEET_BEATS
+    );
+    expect(store.state.undoRedo.redoString()).toBe("");
+
+    // commit
+    store.commit(Mutations.UNDO);
+    expect(store.state.undoRedo.currentShapshot).toBe(1);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeTruthy();
+    expect(store.state.undoRedo.undoString()).toBe(Mutations.ADD_DOTS);
+    expect(store.state.undoRedo.redoString()).toBe(
+      Mutations.SET_STUNT_SHEET_BEATS
+    );
+
+    // commit
+    store.commit(Mutations.SET_STUNT_SHEET_TITLE, { title: "new show" });
+    expect(store.state.undoRedo.currentShapshot).toBe(2);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe(
+      Mutations.SET_STUNT_SHEET_TITLE
+    );
+    expect(store.state.undoRedo.redoString()).toBe("");
+
+    // commit
+    store.commit(Mutations.SET_STUNT_SHEET_TITLE, { title: "Other show" });
+    expect(store.state.undoRedo.currentShapshot).toBe(2);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    expect(store.state.undoRedo.undoString()).toBe(
+      Mutations.SET_STUNT_SHEET_TITLE
+    );
+    expect(store.state.undoRedo.redoString()).toBe("");
+  });
+
+  it("testing Max Undos", () => {
+    const store = generateStore({});
+    const maxSnapshots = 10;
+    store.state.undoRedo.maxSnapshots = maxSnapshots;
+    expect(store.state.undoRedo.maxSnapshots).toBe(maxSnapshots);
+    expect(store.state.undoRedo.currentShapshot).toBe(0);
+    expect(store.state.undoRedo.stateSnapshots[0][1]).toBe("");
+    expect(store.state.undoRedo.canUndo()).toBeFalsy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].forEach((element) => {
+      store.commit(Mutations.ADD_DOTS, [{ x: element, y: element }]);
+    });
+    expect(store.state.undoRedo.currentShapshot).toBe(maxSnapshots - 1);
+    expect(store.state.undoRedo.stateSnapshots[9][1]).toBe(Mutations.ADD_DOTS);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+    for (let i = 0; i < maxSnapshots; i++) {
+      store.commit(Mutations.UNDO);
+    }
+    expect(store.state.undoRedo.currentShapshot).toBe(0);
+    expect(store.state.undoRedo.canUndo()).toBeFalsy();
+    expect(store.state.undoRedo.canRedo()).toBeTruthy();
+
+    store.commit(Mutations.ADD_DOTS, [{ x: 12, y: 12 }]);
+    expect(store.state.undoRedo.currentShapshot).toBe(1);
+    expect(store.state.undoRedo.stateSnapshots[1][1]).toBe(Mutations.ADD_DOTS);
+    expect(store.state.undoRedo.canUndo()).toBeTruthy();
+    expect(store.state.undoRedo.canRedo()).toBeFalsy();
+  });
+});

--- a/tests/unit/models/UndoRedo.spec.ts
+++ b/tests/unit/models/UndoRedo.spec.ts
@@ -1,7 +1,7 @@
 import { createLocalVue } from "@vue/test-utils";
 import Vue, { VueConstructor } from "vue";
-import Vuex, { Store } from "vuex";
-import { CalChartState, generateStore } from "@/store";
+import Vuex from "vuex";
+import { generateStore } from "@/store";
 import { Mutations } from "@/store/mutations";
 
 describe("models/UndoRedo", () => {

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -22,8 +22,8 @@ describe("store/mutations", () => {
               dotAppearances: [new DotAppearance(), new DotAppearance()],
             }),
           ],
+          selectedSS: 0,
         }),
-        selectedSS: 0,
       });
     });
 
@@ -49,8 +49,8 @@ describe("store/mutations", () => {
             }),
             new StuntSheet(),
           ],
+          selectedSS: 0,
         }),
-        selectedSS: 0,
       });
     });
 
@@ -83,8 +83,8 @@ describe("store/mutations", () => {
             }),
             new StuntSheet(),
           ],
+          selectedSS: 0,
         }),
-        selectedSS: 0,
       });
     });
 
@@ -119,8 +119,8 @@ describe("store/mutations", () => {
             }),
             new StuntSheet(),
           ],
+          selectedSS: 0,
         }),
-        selectedSS: 0,
       });
     });
 
@@ -146,31 +146,30 @@ describe("store/mutations", () => {
         new StuntSheet({ beats: 2 }),
       ];
       store = generateStore({
-        show: new Show({ stuntSheets }),
-        selectedSS: 0,
-        beat: 1,
+        show: new Show({
+          stuntSheets,
+          selectedSS: 0,
+          beat: 1,
+        }),
       });
     });
 
     it("increments selectedSS at the end of stuntsheet", () => {
       store.commit(Mutations.INCREMENT_BEAT);
-      expect(store.state.selectedSS).toBe(1);
-      expect(store.state.beat).toBe(0);
+      expect(store.state.show.selectedSS).toBe(1);
+      expect(store.getters.getBeat).toBe(0);
     });
 
     it("increments beat in the middle of a stuntsheet", () => {
       store.commit(Mutations.INCREMENT_BEAT);
-      expect(store.state.selectedSS).toBe(1);
-      expect(store.state.beat).toBe(1);
+      expect(store.state.show.selectedSS).toBe(1);
+      expect(store.getters.getBeat).toBe(1);
     });
 
     it("does nothing at end of show", () => {
       store.commit(Mutations.INCREMENT_BEAT);
-      expect(store.state.selectedSS).toBe(1);
-      expect(store.state.beat).toBe(2);
-      store.commit(Mutations.INITIAL_SHOW_STATE);
-      expect(store.state.selectedSS).toBe(1);
-      expect(store.state.beat).toBe(2);
+      expect(store.state.show.selectedSS).toBe(1);
+      expect(store.getters.getBeat).toBe(2);
     });
   });
 
@@ -181,28 +180,30 @@ describe("store/mutations", () => {
         new StuntSheet({ beats: 2 }),
       ];
       store = generateStore({
-        show: new Show({ stuntSheets }),
-        selectedSS: 1,
-        beat: 0,
+        show: new Show({
+          stuntSheets,
+          selectedSS: 1,
+          beat: 0,
+        }),
       });
     });
 
     it("decrements selectedSS at the beginning of stuntsheet", () => {
       store.commit(Mutations.DECREMENT_BEAT);
-      expect(store.state.selectedSS).toBe(0);
-      expect(store.state.beat).toBe(1);
+      expect(store.state.show.selectedSS).toBe(0);
+      expect(store.getters.getBeat).toBe(1);
     });
 
     it("decrements beat in the middle of a stuntsheet", () => {
       store.commit(Mutations.DECREMENT_BEAT);
-      expect(store.state.selectedSS).toBe(0);
-      expect(store.state.beat).toBe(0);
+      expect(store.state.show.selectedSS).toBe(0);
+      expect(store.getters.getBeat).toBe(0);
     });
 
     it("does nothing at beginning of show", () => {
       store.commit(Mutations.DECREMENT_BEAT);
-      expect(store.state.selectedSS).toBe(0);
-      expect(store.state.beat).toBe(0);
+      expect(store.state.show.selectedSS).toBe(0);
+      expect(store.getters.getBeat).toBe(0);
     });
   });
 });

--- a/tests/unit/tools/ToolBoxSelect.spec.ts
+++ b/tests/unit/tools/ToolBoxSelect.spec.ts
@@ -3,6 +3,7 @@ import { GlobalStore } from "@/store";
 import BaseTool from "@/tools/BaseTool";
 import BaseMoveTool from "@/tools/BaseMoveTool";
 import StuntSheetDot from "@/models/StuntSheetDot";
+import { MARCH_TYPES } from "@/models/util/constants";
 
 describe("tools/ToolBoxSelect", () => {
   let tool: BaseTool;
@@ -25,66 +26,66 @@ describe("tools/ToolBoxSelect", () => {
     stuntSheet.stuntSheetDots.push(new StuntSheetDot({ x: 2, y: 4 }));
 
     it("Click where nothing is", () => {
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("Click on a dot", () => {
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
     });
 
     it("Click on a space loses selection", () => {
-      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 6, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[6, 2]]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("Click on a dot loses selection and adds another", () => {
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 4, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 4, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([0]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
@@ -93,12 +94,12 @@ describe("tools/ToolBoxSelect", () => {
         new MouseEvent("mousedown", { clientX: 4, clientY: 2, shiftKey: true })
       );
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 4, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
@@ -112,19 +113,19 @@ describe("tools/ToolBoxSelect", () => {
         })
       );
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 2, clientY: 2 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([1]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([1]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("Selecting box will select all", () => {
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
 
       tool.onMouseMove(new MouseEvent("mousemove", { clientX: 6, clientY: 6 }));
@@ -138,13 +139,13 @@ describe("tools/ToolBoxSelect", () => {
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 6 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
 
     it("shift and move will move the dots", () => {
       expect(GlobalStore.state.grapherToolDots).toEqual([]);
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
       tool.onMouseDown(
         new MouseEvent("mousedown", { clientX: 2, clientY: 2, shiftKey: true })
@@ -167,7 +168,7 @@ describe("tools/ToolBoxSelect", () => {
         y: 4,
         dotLabelIndex: null,
       });
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseMove(new MouseEvent("mousemove", { clientX: 6, clientY: 6 }));
@@ -189,32 +190,43 @@ describe("tools/ToolBoxSelect", () => {
         y: 8,
         dotLabelIndex: null,
       });
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 6, clientY: 6 }));
 
       expect(GlobalStore.state.grapherToolDots).toEqual([]);
-      expect(GlobalStore.state.selectedDotIds).toEqual([0, 1, 2]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([0, 1, 2]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
-      expect(stuntSheet.stuntSheetDots[0]).toMatchObject({
-        x: 6,
-        y: 6,
-        dotTypeIndex: 0,
-        id: 0,
-      });
-      expect(stuntSheet.stuntSheetDots[1]).toMatchObject({
-        x: 8,
-        y: 6,
-        dotTypeIndex: 0,
-        id: 1,
-      });
-      expect(stuntSheet.stuntSheetDots[2]).toMatchObject({
-        x: 6,
-        y: 8,
-        dotTypeIndex: 0,
-        id: 2,
-      });
+      expect(stuntSheet.stuntSheetDots).toEqual([
+        new StuntSheetDot({
+          cachedFlow: [
+            { direction: 90, marchType: MARCH_TYPES.HS, x: 6, y: 6 },
+          ],
+          x: 6,
+          y: 6,
+          dotTypeIndex: 0,
+          id: 0,
+        }),
+        new StuntSheetDot({
+          cachedFlow: [
+            { direction: 90, marchType: MARCH_TYPES.HS, x: 8, y: 6 },
+          ],
+          x: 8,
+          y: 6,
+          dotTypeIndex: 0,
+          id: 1,
+        }),
+        new StuntSheetDot({
+          cachedFlow: [
+            { direction: 90, marchType: MARCH_TYPES.HS, x: 6, y: 8 },
+          ],
+          x: 6,
+          y: 8,
+          dotTypeIndex: 0,
+          id: 2,
+        }),
+      ]);
     });
   });
 });

--- a/tests/unit/tools/ToolLassoSelect.spec.ts
+++ b/tests/unit/tools/ToolLassoSelect.spec.ts
@@ -19,12 +19,12 @@ describe("tools/ToolBoxSelect", () => {
 
   describe("Selecting with a lasso", () => {
     it("Click where nothing is", () => {
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
 
       tool.onMouseDown(new MouseEvent("mousedown", { clientX: 0, clientY: 0 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([[0, 0]]);
 
       tool.onMouseMove(new MouseEvent("mousemove", { clientX: 3, clientY: 1 }));
@@ -36,7 +36,7 @@ describe("tools/ToolBoxSelect", () => {
 
       tool.onMouseUp(new MouseEvent("mouseup", { clientX: 3, clientY: 1 }));
 
-      expect(GlobalStore.state.selectedDotIds).toEqual([]);
+      expect(GlobalStore.getters.getSelectedDotIds).toEqual([]);
       expect(GlobalStore.state.selectionLasso).toEqual([]);
     });
   });


### PR DESCRIPTION
This closely follows the outline by Anthony Gore:
https://vuejsdevelopers.com/2017/11/13/vue-js-vuex-undo-redo/

What we do is we have the undo system implemented as a stack of Store Commit changes. When we do an undo, we go back to an initial state and redo all of the Store commit commands. With CalChart, not every Store commit is a change we want to undo, so we have a filter where we only save certain commits.

Adding bottom row buttons
using hotkeys.
adding File/Edit menu.

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
