### PR TITLE
Changed lasso and box selection icons

### DIFF
--- a/src/components/menu-bottom/MenuBottomTools.vue
+++ b/src/components/menu-bottom/MenuBottomTools.vue
@@ -45,13 +45,13 @@ export default Vue.extend({
     toolDataList: [
       {
         label: "Drag Box to select, shift to add, shift+alt/option to toggle",
-        icon: "hand-right",
+        icon: "select",
         tool: ToolBoxSelect,
         "data-test": "select-box-move",
       },
       {
         label: "Lasso to select, shift to add, shift+alt/option to toggle",
-        icon: "pencil",
+        icon: "lasso",
         tool: ToolLassoSelect,
         "data-test": "select-lasso-move",
       },


### PR DESCRIPTION
## Description

Fixes issue #114 

Fixes the icons for lasso and box sect tools

## Pre-PR checklist

- [x] Ran `npm run serve` and:
  - [x] Checked basic functionality
  - [ x] Checked that errors are handled
- [ ] Ran `npm run lint`
- [ ] Ran `npm run test:unit`
- [ ] Ran `npm run test:e2e` and ran relevant tests
- [ ] Attached reviewers to PR and pinged on Slack/email

## Screenshots/GIFs

![image](https://user-images.githubusercontent.com/29964426/126883711-e2bf261c-455d-4cf1-b245-dc5259af8965.png)

