### PR TITLE
Upload E2E videos on success and failure, cache npm

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,11 +11,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm ci
       - run: npm run lint:ci
       - run: npm run test:unit
       - run: npm run test:e2e:ci
       - name: Upload e2e videos
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v2
         with:
           path: tests/e2e/videos/**/*.mp4

--- a/tests/e2e/specs/App.spec.js
+++ b/tests/e2e/specs/App.spec.js
@@ -2,8 +2,6 @@ describe("App.vue", () => {
   it("Menus and grapher exists", () => {
     cy.visit("/");
 
-    cy.get('[data-test="app"]').find(".doesnotexist");
-
     cy.get('[data-test="app"]').find(".grapher");
 
     cy.get('[data-test="app"]').find(".menu-top");

--- a/tests/e2e/specs/App.spec.js
+++ b/tests/e2e/specs/App.spec.js
@@ -2,6 +2,8 @@ describe("App.vue", () => {
   it("Menus and grapher exists", () => {
     cy.visit("/");
 
+    cy.get('[data-test="app"]').find(".doesnotexist");
+
     cy.get('[data-test="app"]').find(".grapher");
 
     cy.get('[data-test="app"]').find(".menu-top");


### PR DESCRIPTION
## Description

Fixes issue #155 

Upload E2E videos on success and failure

Cache some NPM files as long as `package-lock.json` stays the same. See https://github.com/actions/cache/blob/main/examples.md#node---npm

## Pre-PR checklist

- [ ] Ran `npm run serve` and:
  - [ ] Checked basic functionality
  - [ ] Checked that errors are handled
- [ ] Ran `npm run lint`
- [ ] Ran `npm run test:unit`
- [ ] Ran `npm run test:e2e` and ran relevant tests
- [ ] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

[Attach screenshots if making a visible change!]
