### PR TITLE
Toggle Field

### DIFF
--- a/src/components/grapher/GrapherField.vue
+++ b/src/components/grapher/GrapherField.vue
@@ -1,6 +1,7 @@
 <template>
   <g class="grapher-field" data-test="grapher-field">
-    <rect v-if="showField"
+    <rect
+      v-if="showField"
       class="grapher-field--rect"
       :width="fieldWidth"
       :height="fieldHeight"

--- a/src/components/grapher/GrapherField.vue
+++ b/src/components/grapher/GrapherField.vue
@@ -1,6 +1,6 @@
 <template>
   <g class="grapher-field" data-test="grapher-field">
-    <rect
+    <rect v-if="showField"
       class="grapher-field--rect"
       :width="fieldWidth"
       :height="fieldHeight"
@@ -113,6 +113,9 @@ export default Vue.extend({
     },
     yardlineNumbers(): boolean {
       return this.$store.state.yardlineNumbers;
+    },
+    showField(): boolean {
+      return this.$store.state.showField;
     },
     fieldWidth(): number {
       // Account for endzones + area between yard lines

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -67,6 +67,14 @@
               Show Dot Labels
             </b-checkbox>
           </b-navbar-item>
+          <b-navbar-item>
+            <b-checkbox
+              v-model="showField"
+              data-test="menu-top--view-show-field"
+            >
+              Show Field
+            </b-checkbox>
+          </b-navbar-item>
         </b-navbar-dropdown>
       </template>
     </b-navbar>
@@ -149,6 +157,15 @@ export default Vue.extend({
       set(enabled: boolean): void {
         this.$store.commit(Mutations.SET_SHOW_DOT_LABELS, enabled);
       },
+    },
+
+    showField: {
+      get(): boolean {
+        return this.$store.state.showField;
+      },
+      set(enabled: boolean): void {
+        this.$store.commit(Mutations.SET_SHOW_FIELD, enabled)
+      }
     },
 
     fileURL(): string {

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -164,8 +164,8 @@ export default Vue.extend({
         return this.$store.state.showField;
       },
       set(enabled: boolean): void {
-        this.$store.commit(Mutations.SET_SHOW_FIELD, enabled)
-      }
+        this.$store.commit(Mutations.SET_SHOW_FIELD, enabled);
+      },
     },
 
     fileURL(): string {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,6 +18,7 @@ Vue.use(Vuex);
  * @property selectedSS        - Index of stuntsheet currently in view
  * @property beat              - The point in time the show is in
  * @property fourStepGrid      - View setting to toggle the grapher grid
+ * @property showField         - View setting to toggle the (green) field
  * @property grapherSvgPanZoom - Initialized upon mounting Grapher
  * @property invertedCTMMatrix - Used to calculate clientX/Y to SVG X/Y
  * @property toolSelected      - See BaseTool
@@ -39,6 +40,8 @@ export class CalChartState extends Serializable<CalChartState> {
   yardlineNumbers = true;
 
   showDotLabels = true;
+
+  showField = true;
 
   grapherSvgPanZoom?: SvgPanZoom.Instance;
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -53,6 +53,7 @@ export enum Mutations {
   SET_YARDLINES = "setYardlines",
   SET_YARDLINE_NUMBERS = "setYardlineNumbers",
   SET_SHOW_DOT_LABELS = "setShowDotLabels",
+  SET_SHOW_FIELD = "setShowField",
   // Tools
   SET_GRAPHER_SVG_PAN_ZOOM = "setGrapherSvgPanZoom",
   SET_INVERTED_CTM_MATRIX = "setInvertedCTMMatrix",
@@ -390,6 +391,9 @@ export const mutations: MutationTree<CalChartState> = {
   },
   [Mutations.SET_SHOW_DOT_LABELS](state, enabled: boolean): void {
     state.showDotLabels = enabled;
+  },
+  [Mutations.SET_SHOW_FIELD](state, enabled: boolean): void {
+    state.showField = enabled;
   },
 
   // Tools

--- a/tests/e2e/specs/menu-top/MenuTop.spec.js
+++ b/tests/e2e/specs/menu-top/MenuTop.spec.js
@@ -91,5 +91,13 @@ describe("components/menu-top/MenuTop", () => {
 
       cy.get('[data-test="grapher-field--yard-number"]').should("not.exist");
     });
+
+    it("can toggle show field", () => {
+      cy.get('[data-test="grapher-field--rect"]').should("be.visible");
+
+      cy.get('[data-test="menu-top--view-show-field"]').click();
+
+      cy.get('[data-test="grapher-field--rect"]').should("not.exist");
+    });
   });
 });

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -84,4 +84,14 @@ describe("components/menu-top/MenuTop", () => {
       expect(store.state.showDotLabels).toBeFalsy();
     });
   });
+
+  it("show field checkbox", () => {
+    expect(store.state.showField).toBeTruthy();
+    const showField = wrapper.find(
+      '[data-test="menu-top--view-show-field"]'
+    );
+    expect(showField.exists()).toBeTruthy();
+    showField.trigger("click");
+    expect(store.state.showField).toBeFalsy();
+  });
 });

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -87,9 +87,7 @@ describe("components/menu-top/MenuTop", () => {
 
   it("show field checkbox", () => {
     expect(store.state.showField).toBeTruthy();
-    const showField = wrapper.find(
-      '[data-test="menu-top--view-show-field"]'
-    );
+    const showField = wrapper.find('[data-test="menu-top--view-show-field"]');
     expect(showField.exists()).toBeTruthy();
     showField.trigger("click");
     expect(store.state.showField).toBeFalsy();


### PR DESCRIPTION
## Description

This PR adds a new checkbox to the View dropdown, which toggles the rendering of the field, which includes both the green background and white outline.

Fixes #42 

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [x] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

![showField-clicked](https://user-images.githubusercontent.com/15698076/121976046-dc6da280-cd37-11eb-97f3-6764bc385ed0.png)
![showField-unclicked](https://user-images.githubusercontent.com/15698076/121976048-dc6da280-cd37-11eb-9414-60c7a8c7dd7b.png)


