### PR TITLE
Change step grid

### DIFF
--- a/src/components/grapher/GrapherField.vue
+++ b/src/components/grapher/GrapherField.vue
@@ -124,13 +124,25 @@ export default Vue.extend({
         this.$store.getters.getFrontHashOffsetY
       );
     },
+    // fourStepGridOffsetsX(): number[] {
+    //   const offset: number = this.$store.state.yardlines ? 8 : 4;
+    //   const retVal: number[] = [4, 8, this.fieldWidth - 8, this.fieldWidth - 4];
+    //   for (
+    //     let offsetX = 12;
+    //     offsetX <= this.fieldWidth - 12;
+    //     offsetX += offset
+    //   ) {
+    //     retVal.push(offsetX);
+    //   }
+    //   return retVal;
+    // },
     fourStepGridOffsetsX(): number[] {
-      const offset: number = this.$store.state.yardlines ? 8 : 4;
-      const retVal: number[] = [4, 8, this.fieldWidth - 8, this.fieldWidth - 4];
+      const retVal: number[] = [];
+      const gridSize: number = this.$store.state.gridSize;
       for (
-        let offsetX = 12;
-        offsetX <= this.fieldWidth - 12;
-        offsetX += offset
+        let offsetX = gridSize * 2;
+        offsetX < this.fieldWidth;
+        offsetX += gridSize * 2
       ) {
         retVal.push(offsetX);
       }
@@ -138,7 +150,12 @@ export default Vue.extend({
     },
     fourStepGridOffsetsY(): number[] {
       const retVal: number[] = [];
-      for (let offsetY = 4; offsetY < this.fieldHeight; offsetY += 4) {
+      const gridSize: number = this.$store.state.gridSize;
+      for (
+        let offsetY = gridSize * 2;
+        offsetY < this.fieldHeight;
+        offsetY += gridSize * 2
+      ) {
         retVal.push(offsetY);
       }
       return retVal;

--- a/src/components/grapher/GrapherField.vue
+++ b/src/components/grapher/GrapherField.vue
@@ -140,9 +140,9 @@ export default Vue.extend({
       const retVal: number[] = [];
       const gridSize: number = this.$store.state.gridSize;
       for (
-        let offsetX = gridSize * 2;
+        let offsetX = gridSize;
         offsetX < this.fieldWidth;
-        offsetX += gridSize * 2
+        offsetX += gridSize
       ) {
         retVal.push(offsetX);
       }
@@ -152,9 +152,9 @@ export default Vue.extend({
       const retVal: number[] = [];
       const gridSize: number = this.$store.state.gridSize;
       for (
-        let offsetY = gridSize * 2;
+        let offsetY = gridSize;
         offsetY < this.fieldHeight;
-        offsetY += gridSize * 2
+        offsetY += gridSize
       ) {
         retVal.push(offsetY);
       }

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -74,19 +74,19 @@
             data-test="menu-top--grid-one"
             @click="changeStepGrid(1)"
           >
-          One Step
+            One Step
           </b-navbar-item>
           <b-navbar-item
             data-test="menu-top--grid-two"
             @click="changeStepGrid(2)"
           >
-          Two Step
+            Two Step
           </b-navbar-item>
           <b-navbar-item
             data-test="menu-top--grid-four"
             @click="changeStepGrid(4)"
           >
-          Four Step
+            Four Step
           </b-navbar-item>
         </b-navbar-dropdown>
       </template>

--- a/src/components/menu-top/MenuTop.vue
+++ b/src/components/menu-top/MenuTop.vue
@@ -68,6 +68,27 @@
             </b-checkbox>
           </b-navbar-item>
         </b-navbar-dropdown>
+
+        <b-navbar-dropdown label="Grid" data-test="menu-top--grid">
+          <b-navbar-item
+            data-test="menu-top--grid-one"
+            @click="changeStepGrid(1)"
+          >
+          One Step
+          </b-navbar-item>
+          <b-navbar-item
+            data-test="menu-top--grid-two"
+            @click="changeStepGrid(2)"
+          >
+          Two Step
+          </b-navbar-item>
+          <b-navbar-item
+            data-test="menu-top--grid-four"
+            @click="changeStepGrid(4)"
+          >
+          Four Step
+          </b-navbar-item>
+        </b-navbar-dropdown>
       </template>
     </b-navbar>
 
@@ -160,6 +181,10 @@ export default Vue.extend({
   methods: {
     newShow(): void {
       this.$store.commit(Mutations.SET_SHOW, new InitialShowState());
+    },
+
+    changeStepGrid(size: number): void {
+      this.$store.commit(Mutations.SET_GRID_SIZE, size);
     },
   },
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,6 +40,8 @@ export class CalChartState extends Serializable<CalChartState> {
 
   showDotLabels = true;
 
+  gridSize = 2;
+
   grapherSvgPanZoom?: SvgPanZoom.Instance;
 
   invertedCTMMatrix?: DOMMatrix;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -34,7 +34,7 @@ export class CalChartState extends Serializable<CalChartState> {
 
   showDotLabels = true;
 
-  gridSize = 2;
+  gridSize = 4;
 
   grapherSvgPanZoom?: SvgPanZoom.Instance;
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -48,6 +48,8 @@ export enum Mutations {
   SET_BEAT = "setBeat",
   INCREMENT_BEAT = "incrementBeat",
   DECREMENT_BEAT = "decrementBeat",
+  // Grid mutations:
+  SET_GRID_SIZE = "setGridSize",
   // Field view mutations:
   SET_FOUR_STEP_GRID = "setFourStepGrid",
   SET_YARDLINES = "setYardlines",
@@ -406,6 +408,12 @@ export const mutations: MutationTree<CalChartState> = {
   },
   [Mutations.SET_SHOW_DOT_LABELS](state, enabled: boolean): void {
     state.showDotLabels = enabled;
+  },
+
+  // Grid Size
+
+  [Mutations.SET_GRID_SIZE](state, size: number): void {
+    state.gridSize = size;
   },
 
   // Tools

--- a/src/tools/BaseTool.ts
+++ b/src/tools/BaseTool.ts
@@ -18,8 +18,10 @@ export default abstract class BaseTool {
    */
   static roundCoordinateToGrid(coordinate: [number, number]): [number, number] {
     return [
-      Math.round(coordinate[0] / 2) * 2,
-      Math.round(coordinate[1] / 2) * 2,
+      Math.round(coordinate[0] / GlobalStore.state.gridSize) *
+        GlobalStore.state.gridSize,
+      Math.round(coordinate[1] / GlobalStore.state.gridSize) *
+        GlobalStore.state.gridSize,
     ];
   }
 

--- a/tests/unit/components/grapher/GrapherField.spec.ts
+++ b/tests/unit/components/grapher/GrapherField.spec.ts
@@ -57,13 +57,35 @@ describe("components/grapher/GrapherField.vue", () => {
       expect(rect.attributes("height")).toBe("24");
     });
 
-    it("four step grid: generates 6 vert lines and 5 horiz lines", () => {
+    it("four step grid: generates appropriate amount of vert and horiz grid lines", async () => {
+      store.commit(Mutations.SET_GRID_SIZE, 2);
+      await wrapper.vm.$nextTick();
       expect(
         wrapper.findAll('[data-test="grapher-field--grid-vertical"]')
-      ).toHaveLength(6);
+      ).toHaveLength(7);
       expect(
         wrapper.findAll('[data-test="grapher-field--grid-horizontal"]')
       ).toHaveLength(5);
+
+      store.commit(Mutations.SET_GRID_SIZE, 1);
+      await wrapper.vm.$nextTick();
+
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-vertical"]')
+      ).toHaveLength(15);
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-horizontal"]')
+      ).toHaveLength(11);
+
+      store.commit(Mutations.SET_GRID_SIZE, 4);
+      await wrapper.vm.$nextTick();
+
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-vertical"]')
+      ).toHaveLength(3);
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-horizontal"]')
+      ).toHaveLength(2);
     });
 
     it("generates no field numbers", () => {
@@ -93,6 +115,7 @@ describe("components/grapher/GrapherField.vue", () => {
       ).toBeFalsy();
 
       store.commit(Mutations.SET_FOUR_STEP_GRID, true);
+      store.commit(Mutations.SET_GRID_SIZE, 2);
       await wrapper.vm.$nextTick();
 
       expect(
@@ -149,13 +172,36 @@ describe("components/grapher/GrapherField.vue", () => {
       ).toBe("84");
     });
 
-    it("four step grid: generates 26 vert lines and 20 horiz lines", () => {
+    it("four step grid: generates 47/95/23 vert lines and 20/41/10 horiz lines", async () => {
+      store.commit(Mutations.SET_GRID_SIZE, 2);
+      await wrapper.vm.$nextTick();
+
       expect(
         wrapper.findAll('[data-test="grapher-field--grid-vertical"]')
-      ).toHaveLength(26);
+      ).toHaveLength(47);
       expect(
         wrapper.findAll('[data-test="grapher-field--grid-horizontal"]')
       ).toHaveLength(20);
+
+      store.commit(Mutations.SET_GRID_SIZE, 1);
+      await wrapper.vm.$nextTick();
+
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-vertical"]')
+      ).toHaveLength(95);
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-horizontal"]')
+      ).toHaveLength(41);
+
+      store.commit(Mutations.SET_GRID_SIZE, 4);
+      await wrapper.vm.$nextTick();
+
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-vertical"]')
+      ).toHaveLength(23);
+      expect(
+        wrapper.findAll('[data-test="grapher-field--grid-horizontal"]')
+      ).toHaveLength(10);
     });
 
     it("generates 18 field numbers", () => {
@@ -194,6 +240,7 @@ describe("components/grapher/GrapherField.vue", () => {
       ).toBeFalsy();
 
       store.commit(Mutations.SET_FOUR_STEP_GRID, true);
+      store.commit(Mutations.SET_GRID_SIZE, 2);
       await wrapper.vm.$nextTick();
 
       expect(

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -87,25 +87,19 @@ describe("components/menu-top/MenuTop", () => {
 
   describe("grid dropdown", () => {
     it("one step grid", () => {
-      const oneStep = wrapper.find(
-        '[data-test="menu-top--grid-one"]'
-      );
+      const oneStep = wrapper.find('[data-test="menu-top--grid-one"]');
       oneStep.trigger("click");
       expect(store.state.gridSize).toEqual(1);
     });
 
     it("two step grid", () => {
-      const twoStep = wrapper.find(
-        '[data-test="menu-top--grid-two"]'
-      );
+      const twoStep = wrapper.find('[data-test="menu-top--grid-two"]');
       twoStep.trigger("click");
       expect(store.state.gridSize).toEqual(2);
     });
 
     it("four step grid", () => {
-      const fourStep = wrapper.find(
-        '[data-test="menu-top--grid-four"]'
-      );
+      const fourStep = wrapper.find('[data-test="menu-top--grid-four"]');
       fourStep.trigger("click");
       expect(store.state.gridSize).toEqual(4);
     });

--- a/tests/unit/components/menu-top/MenuTop.spec.ts
+++ b/tests/unit/components/menu-top/MenuTop.spec.ts
@@ -84,4 +84,30 @@ describe("components/menu-top/MenuTop", () => {
       expect(store.state.showDotLabels).toBeFalsy();
     });
   });
+
+  describe("grid dropdown", () => {
+    it("one step grid", () => {
+      const oneStep = wrapper.find(
+        '[data-test="menu-top--grid-one"]'
+      );
+      oneStep.trigger("click");
+      expect(store.state.gridSize).toEqual(1);
+    });
+
+    it("two step grid", () => {
+      const twoStep = wrapper.find(
+        '[data-test="menu-top--grid-two"]'
+      );
+      twoStep.trigger("click");
+      expect(store.state.gridSize).toEqual(2);
+    });
+
+    it("four step grid", () => {
+      const fourStep = wrapper.find(
+        '[data-test="menu-top--grid-four"]'
+      );
+      fourStep.trigger("click");
+      expect(store.state.gridSize).toEqual(4);
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR adds a new dropdown to the top menu, Grid, which allows the user to change the grid size. However, there are some issues I would like to address, both on my end and in general.

Addresses issue #62 

## Problems

1. I have not yet changed the coordinate rounding function. Could someone tells me where it is called so I can figure out how best to change it?
2. The old logic for horizontal grid generation explicitly avoided generating grid lines on yard lines unless the yard lines were removed. However, to make it easier to extend to 1-step and 4-step grids, I changed the logic to resemble the vertical lines, and therefore redundantly generates grid lines on top of yardlines. Should we strive to keep gridline generation non-redundant, or would it be easier in the long run to keep it as I have it? For reference, the old X-Offset function is present, but commented out.
3. Due to the dimensions of the field, the 4 Step grid leaves a small horizontal space at the bottom of the field. Should we keep 4 Step grid generation as is, or should we change it somehow?

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [x] Checked that errors are handled
- [x] Ran `npm run lint`
- [x] Ran `npm run test:unit`
- [ ] Ran `npm run test:e2e` and ran relevant tests
- [x] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs
![grid-size-1](https://user-images.githubusercontent.com/15698076/122512413-ab060880-cfbd-11eb-97b9-88abcd3b68a7.png)
![grid-size-2](https://user-images.githubusercontent.com/15698076/122512415-ab9e9f00-cfbd-11eb-86d2-df9fef5c75b4.png)
![grid-size-4](https://user-images.githubusercontent.com/15698076/122512416-ab9e9f00-cfbd-11eb-8d2c-af3cea30287f.png)

